### PR TITLE
Bootstrap project scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 RoastPilot is a spec-driven MCP server for autonomous coffee roasting.
 
-The package is published as `coffee-roaster-mcp` and will provide one local MCP runtime for roaster control, telemetry, first-crack detection integration, roast metrics, and log export.
+The package name is `coffee-roaster-mcp`. PyPI publishing is planned for the v0.1 release; this repository currently contains the local package scaffold and project plan.
+
+RoastPilot will provide one local MCP runtime for roaster control, telemetry, first-crack detection integration, roast metrics, and log export.
 
 The project is currently in bootstrap. See `docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md` and `docs/state/registry.md` for the active plan and state.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# RoastPilot
+
+RoastPilot is a spec-driven MCP server for autonomous coffee roasting.
+
+The package is published as `coffee-roaster-mcp` and will provide one local MCP runtime for roaster control, telemetry, first-crack detection integration, roast metrics, and log export.
+
+The project is currently in bootstrap. See `docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md` and `docs/state/registry.md` for the active plan and state.

--- a/docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md
+++ b/docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md
@@ -1,0 +1,571 @@
+# Coffee Roaster MCP v0.1 Overall Plan
+
+## Summary
+
+Build `RoastPilot`, a standalone Python MCP server published as `coffee-roaster-mcp`, that replaces the current two-MCP plus n8n POC with one local process that owns roaster control, telemetry, microphone first-crack detection, roast timing, derived metrics, event logging, and export.
+
+The model repo remains the source of truth for training, ONNX export, Hugging Face publishing, model cards, and dataset cards. This MCP only consumes released Hugging Face artifacts from `syamaner/coffee-first-crack-detection`.
+
+## Repository Identity
+
+- GitHub repository name: `coffee-roaster-mcp`.
+- Python package name: `coffee-roaster-mcp`.
+- Python import package: `coffee_roaster_mcp`.
+- Console entrypoint: `coffee-roaster-mcp`.
+- Product/display name: `RoastPilot`.
+- MCP Registry name: `io.github.syamaner/coffee-roaster-mcp`.
+- Default config file: `coffee-roaster-mcp.yaml`.
+- Rationale: use `coffee-roaster-mcp` for boring infrastructure names where searchability and install clarity matter. Use `RoastPilot` for README, docs, demos, and blog framing where a product name reads better.
+
+## Core Architecture
+
+- Use one local stdio MCP server for v0.1.
+- Keep agent orchestration and n8n out of scope.
+- Add one authoritative `RoastSession` runtime with session id, monotonic clock, roaster driver, first-crack detector, telemetry buffer, event timeline, and append-only log writer.
+- `beans_added_at` is T0.
+- `first_crack_at` is recorded once from detector or manual override.
+- `beans_dropped_at` ends roast timing.
+- All timing, RoR, deltas, development percent, and logs are computed inside the MCP.
+
+## MCP Tools
+
+- `start_roast_session`: creates session, connects roaster, starts telemetry, optionally starts detector.
+- `get_roast_state`: returns phase, temps, controls, events, elapsed time, development percent, RoR, and deltas.
+- `set_heat`: sets heat percentage.
+- `set_fan`: sets fan percentage.
+- `mark_beans_added`: records T0 and emits `beans_added`.
+- `mark_first_crack`: records first crack manually and emits `first_crack_detected`.
+- `drop_beans`: records drop, executes driver drop action, emits `beans_dropped`.
+- `start_cooling`: starts cooling and emits `cooling_started`.
+- `stop_cooling`: stops cooling and emits `cooling_stopped`.
+- `export_roast_log`: exports active session by default, or a provided `session_id`, returning JSONL, CSV, and summary paths.
+- `emergency_stop`: turns heat off, attempts safe cooling behavior, records emergency/fault event.
+
+## Session Metrics
+
+- `roast_elapsed_seconds`: from `beans_added_at` to now, or to `beans_dropped_at` after drop.
+- `development_time_seconds`: from `first_crack_at` to now, or to drop.
+- `development_time_percent`: `development_time_seconds / roast_elapsed_seconds * 100`.
+- `bean_delta_60s_c`: latest bean temp minus oldest bean temp in rolling 60s window.
+- `env_delta_60s_c`: latest env temp minus oldest env temp in rolling 60s window.
+- `bean_ror_c_per_min`: bean temp slope over rolling window, normalized to C/min.
+- `env_ror_c_per_min`: env temp slope over rolling window, normalized to C/min.
+- RoR returns null until at least 10 seconds of samples exist.
+- Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
+
+## Config Schema
+
+Default config file path: `./coffee-roaster-mcp.yaml`.
+
+```yaml
+transport:
+  type: stdio
+
+roaster:
+  driver: mock
+  port: null
+  baudrate: 115200
+  temperature_unit: celsius
+  command_interval_seconds: 0.3
+
+first_crack:
+  mode: disabled  # disabled | audio | manual
+  repo_id: syamaner/coffee-first-crack-detection
+  revision: null  # null means latest; release builds should pin this
+  precision: int8
+  local_model_dir: null
+  onnx_threads: 2
+  allow_manual_override: true
+
+audio:
+  input_device: null
+  sample_rate: 16000
+
+logging:
+  log_dir: ./logs
+  sample_interval_seconds: 1.0
+  export_formats:
+    - jsonl
+    - csv
+    - summary
+
+session:
+  auto_t0_detection_enabled: false
+  ror_window_seconds: 60
+  ror_min_sample_seconds: 10
+```
+
+Environment overrides:
+
+- `COFFEE_ROASTER_MCP_CONFIG`
+- `COFFEE_ROASTER_DRIVER`
+- `COFFEE_ROASTER_PORT`
+- `COFFEE_ROASTER_TEMP_UNIT`
+- `COFFEE_FIRST_CRACK_MODE`
+- `COFFEE_FIRST_CRACK_REPO_ID`
+- `COFFEE_FIRST_CRACK_REVISION`
+- `COFFEE_FIRST_CRACK_PRECISION`
+- `COFFEE_FIRST_CRACK_LOCAL_MODEL_DIR`
+- `COFFEE_FIRST_CRACK_ONNX_THREADS`
+- `COFFEE_AUDIO_INPUT_DEVICE`
+- `COFFEE_ROAST_LOG_DIR`
+- `HF_HOME`
+
+## Model Runtime
+
+- Use ONNX Runtime.
+- Default model: INT8 at `onnx/int8/model_quantized.onnx`.
+- Optional model: FP32 at `onnx/fp32/model.onnx`.
+- Resolve model artifacts through `huggingface_hub`.
+- Allow `local_model_dir` for offline operation.
+- Validate required ONNX model and feature extractor files before detection starts.
+- Record first-crack event metadata: model repo, revision, precision, timestamp, and confidence if available.
+- Do not implement model sync, training, export, or card publishing in this repo.
+
+## Roaster Abstraction
+
+- Define `RoasterDriver` with `connect`, `disconnect`, `read_state`, `set_heat`, `set_fan`, `drop_beans`, `start_cooling`, `stop_cooling`, `emergency_stop`, and `capabilities`.
+- Ship `mock` driver for tests, demos, registry install smoke tests, and vertical-slice validation.
+- Ship `hottop_kn8828b_2k_plus` driver for the current hardware.
+- Normalize driver state to bean temp C, env temp C, heat %, fan %, cooling on/off, connected, and raw vendor data.
+- Capabilities describe control ranges, step sizes, supported actions, sensor units, and whether continuous command streaming is required.
+
+## Hottop Driver Requirements
+
+- Use the existing direct serial protocol approach unless verification proves `pyhottop` is safer.
+- Preserve continuous command loop behavior around 0.3s.
+- Support 36-byte command/status packets and checksum validation.
+- Initialize in safe state: heat off, fan controlled, cooling off unless commanded.
+- Heat above zero implies drum-on where required by the Hottop protocol.
+- Drop is compound: heat off, drum off, drop/solenoid active, cooling on, main fan high.
+- Cooling stop clears cooling motor, solenoid/drop path, and main fan as appropriate.
+- Temperature mode is explicit: `celsius`, `fahrenheit`, or `auto`.
+- Ignore startup zero/unready readings until plausible telemetry arrives.
+- Add a Hottop verification spike because command-loop behavior and temp units are the main hardware risks.
+
+## Roast Logs
+
+- Write append-only JSONL during roast.
+- Export CSV and `summary.json`.
+- Store files under `logs/roasts/{session_id}/`.
+- Log at 1 Hz plus immediate event rows.
+- Required CSV columns:
+  - `timestamp_utc`
+  - `elapsed_seconds`
+  - `phase`
+  - `bean_temp_c`
+  - `env_temp_c`
+  - `heat_level_percent`
+  - `fan_level_percent`
+  - `cooling_on`
+  - `event`
+  - `beans_added`
+  - `first_crack_detected`
+  - `beans_dropped`
+  - `development_time_percent`
+  - `bean_ror_c_per_min`
+  - `env_ror_c_per_min`
+  - `bean_delta_60s_c`
+  - `env_delta_60s_c`
+  - `fc_model_repo`
+  - `fc_model_revision`
+  - `fc_model_precision`
+
+Example telemetry JSONL row:
+
+```json
+{"timestamp_utc":"2026-04-30T10:15:31Z","elapsed_seconds":391.2,"phase":"roasting","bean_temp_c":176.4,"env_temp_c":204.8,"heat_level_percent":60,"fan_level_percent":35,"cooling_on":false,"event":null,"development_time_percent":null,"bean_ror_c_per_min":7.2,"env_ror_c_per_min":3.1,"bean_delta_60s_c":7.2,"env_delta_60s_c":3.1}
+```
+
+Example event JSONL row:
+
+```json
+{"timestamp_utc":"2026-04-30T10:18:42Z","elapsed_seconds":582.6,"phase":"development","event":"first_crack_detected","first_crack_detected":true,"bean_temp_c":194.1,"env_temp_c":216.3,"heat_level_percent":45,"fan_level_percent":50,"cooling_on":false,"development_time_percent":0.0,"fc_model_repo":"syamaner/coffee-first-crack-detection","fc_model_revision":"pinned-release","fc_model_precision":"int8"}
+```
+
+Example CSV header:
+
+```csv
+timestamp_utc,elapsed_seconds,phase,bean_temp_c,env_temp_c,heat_level_percent,fan_level_percent,cooling_on,event,beans_added,first_crack_detected,beans_dropped,development_time_percent,bean_ror_c_per_min,env_ror_c_per_min,bean_delta_60s_c,env_delta_60s_c,fc_model_repo,fc_model_revision,fc_model_precision
+```
+
+Example `summary.json`:
+
+```json
+{
+  "session_id": "20260430-101000",
+  "started_at_utc": "2026-04-30T10:10:00Z",
+  "beans_added_at_utc": "2026-04-30T10:12:00Z",
+  "first_crack_at_utc": "2026-04-30T10:18:42Z",
+  "beans_dropped_at_utc": "2026-04-30T10:20:10Z",
+  "total_roast_seconds": 490.0,
+  "development_time_seconds": 88.0,
+  "development_time_percent": 17.96,
+  "roaster_driver": "hottop_kn8828b_2k_plus",
+  "first_crack_model": {
+    "repo_id": "syamaner/coffee-first-crack-detection",
+    "revision": "pinned-release",
+    "precision": "int8"
+  }
+}
+```
+
+## Distribution And Registry
+
+- Source repo target: `github.com/syamaner/coffee-roaster-mcp`.
+- Publish package to PyPI as `coffee-roaster-mcp`.
+- Add console entrypoint `coffee-roaster-mcp`.
+- Add root `server.json` for MCP Registry.
+- Register as `io.github.syamaner/coffee-roaster-mcp`.
+- Use `RoastPilot` as the human-facing title/display name.
+- Add README verification string: `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`.
+- Use `mcp-publisher` in GitHub Actions after PyPI publish.
+- Align git tag, package version, PyPI version, and `server.json.version`.
+- Keep GHCR container optional after v0.1.
+- Hugging Face hosts model/data. PyPI hosts code. MCP Registry hosts discovery metadata.
+
+Minimal `server.json` target:
+
+```json
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.syamaner/coffee-roaster-mcp",
+  "title": "RoastPilot",
+  "description": "Control coffee roasts, detect first crack, and export roast logs.",
+  "version": "0.1.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "coffee-roaster-mcp",
+      "version": "0.1.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}
+```
+
+## Spec-Driven Delivery Model
+
+This project will be delivered using the same spec-driven operating model as the first-crack detection rebuild. The goal is to keep agent work bounded by explicit rules, durable project state, and story-level acceptance criteria rather than relying on chat context alone.
+
+### AGENTS.md Rulebook
+
+Add a root `AGENTS.md` that defines:
+
+- Python version, typing rules, linting, formatting, and test requirements.
+- Dependency rules: all runtime and dev dependencies must be declared in `pyproject.toml`.
+- Hardware safety rules for Hottop control, drop, cooling, and emergency stop.
+- Model boundary rules: this repo consumes Hugging Face model artifacts but does not train, export, or sync models.
+- Storage rules: no model weights, audio files, roast logs, or hardware captures committed to git.
+- Distribution rules for PyPI, MCP Registry, and version alignment.
+- Required state-reading workflow before implementation.
+
+Required pre-task workflow:
+
+1. Read `docs/state/registry.md`.
+2. Open the active epic file.
+3. Read the GitHub issue for the story.
+4. Confirm acceptance criteria and current risks.
+5. Work on a branch named `feature/{issue-number}-{slug}`.
+
+Required post-task workflow:
+
+1. Run the required checks.
+2. Update the story status in the active epic file.
+3. Update active context and decision notes if behavior changed.
+4. Comment on the GitHub issue with what was built and how it was tested.
+5. Open a PR referencing the story issue.
+
+### Durable Epic State
+
+Add project state files under `docs/state/`:
+
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+`registry.md` points to the active epic and summarizes the current project phase.
+
+The active epic file tracks:
+
+- Epic and story list.
+- Story status.
+- Active story.
+- Current architecture decisions.
+- Current risks.
+- Hardware validation notes.
+- Registry publishing notes.
+- Active context for the next agent session.
+
+### Story Specification Standard
+
+Every story starts as a GitHub issue before implementation.
+
+Each issue includes:
+
+- Problem statement.
+- In scope.
+- Out of scope.
+- Public interface or config changes.
+- Implementation notes.
+- Acceptance criteria.
+- Required tests.
+- Manual validation steps, when hardware or publishing is involved.
+
+Risky stories require a short implementation plan before code, especially:
+
+- Hottop command loop and packet handling.
+- Drop, cooling, and emergency stop behavior.
+- MCP Registry publishing.
+- First-crack event integration into the roast timeline.
+- Log export schema changes.
+
+### Repo-Local Skills And Runbooks
+
+Add repo-local skills or runbooks for repeatable workflows. These should encode exact command sequences and validation steps so the agent does not improvise.
+
+Recommended skills:
+
+- `mcp-dev`: install dev environment, run lint/typecheck/tests, start mock MCP server, call basic MCP tools, inspect generated logs.
+- `mock-roast`: start mock session, mark beans added, inject first crack, change heat/fan, drop beans, export logs, validate JSONL/CSV/summary.
+- `hottop-validation`: confirm serial port, connect, read telemetry, verify temp units, test heat/fan/drop/cooling/emergency stop, record validation notes.
+- `release-registry`: verify version alignment, build package, validate `server.json`, publish PyPI, install from PyPI, run mock smoke test, publish MCP Registry metadata, verify registry listing.
+
+Do not add model training, ONNX export, or Hugging Face sync skills to this repo. Those remain in the `coffee-first-crack-detection` model repo.
+
+### Actor Responsibilities
+
+Human owner:
+
+- Roast safety.
+- Architecture decisions.
+- MCP tool contracts.
+- Roaster abstraction boundaries.
+- Metrics semantics.
+- First-crack behavior acceptance.
+- Hardware-ready release decision.
+
+Coding agent:
+
+- Implementation against accepted story specs.
+- Tests.
+- Packaging.
+- Documentation.
+- Runbooks.
+- Release automation.
+
+Code review:
+
+- Type safety.
+- API misuse.
+- Dependency hygiene.
+- Missing error handling.
+- Test gaps.
+- Documentation accuracy.
+
+Do not rely on code review to validate coffee roasting safety, Hottop hardware behavior, first-crack signal quality, or roast metric semantics. Those remain explicit human-review responsibilities.
+
+## Release Checklist
+
+- Confirm tests pass locally.
+- Confirm mock MCP server starts through console entrypoint.
+- Confirm package builds cleanly.
+- Confirm `server.json.version` matches package version.
+- Confirm README contains MCP verification string.
+- Pin HF model revision before release.
+- Publish package to TestPyPI if desired.
+- Install package from TestPyPI and run mock smoke test.
+- Publish package to PyPI.
+- Install package from PyPI and run mock smoke test.
+- Authenticate `mcp-publisher` with GitHub OIDC in CI.
+- Publish MCP Registry metadata.
+- Confirm registry page renders expected package and install metadata.
+- Create GitHub release from tag.
+- Run manual Hottop validation before labeling a release hardware-ready.
+
+## Epics, Stories, And Acceptance Criteria
+
+### Epic 1: Repo, Packaging, And Developer Workflow
+
+Stories:
+
+- Create standalone GitHub repo `syamaner/coffee-roaster-mcp`.
+- Add package scaffold using `coffee-roaster-mcp` as the PyPI name and `coffee_roaster_mcp` as the Python import package.
+- Add config loading from YAML and env vars.
+- Add dev commands for test, lint, typecheck, and mock server.
+- Add CI for tests and package build.
+- Add README and local run instructions.
+- Add repo-local skills/runbooks.
+
+Acceptance criteria:
+
+- `coffee-roaster-mcp --help` works after editable install.
+- Mock server can start without roaster hardware or model download.
+- CI runs tests and package build.
+- Config defaults allow a local mock run with no config file.
+
+### Epic 2: MCP Runtime And Session Core
+
+Stories:
+
+- Implement stdio MCP entrypoint.
+- Implement session lifecycle and event timeline.
+- Implement MCP tools.
+- Implement phase transitions.
+- Implement emergency stop and fault recording.
+- Build thin vertical slice with mock roaster and injected first crack.
+
+Acceptance criteria:
+
+- A mock roast can start, mark beans added, mark first crack, drop beans, and export logs.
+- `get_roast_state` returns consistent timestamps, phase, metrics, and latest controls.
+- First crack is recorded once unless manual override is explicitly allowed.
+- Emergency stop records an event and calls the driver safety method.
+
+### Epic 3: Roaster Abstraction And Hottop Driver
+
+Stories:
+
+- Define `RoasterDriver` interface and capabilities.
+- Implement mock driver.
+- Implement Hottop connection lifecycle.
+- Implement Hottop command loop.
+- Implement Hottop heat, fan, drop, cooling, stop cooling, and emergency stop.
+- Implement Hottop packet parse/build and temp unit handling.
+- Run Hottop integration verification spike.
+
+Acceptance criteria:
+
+- Mock driver passes contract tests.
+- Hottop packet tests cover checksum, invalid packets, and temp conversion.
+- Command loop starts and stops cleanly.
+- Manual Hottop checklist passes before hardware-ready release label.
+
+### Epic 4: First-Crack Detection With HF Models
+
+Stories:
+
+- Add HF artifact resolver.
+- Load INT8 ONNX by default.
+- Load FP32 ONNX by config.
+- Support `local_model_dir`.
+- Add audio capture and detector adapter.
+- Feed confirmed detection into session timeline.
+
+Acceptance criteria:
+
+- INT8 resolver selects `onnx/int8/model_quantized.onnx`.
+- FP32 resolver selects `onnx/fp32/model.onnx`.
+- Offline local directory works without HF network access.
+- Mocked detector output creates exactly one `first_crack_detected` event.
+
+### Epic 5: Roast Metrics And Log Export
+
+Stories:
+
+- Implement rolling telemetry buffer.
+- Compute elapsed time, development time, development percent.
+- Compute 60s deltas and RoR.
+- Write JSONL log rows.
+- Export CSV and summary JSON.
+- Add log schema tests.
+
+Acceptance criteria:
+
+- RoR is null before 10 seconds of samples.
+- RoR and deltas are correct for regular and irregular sample intervals.
+- JSONL, CSV, and summary include required fields.
+- Event rows are written immediately, not only on the 1 Hz sample loop.
+
+### Epic 6: Distribution And MCP Registry Publishing
+
+Stories:
+
+- Add PyPI metadata.
+- Add README verification string.
+- Add `server.json`.
+- Add release workflow.
+- Add MCP Registry publishing verification spike.
+- Document install and hardware setup.
+
+Acceptance criteria:
+
+- Package installs from PyPI.
+- `server.json` validates against current MCP schema.
+- Registry publish flow is documented and tested before v0.1 release.
+- Registry listing points to the PyPI package and stdio transport.
+
+### Epic 7: End-To-End Validation And Release Readiness
+
+Stories:
+
+- Test full mock roast through MCP tools.
+- Test package install smoke flow.
+- Test MCP client connection.
+- Run Hottop manual hardware validation.
+- Produce v0.1 release checklist.
+
+Acceptance criteria:
+
+- Full mock roast works from install to exported logs.
+- MCP client can discover and call tools.
+- Manual hardware results are recorded.
+- Release is tagged only after package, registry, and smoke tests pass.
+
+## Spikes
+
+Keep only three spikes:
+
+- Hottop integration verification.
+- MCP Registry publishing verification.
+- Thin vertical slice through mock roaster, injected first crack, metrics, logs, and MCP tools.
+
+Do not spike HF ONNX loading or basic audio detection unless implementation contradicts the working reference prototype.
+
+## Test Plan
+
+- Unit test session timing, event ordering, phase transitions, and development percent.
+- Unit test rolling 60s deltas and RoR with irregular sample intervals.
+- Unit test JSONL, CSV, and summary export.
+- Unit test HF resolver for INT8, FP32, pinned revision, and local model dir.
+- Unit test detector adapter with mocked ONNX outputs.
+- Unit test mock driver and `RoasterDriver` contract.
+- Unit test Hottop packet build/parse, checksum validation, temp conversion, invalid startup readings, and command-loop cleanup.
+- Integration test full mock roast through MCP tools to exported logs.
+- Packaging smoke test from built wheel.
+- MCP client smoke test.
+- Manual Hottop test for connect, telemetry, heat, fan, drop, cooling, stop cooling, and emergency stop.
+
+## Blog Series Framing
+
+RoastPilot is the next spec-driven production rebuild after the first-crack detection project.
+
+Suggested framing:
+
+- The first series productionized the ML detector.
+- This series productionizes autonomous roast orchestration.
+- The old two-MCP plus n8n system worked, but created synchronization debt.
+- The rebuild moves timing, telemetry, first-crack events, development percent, RoR, logs, and hardware control into one runtime.
+- The core story is not just "building an MCP server." It is using spec-driven development to turn a working prototype into a distributable, testable, hardware-aware MCP product.
+
+Suggested post angle:
+
+> The prototype proved the idea. The rebuild is about control: one clock, one event timeline, one log, one hardware abstraction, and one MCP surface an agent can safely use later.
+
+Possible post title:
+
+> Building RoastPilot: a Spec-Driven MCP for Autonomous Coffee Roasting
+
+## Assumptions And Defaults
+
+- v0.1 is local-first stdio MCP.
+- Agent and n8n orchestration are out of scope.
+- INT8 ONNX is the default runtime model.
+- FP32 ONNX is supported for validation and quality comparison.
+- The reference first-crack prototype is already proven.
+- The model repo remains the source of truth for model production and Hugging Face sync.
+- Auto-T0 detection is disabled by default.
+- First-crack mode defaults to `disabled` so mock install and registry smoke tests do not require model download or audio hardware.
+- Release builds should pin the Hugging Face model revision.
+- The MCP Registry is preview, so registry publishing gets a verification story before release.

--- a/docs/session-summaries/2026-05-03-bootstrap-pr64.md
+++ b/docs/session-summaries/2026-05-03-bootstrap-pr64.md
@@ -1,0 +1,283 @@
+# Session Summary: RoastPilot Bootstrap And PR #64
+
+Date: 2026-05-03
+
+Repository: `syamaner/coffee-roaster-mcp`
+
+Branch: `feature/9-add-python-package-scaffold`
+
+Pull request: #64, `Bootstrap project scaffold`
+
+Current PR head: `cf7af53`
+
+## Purpose
+
+This session bootstrapped the new RoastPilot repository from the detailed plan created in the old `coffee-roasting` repository.
+
+The target was to start the spec-driven development workflow properly:
+
+- create durable project state in the new repo
+- create GitHub epics and stories
+- scaffold the Python package
+- open a PR instead of closing stories directly
+- process Copilot review comments through follow-up commits
+
+## What We Created Locally
+
+Added durable state and planning docs:
+
+- `docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md`
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+- `docs/state/github-issues.md`
+
+Added initial package scaffold:
+
+- `pyproject.toml`
+- `README.md`
+- `src/coffee_roaster_mcp/__init__.py`
+- `src/coffee_roaster_mcp/cli.py`
+- `tests/test_package.py`
+
+The package identity was set as:
+
+- Product/display name: `RoastPilot`
+- GitHub repo: `syamaner/coffee-roaster-mcp`
+- PyPI package name: `coffee-roaster-mcp`
+- Python import package: `coffee_roaster_mcp`
+- Console entrypoint: `coffee-roaster-mcp`
+- MCP Registry name: `io.github.syamaner/coffee-roaster-mcp`
+
+## GitHub Planning Setup
+
+Created the GitHub planning structure:
+
+- Milestone: `v0.1`
+- Labels:
+  - `epic`
+  - `story`
+  - `spike`
+  - `bootstrap`
+  - `runtime`
+  - `driver`
+  - `model`
+  - `logging`
+  - `distribution`
+  - `validation`
+- Epic issues: #1 through #7
+- Story issues: #8 through #60
+- Standalone spike issues: #61 through #63
+
+Total GitHub issue count created for v0.1 planning: 63.
+
+Breakdown:
+
+- 7 epic issues
+- 53 story issues
+- 3 standalone spike issues
+
+Issue linking was added after initial creation:
+
+- Each epic issue now has a task list of its child story issues.
+- Each story issue now includes a `Parent epic` reference.
+
+## PR Timeline
+
+PR #64 was opened for the first bootstrap branch.
+
+Commits in the PR:
+
+1. `eb63847` - `feat: bootstrap project scaffold`
+   - Added project plan, durable state docs, issue index, package scaffold, CLI module, and smoke tests.
+
+2. `943ffe8` - `fix: address scaffold review feedback`
+   - Addressed the first Copilot review batch.
+
+3. `c13d947` - `test: cover cli help path`
+   - Addressed the second Copilot review batch.
+
+4. `cf7af53` - `docs: update bootstrap state after cli smoke`
+   - Addressed the final Copilot review batch.
+
+Net diff against `main` at the time of this summary:
+
+- 9 files changed
+- 1,193 insertions
+- 0 deletions
+
+## GitHub Copilot Review Summary
+
+Copilot reviewed PR #64 three times.
+
+Review batches:
+
+- Review 1: 5 comments
+- Review 2: 2 comments
+- Review 3: 2 comments
+
+Total Copilot review comments: 9.
+
+Project-owner response comments posted to the PR: 3.
+
+### Review 1: Initial Scaffold Feedback
+
+Copilot raised 5 issues.
+
+1. `main()` parsed real process args
+   - Problem: `main()` called `parse_args()` with default `sys.argv`, so `pytest` flags could cause `SystemExit`.
+   - Fix: changed `main()` to accept `argv: Sequence[str] | None = None` and call `parser.parse_args(argv)`.
+   - Commit: `943ffe8`
+
+2. Durable validation notes were stale
+   - Problem: the epic file said no validation had run, while the PR already included validation notes.
+   - Fix: updated `docs/state/epics/coffee-roaster-mcp-v0.1.md` with validation notes for E1-S1 and E1-S2.
+   - Commit: `943ffe8`
+
+3. Version existed in two places
+   - Problem: `pyproject.toml` had `version = "0.1.0"` while `__init__.py` also had `__version__ = "0.1.0"`.
+   - Fix: changed `pyproject.toml` to `dynamic = ["version"]` and configured Hatch to read the version from `src/coffee_roaster_mcp/__init__.py`.
+   - Commit: `943ffe8`
+
+4. `--version` behavior was not tested
+   - Problem: tests covered `parser.prog` and no-arg `main()`, but not `main(["--version"])`.
+   - Fix: added `test_main_prints_version`.
+   - Commit: `943ffe8`
+
+5. `README.md` was missing
+   - Problem: `project.readme = "README.md"` would make Hatchling fail during metadata/build because the file did not exist.
+   - Fix: added a minimal `README.md`.
+   - Commit: `943ffe8`
+
+### Review 2: Test Import And Help Coverage
+
+Copilot raised 2 issues.
+
+1. Plain `pytest` could not import the `src/` package
+   - Problem: tests imported `coffee_roaster_mcp`, but the repo uses a `src/` layout and plain `pytest` would not have `src` on `sys.path`.
+   - Fix: added `pythonpath = ["src"]` under `[tool.pytest.ini_options]`.
+   - Commit: `c13d947`
+
+2. `--help` behavior was not tested
+   - Problem: `--help` is part of the documented CLI acceptance criteria, but only no-arg and `--version` paths were tested.
+   - Fix: added `test_main_prints_help`.
+   - Commit: `c13d947`
+
+### Review 3: Durable State And README Wording
+
+Copilot raised 2 issues.
+
+1. Active story was stale
+   - Problem: E1-S3 CLI basics had effectively been implemented by the PR, but durable state still pointed to E1-S3 as active.
+   - Fix: marked E1-S3 complete and moved active story to E1-S4.
+   - Commit: `cf7af53`
+
+2. README implied PyPI publication had already happened
+   - Problem: wording said the package is published as `coffee-roaster-mcp`, but PyPI publishing is still planned for v0.1.
+   - Fix: changed README wording to say the package name is `coffee-roaster-mcp` and PyPI publishing is planned for v0.1.
+   - Commit: `cf7af53`
+
+## Validation Performed
+
+Local validation was limited by the fresh environment.
+
+Successful checks:
+
+- Parsed `pyproject.toml` with stdlib `tomllib`.
+- Confirmed package name is `coffee-roaster-mcp`.
+- Confirmed console script target is `coffee_roaster_mcp.cli:main`.
+- Confirmed Hatch dynamic version path is `src/coffee_roaster_mcp/__init__.py`.
+- Confirmed pytest config includes `pythonpath = ["src"]`.
+- Ran package import smoke check with `PYTHONPATH=src`.
+- Ran CLI no-arg smoke check with `PYTHONPATH=src`.
+- Ran CLI `--version` smoke check with `PYTHONPATH=src`.
+- Ran CLI `--help` smoke check with `PYTHONPATH=src`.
+
+Checks not run:
+
+- Full `pytest`.
+- Package build through Hatchling.
+
+Reason:
+
+- Ambient Python did not have `pytest`.
+- Ambient Python did not have `hatchling`.
+- `uv` was not installed in the shell environment.
+
+This is expected at this bootstrap point. Full dev environment setup is planned in follow-up stories.
+
+## Current Durable State
+
+The active epic state now says:
+
+- E1-S1 complete
+- E1-S2 complete
+- E1-S3 complete
+- Active story: E1-S4, config loading from YAML and environment variables
+
+GitHub issue #9 remains open because the correct workflow is:
+
+1. implement on branch
+2. open PR
+3. review
+4. merge
+5. close story issue
+
+The earlier impulse to close the issue immediately was corrected before the issue was closed.
+
+## Token Usage Notes
+
+Exact billable token usage for this Codex session is not available from the local repository, GitHub CLI, or the runtime-visible command outputs.
+
+Do not quote a numeric token total for this session unless it is retrieved later from Codex/OpenAI platform telemetry or an exported session log that includes token accounting.
+
+Observed non-PII Codex status from the local UI during this session:
+
+- Codex version: `v0.128.0`
+- Model: `gpt-5.5`
+- Reasoning effort: `medium`
+- Summaries: `auto`
+- Collaboration mode: `Default`
+- Context window status: `30% left`
+- Context usage shown by UI: `183K used / 258K`
+- Five-hour limit status: `41% left`
+- Five-hour limit reset: `22:30`
+- Weekly limit status: `72% left`
+- Weekly limit reset: `18:17 on 6 May`
+
+Useful proxy stats for the blog:
+
+- 63 GitHub issues created for the v0.1 plan.
+- 7 epic issues.
+- 53 story issues.
+- 3 standalone spike issues.
+- 1 bootstrap PR opened.
+- 4 commits pushed to the PR.
+- 3 Copilot review batches.
+- 9 Copilot review comments.
+- 9 files changed in the PR.
+- 1,193 inserted lines at the time of this summary.
+
+## Blog-Relevant Observations
+
+- The spec-driven workflow caught a process mistake: story issues should not close until after PR review and merge.
+- Durable state files matter because Copilot correctly caught stale state twice.
+- Copilot was useful as a workflow and packaging reviewer:
+  - it caught test arg handling
+  - it caught missing README metadata
+  - it caught version drift risk
+  - it caught missing test coverage
+  - it caught stale project state
+- The human workflow decision remained important:
+  - keep issues open until PR review and merge
+  - use boring infrastructure naming plus a product name
+  - keep model production out of this repo
+
+## Next Recommended Step
+
+Finish review and merge PR #64.
+
+After merge:
+
+1. Close #8 and #9.
+2. Keep #10 in sync with E1-S3 if needed, or close it if PR #64 is accepted as satisfying CLI basics.
+3. Start E1-S4 on a new branch for config loading.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -1,0 +1,348 @@
+# RoastPilot v0.1 Epic
+
+## Epic Summary
+
+Build RoastPilot as a standalone Python MCP server published as `coffee-roaster-mcp`. The server owns roaster control, telemetry, first-crack detection integration, roast timing, derived metrics, event logging, and export in one local stdio process.
+
+The first implementation milestone is a mock vertical slice that requires no roaster hardware and no model download.
+
+## Status Legend
+
+- `[ ]` Not started
+- `[~]` In progress
+- `[x]` Complete
+- `[!]` Blocked
+
+## Active Context
+
+- Current phase: Bootstrap
+- Active story: `E1-S3`
+- Current target: CLI basics
+- Product/display name: `RoastPilot`
+- GitHub repo: `syamaner/coffee-roaster-mcp`
+- PyPI package: `coffee-roaster-mcp`
+- Python import package: `coffee_roaster_mcp`
+- Console entrypoint: `coffee-roaster-mcp`
+- MCP Registry name: `io.github.syamaner/coffee-roaster-mcp`
+
+## Current Decisions
+
+- v0.1 uses local stdio MCP transport.
+- Agent and n8n orchestration are out of scope.
+- Default roaster driver is `mock`.
+- First-crack mode defaults to `disabled` so mock install and registry smoke tests do not require audio hardware or model download.
+- ONNX INT8 is the default real model backend.
+- ONNX FP32 is supported by config.
+- The `coffee-first-crack-detection` repo remains the source of truth for training, ONNX export, Hugging Face sync, model cards, and dataset cards.
+- This repo consumes released Hugging Face artifacts only.
+- Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
+
+## Current Risks
+
+- Hottop command-loop behavior and temperature units need hardware verification.
+- MCP Registry publishing is preview and needs verification before release.
+- First-crack event integration must preserve one authoritative session timeline.
+- Log schema changes need compatibility discipline once users start collecting roast logs.
+
+## Definition Of Done
+
+Every implementation story is done only when:
+
+- The story acceptance criteria are met.
+- Required unit or integration tests are added or updated.
+- `ruff check`, formatting check, typecheck, and tests pass once the tooling exists.
+- Public docs or runbooks are updated when operator behavior changes.
+- The active epic state is updated with status, decision notes, and validation notes.
+
+## Epic 1: Repo, Packaging, And Developer Workflow
+
+Goal: create a usable standalone Python project with durable state, dev workflow, and mock-first defaults.
+
+### Stories
+
+- [x] `E1-S1` Create standalone repo state and project plan docs.
+  - Done when `docs/state/registry.md`, this active epic, and `docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md` exist in the repo.
+
+- [x] `E1-S2` Add Python package scaffold.
+  - Done when `pyproject.toml`, `src/coffee_roaster_mcp/`, `tests/`, and the `coffee-roaster-mcp` console entrypoint exist.
+
+- [ ] `E1-S3` Add CLI basics.
+  - Done when `coffee-roaster-mcp --help` and `coffee-roaster-mcp --version` work after editable install.
+
+- [ ] `E1-S4` Add config loading from YAML and environment variables.
+  - Done when config defaults allow a local mock run with no config file and documented env overrides are supported.
+
+- [ ] `E1-S5` Add local dev commands.
+  - Done when there are documented commands for lint, format check, typecheck, tests, and mock server run.
+
+- [ ] `E1-S6` Add CI for tests and package build.
+  - Done when GitHub Actions runs checks and builds the package on pull requests.
+
+- [ ] `E1-S7` Add initial README and install/run documentation.
+  - Done when README explains RoastPilot, local mock run, Hottop config placeholder, Hugging Face model boundary, and log export.
+
+- [ ] `E1-S8` Add repo-local skills or runbooks.
+  - Done when `mcp-dev`, `mock-roast`, `hottop-validation`, and `release-registry` workflows exist as repo-local docs or skills.
+
+### Epic Acceptance Criteria
+
+- `coffee-roaster-mcp --help` works after editable install.
+- Mock server can start without roaster hardware or model download.
+- CI runs tests and package build.
+- Config defaults allow a local mock run with no config file.
+
+## Epic 2: MCP Runtime And Session Core
+
+Goal: implement one authoritative roast session runtime and MCP tool surface.
+
+### Stories
+
+- [ ] `E2-S1` Implement stdio MCP server entrypoint.
+  - Done when the server starts locally and exposes a minimal tool list.
+
+- [ ] `E2-S2` Implement `RoastSession` lifecycle.
+  - Done when sessions have id, monotonic clock, phase, event timeline, telemetry buffer, and log writer references.
+
+- [ ] `E2-S3` Implement core event timeline.
+  - Done when `beans_added`, `first_crack_detected`, `beans_dropped`, `cooling_started`, `cooling_stopped`, and `fault` can be recorded with timestamps.
+
+- [ ] `E2-S4` Implement core MCP tools.
+  - Done when `start_roast_session`, `get_roast_state`, `set_heat`, `set_fan`, `mark_beans_added`, `mark_first_crack`, `drop_beans`, `start_cooling`, `stop_cooling`, `export_roast_log`, and `emergency_stop` exist.
+
+- [ ] `E2-S5` Implement phase transitions.
+  - Done when session phase changes are deterministic for pre-roast, roasting, development, dropped, cooling, complete, and fault states.
+
+- [ ] `E2-S6` Implement emergency stop and fault recording.
+  - Done when emergency stop records an event and calls the active driver safety method.
+
+- [ ] `E2-S7` Complete thin vertical slice spike.
+  - Done when a mock roast can start, mark beans added, inject first crack, drop beans, return state, and export logs in one process.
+
+### Epic Acceptance Criteria
+
+- A mock roast can start, mark beans added, mark first crack, drop beans, and export logs.
+- `get_roast_state` returns consistent timestamps, phase, metrics, and latest controls.
+- First crack is recorded once unless manual override is explicitly allowed.
+- Emergency stop records an event and calls the driver safety method.
+
+## Epic 3: Roaster Abstraction And Hottop Driver
+
+Goal: support multiple roasters behind one driver contract while preserving current Hottop behavior.
+
+### Stories
+
+- [ ] `E3-S1` Define `RoasterDriver` interface and capabilities model.
+  - Done when drivers expose connection lifecycle, read state, heat/fan control, drop, cooling, emergency stop, and capabilities.
+
+- [ ] `E3-S2` Implement mock driver.
+  - Done when the mock driver supports deterministic telemetry and passes contract tests.
+
+- [ ] `E3-S3` Implement normalized roaster state model.
+  - Done when driver state includes bean temp C, env temp C, heat %, fan %, cooling on/off, connected, and raw vendor data.
+
+- [ ] `E3-S4` Implement Hottop serial connection lifecycle.
+  - Done when the Hottop driver can connect, disconnect, and clean up without leaving command loops running.
+
+- [ ] `E3-S5` Implement Hottop command loop.
+  - Done when continuous command streaming around 0.3s is implemented and lifecycle-tested.
+
+- [ ] `E3-S6` Implement Hottop packet build/parse.
+  - Done when 36-byte packet construction, status parsing, and checksum validation are unit tested.
+
+- [ ] `E3-S7` Implement Hottop heat, fan, drop, cooling, stop cooling, and emergency stop.
+  - Done when commands preserve safe defaults and known compound drop/cooling behavior.
+
+- [ ] `E3-S8` Implement Hottop temperature unit handling.
+  - Done when `celsius`, `fahrenheit`, and `auto` modes are supported and tested with plausible readings.
+
+- [ ] `E3-S9` Run Hottop integration verification spike.
+  - Done when packet parsing, temp units, command cadence, drop, cooling, and cleanup have manual validation notes.
+
+### Epic Acceptance Criteria
+
+- Mock driver passes contract tests.
+- Hottop packet tests cover checksum, invalid packets, and temp conversion.
+- Command loop starts and stops cleanly.
+- Manual Hottop checklist passes before hardware-ready release label.
+
+## Epic 4: First-Crack Detection With HF Models
+
+Goal: consume released Hugging Face model artifacts and feed first-crack events into the single roast timeline.
+
+### Stories
+
+- [ ] `E4-S1` Add Hugging Face artifact resolver.
+  - Done when model files can be resolved from `syamaner/coffee-first-crack-detection` using configured revision.
+
+- [ ] `E4-S2` Load INT8 ONNX by default.
+  - Done when `onnx/int8/model_quantized.onnx` is selected for `precision: int8`.
+
+- [ ] `E4-S3` Load FP32 ONNX by config.
+  - Done when `onnx/fp32/model.onnx` is selected for `precision: fp32`.
+
+- [ ] `E4-S4` Support local offline model directory.
+  - Done when `local_model_dir` works without Hugging Face network access.
+
+- [ ] `E4-S5` Validate required detector artifacts before detection starts.
+  - Done when missing ONNX model or feature extractor files fail clearly before audio detection begins.
+
+- [ ] `E4-S6` Add audio capture pipeline.
+  - Done when configured audio input can feed detector windows without blocking roaster telemetry.
+
+- [ ] `E4-S7` Add detector adapter.
+  - Done when detector output maps to a confirmed first-crack event with timestamp, precision, revision, and confidence when available.
+
+- [ ] `E4-S8` Integrate first crack with session timeline.
+  - Done when mocked detector output creates exactly one `first_crack_detected` event.
+
+### Epic Acceptance Criteria
+
+- INT8 resolver selects `onnx/int8/model_quantized.onnx`.
+- FP32 resolver selects `onnx/fp32/model.onnx`.
+- Offline local directory works without HF network access.
+- Mocked detector output creates exactly one `first_crack_detected` event.
+
+## Epic 5: Roast Metrics And Log Export
+
+Goal: compute roast metrics from one session clock and export durable logs.
+
+### Stories
+
+- [ ] `E5-S1` Implement rolling telemetry buffer.
+  - Done when bean/env samples are retained for rolling metric calculations.
+
+- [ ] `E5-S2` Compute elapsed roast time.
+  - Done when `roast_elapsed_seconds` is computed from `beans_added_at` to now or drop.
+
+- [ ] `E5-S3` Compute development time and percent.
+  - Done when development time starts at first crack and development percent is `development_time_seconds / roast_elapsed_seconds * 100`.
+
+- [ ] `E5-S4` Compute 60s bean/env deltas.
+  - Done when latest minus oldest sample in rolling 60s window is returned for bean and environment temps.
+
+- [ ] `E5-S5` Compute bean/env RoR.
+  - Done when RoR is normalized to C/min and returns null before 10 seconds of samples.
+
+- [ ] `E5-S6` Write append-only JSONL roast log.
+  - Done when telemetry rows are written at 1 Hz and event rows are written immediately.
+
+- [ ] `E5-S7` Export CSV roast log.
+  - Done when CSV includes all required columns from the plan.
+
+- [ ] `E5-S8` Export `summary.json`.
+  - Done when summary includes session timestamps, total roast seconds, development metrics, roaster driver, and first-crack model metadata.
+
+- [ ] `E5-S9` Add log schema tests.
+  - Done when JSONL, CSV, and summary schema completeness is covered by tests.
+
+### Epic Acceptance Criteria
+
+- RoR is null before 10 seconds of samples.
+- RoR and deltas are correct for regular and irregular sample intervals.
+- JSONL, CSV, and summary include required fields.
+- Event rows are written immediately, not only on the 1 Hz sample loop.
+
+## Epic 6: Distribution And MCP Registry Publishing
+
+Goal: make RoastPilot installable and discoverable through PyPI and the MCP Registry.
+
+### Stories
+
+- [ ] `E6-S1` Add PyPI package metadata.
+  - Done when package metadata is complete for `coffee-roaster-mcp`.
+
+- [ ] `E6-S2` Add README MCP verification string.
+  - Done when README includes `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`.
+
+- [ ] `E6-S3` Add `server.json`.
+  - Done when registry metadata uses name `io.github.syamaner/coffee-roaster-mcp`, title `RoastPilot`, package `coffee-roaster-mcp`, and stdio transport.
+
+- [ ] `E6-S4` Add version alignment check.
+  - Done when package version and `server.json.version` cannot drift unnoticed.
+
+- [ ] `E6-S5` Add release workflow.
+  - Done when CI can build, test, publish to PyPI, and publish registry metadata after tag release.
+
+- [ ] `E6-S6` Run MCP Registry publishing verification spike.
+  - Done when `server.json`, PyPI verification, and `mcp-publisher` flow are documented and tested before v0.1 release.
+
+- [ ] `E6-S7` Document install and hardware setup.
+  - Done when docs cover mock install, Hottop config, Hugging Face model config, offline model path, and log output paths.
+
+### Epic Acceptance Criteria
+
+- Package installs from PyPI.
+- `server.json` validates against current MCP schema.
+- Registry publish flow is documented and tested before v0.1 release.
+- Registry listing points to the PyPI package and stdio transport.
+
+## Epic 7: End-To-End Validation And Release Readiness
+
+Goal: prove the package works from install through mock roast, MCP client calls, hardware validation, and release.
+
+### Stories
+
+- [ ] `E7-S1` Test full mock roast through MCP tools.
+  - Done when a mock roast works from session start to exported logs.
+
+- [ ] `E7-S2` Test package install smoke flow.
+  - Done when a built wheel can be installed and `coffee-roaster-mcp --help` works.
+
+- [ ] `E7-S3` Test MCP client connection.
+  - Done when a real MCP client can discover and call the server tools.
+
+- [ ] `E7-S4` Run Hottop manual hardware validation.
+  - Done when manual validation results are recorded against the checklist.
+
+- [ ] `E7-S5` Produce v0.1 release checklist.
+  - Done when release steps cover tests, package build, version alignment, HF revision pin, PyPI publish, registry publish, GitHub release, and hardware-ready labeling.
+
+### Epic Acceptance Criteria
+
+- Full mock roast works from install to exported logs.
+- MCP client can discover and call tools.
+- Manual hardware results are recorded.
+- Release is tagged only after package, registry, and smoke tests pass.
+
+## Spikes
+
+### `SP1` Thin Vertical Slice
+
+- Epic: `E2`
+- Goal: prove one process can run mock roaster telemetry, injected first crack, metrics, logs, and MCP tool calls.
+- Output: working mock flow and notes on any architecture changes.
+
+### `SP2` Hottop Integration Verification
+
+- Epic: `E3`
+- Goal: confirm packet parsing, temperature units, checksum behavior, command cadence, drop, cooling, and cleanup on real hardware.
+- Output: validation notes and final driver decisions.
+
+### `SP3` MCP Registry Publishing Verification
+
+- Epic: `E6`
+- Goal: verify `server.json`, PyPI verification string, and `mcp-publisher` flow while the registry is preview.
+- Output: validated metadata template and release checklist updates.
+
+## Story Workflow
+
+Before starting a story:
+
+1. Read `docs/state/registry.md`.
+2. Read this active epic.
+3. Read the linked GitHub issue.
+4. Confirm acceptance criteria and current risks.
+5. Create branch `feature/{issue-number}-{slug}`.
+
+After completing a story:
+
+1. Run required checks.
+2. Update story status in this epic.
+3. Update Active Context and Current Decisions if behavior changed.
+4. Add validation notes.
+5. Comment on the GitHub issue with what changed and how it was tested.
+6. Open a PR referencing the issue.
+
+## Validation Notes
+
+No validation has been run yet. The repo is in bootstrap state.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -345,4 +345,9 @@ After completing a story:
 
 ## Validation Notes
 
-No validation has been run yet. The repo is in bootstrap state.
+- E1-S1 created durable state docs and the copied overall plan.
+- E1-S2 added the initial Python package scaffold, console entrypoint declaration, package module, CLI module, and package smoke tests.
+- Validation run for E1-S2:
+  - Parsed `pyproject.toml` with stdlib `tomllib` and confirmed package name plus console script target.
+  - Ran `PYTHONPATH=src` package import and CLI parser smoke check successfully.
+  - Full `pytest` execution is pending dev environment setup because ambient Python does not have `pytest` installed yet.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E1-S3`
-- Current target: CLI basics
+- Active story: `E1-S4`
+- Current target: Config loading from YAML and environment variables
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -66,7 +66,7 @@ Goal: create a usable standalone Python project with durable state, dev workflow
 - [x] `E1-S2` Add Python package scaffold.
   - Done when `pyproject.toml`, `src/coffee_roaster_mcp/`, `tests/`, and the `coffee-roaster-mcp` console entrypoint exist.
 
-- [ ] `E1-S3` Add CLI basics.
+- [x] `E1-S3` Add CLI basics.
   - Done when `coffee-roaster-mcp --help` and `coffee-roaster-mcp --version` work after editable install.
 
 - [ ] `E1-S4` Add config loading from YAML and environment variables.
@@ -347,7 +347,11 @@ After completing a story:
 
 - E1-S1 created durable state docs and the copied overall plan.
 - E1-S2 added the initial Python package scaffold, console entrypoint declaration, package module, CLI module, and package smoke tests.
+- E1-S3 added CLI help/version behavior and smoke coverage.
 - Validation run for E1-S2:
   - Parsed `pyproject.toml` with stdlib `tomllib` and confirmed package name plus console script target.
   - Ran `PYTHONPATH=src` package import and CLI parser smoke check successfully.
   - Full `pytest` execution is pending dev environment setup because ambient Python does not have `pytest` installed yet.
+- Validation run for E1-S3:
+  - Parsed `pyproject.toml` and confirmed pytest `pythonpath` config.
+  - Ran `PYTHONPATH=src` `--help` and `--version` smoke checks successfully.

--- a/docs/state/github-issues.md
+++ b/docs/state/github-issues.md
@@ -1,0 +1,95 @@
+# RoastPilot GitHub Issue Index
+
+Repository: `syamaner/coffee-roaster-mcp`
+
+Milestone: `v0.1`
+
+## Epics
+
+- #1 Epic 1: Repo, Packaging, And Developer Workflow
+- #2 Epic 2: MCP Runtime And Session Core
+- #3 Epic 3: Roaster Abstraction And Hottop Driver
+- #4 Epic 4: First-Crack Detection With HF Models
+- #5 Epic 5: Roast Metrics And Log Export
+- #6 Epic 6: Distribution And MCP Registry Publishing
+- #7 Epic 7: End-To-End Validation And Release Readiness
+
+## Epic 1 Stories
+
+- #8 E1-S1: Create standalone repo state and project plan docs
+- #9 E1-S2: Add Python package scaffold
+- #10 E1-S3: Add CLI basics
+- #11 E1-S4: Add config loading from YAML and environment variables
+- #12 E1-S5: Add local dev commands
+- #13 E1-S6: Add CI for tests and package build
+- #14 E1-S7: Add initial README and install/run documentation
+- #15 E1-S8: Add repo-local skills or runbooks
+
+## Epic 2 Stories
+
+- #16 E2-S1: Implement stdio MCP server entrypoint
+- #17 E2-S2: Implement RoastSession lifecycle
+- #18 E2-S3: Implement core event timeline
+- #19 E2-S4: Implement core MCP tools
+- #20 E2-S5: Implement phase transitions
+- #21 E2-S6: Implement emergency stop and fault recording
+- #22 E2-S7: Complete thin vertical slice spike
+
+## Epic 3 Stories
+
+- #23 E3-S1: Define RoasterDriver interface and capabilities model
+- #24 E3-S2: Implement mock driver
+- #25 E3-S3: Implement normalized roaster state model
+- #26 E3-S4: Implement Hottop serial connection lifecycle
+- #27 E3-S5: Implement Hottop command loop
+- #28 E3-S6: Implement Hottop packet build/parse
+- #29 E3-S7: Implement Hottop heat, fan, drop, cooling, stop cooling, and emergency stop
+- #30 E3-S8: Implement Hottop temperature unit handling
+- #31 E3-S9: Run Hottop integration verification spike
+
+## Epic 4 Stories
+
+- #32 E4-S1: Add Hugging Face artifact resolver
+- #33 E4-S2: Load INT8 ONNX by default
+- #34 E4-S3: Load FP32 ONNX by config
+- #35 E4-S4: Support local offline model directory
+- #36 E4-S5: Validate required detector artifacts before detection starts
+- #37 E4-S6: Add audio capture pipeline
+- #38 E4-S7: Add detector adapter
+- #39 E4-S8: Integrate first crack with session timeline
+
+## Epic 5 Stories
+
+- #40 E5-S1: Implement rolling telemetry buffer
+- #41 E5-S2: Compute elapsed roast time
+- #42 E5-S3: Compute development time and percent
+- #43 E5-S4: Compute 60s bean/env deltas
+- #44 E5-S5: Compute bean/env RoR
+- #45 E5-S6: Write append-only JSONL roast log
+- #46 E5-S7: Export CSV roast log
+- #47 E5-S8: Export summary.json
+- #48 E5-S9: Add log schema tests
+
+## Epic 6 Stories
+
+- #49 E6-S1: Add PyPI package metadata
+- #50 E6-S2: Add README MCP verification string
+- #51 E6-S3: Add server.json
+- #52 E6-S4: Add version alignment check
+- #53 E6-S5: Add release workflow
+- #54 E6-S6: Run MCP Registry publishing verification spike
+- #55 E6-S7: Document install and hardware setup
+
+## Epic 7 Stories
+
+- #56 E7-S1: Test full mock roast through MCP tools
+- #57 E7-S2: Test package install smoke flow
+- #58 E7-S3: Test MCP client connection
+- #59 E7-S4: Run Hottop manual hardware validation
+- #60 E7-S5: Produce v0.1 release checklist
+
+## Standalone Spikes
+
+- #61 SP1: Thin Vertical Slice
+- #62 SP2: Hottop Integration Verification
+- #63 SP3: MCP Registry Publishing Verification

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -1,0 +1,25 @@
+# RoastPilot Project State Registry
+
+## Active Epic
+
+- Epic file: `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+- GitHub issue index: `docs/state/github-issues.md`
+- Project: RoastPilot
+- Repository: `syamaner/coffee-roaster-mcp`
+- Package: `coffee-roaster-mcp`
+- MCP Registry name: `io.github.syamaner/coffee-roaster-mcp`
+- Current phase: Bootstrap
+
+## Working Rules
+
+- Before starting implementation, read this registry, then the active epic, then the GitHub issue for the story.
+- Each story should have acceptance criteria before code starts.
+- Risky stories require a short implementation plan before code.
+- Keep model training, ONNX export, and Hugging Face sync in the `coffee-first-crack-detection` model repo.
+- This repo consumes released Hugging Face model artifacts only.
+
+## Active Context
+
+RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
+
+The first implementation milestone is a thin mock vertical slice: install the package, start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ path = "src/coffee_roaster_mcp/__init__.py"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
+pythonpath = ["src"]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coffee-roaster-mcp"
-version = "0.1.0"
+dynamic = ["version"]
 description = "RoastPilot: a spec-driven MCP server for autonomous coffee roasting."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -46,6 +46,9 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/coffee_roaster_mcp"]
+
+[tool.hatch.version]
+path = "src/coffee_roaster_mcp/__init__.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = ["hatchling>=1.26"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coffee-roaster-mcp"
+version = "0.1.0"
+description = "RoastPilot: a spec-driven MCP server for autonomous coffee roasting."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { file = "LICENSE" }
+authors = [
+  { name = "Sertan Yamaner" }
+]
+keywords = [
+  "coffee",
+  "coffee-roasting",
+  "mcp",
+  "model-context-protocol",
+  "roastpilot"
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence"
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/syamaner/coffee-roaster-mcp"
+Repository = "https://github.com/syamaner/coffee-roaster-mcp"
+Issues = "https://github.com/syamaner/coffee-roaster-mcp/issues"
+
+[project.scripts]
+coffee-roaster-mcp = "coffee_roaster_mcp.cli:main"
+
+[dependency-groups]
+dev = [
+  "pytest>=8.0",
+  "ruff>=0.8",
+  "pyright>=1.1"
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/coffee_roaster_mcp"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.pyright]
+pythonVersion = "3.11"
+typeCheckingMode = "strict"
+include = ["src", "tests"]

--- a/src/coffee_roaster_mcp/__init__.py
+++ b/src/coffee_roaster_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""RoastPilot MCP server package."""
+
+__version__ = "0.1.0"

--- a/src/coffee_roaster_mcp/cli.py
+++ b/src/coffee_roaster_mcp/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Sequence
 
 from coffee_roaster_mcp import __version__
 
@@ -21,8 +22,8 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main() -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     """Run the RoastPilot CLI."""
     parser = build_parser()
-    parser.parse_args()
+    parser.parse_args(argv)
     return 0

--- a/src/coffee_roaster_mcp/cli.py
+++ b/src/coffee_roaster_mcp/cli.py
@@ -1,0 +1,28 @@
+"""Command line entrypoint for RoastPilot."""
+
+from __future__ import annotations
+
+import argparse
+
+from coffee_roaster_mcp import __version__
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the RoastPilot command line parser."""
+    parser = argparse.ArgumentParser(
+        prog="coffee-roaster-mcp",
+        description="RoastPilot: a spec-driven MCP server for autonomous coffee roasting.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    return parser
+
+
+def main() -> int:
+    """Run the RoastPilot CLI."""
+    parser = build_parser()
+    parser.parse_args()
+    return 0

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,3 +1,5 @@
+import pytest
+
 from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.cli import build_parser, main
 
@@ -13,4 +15,12 @@ def test_cli_parser_program_name() -> None:
 
 
 def test_main_returns_success() -> None:
-    assert main() == 0
+    assert main([]) == 0
+
+
+def test_main_prints_version(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--version"])
+
+    assert exc_info.value.code == 0
+    assert capsys.readouterr().out.strip() == f"coffee-roaster-mcp {__version__}"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,16 @@
+from coffee_roaster_mcp import __version__
+from coffee_roaster_mcp.cli import build_parser, main
+
+
+def test_version_is_defined() -> None:
+    assert __version__ == "0.1.0"
+
+
+def test_cli_parser_program_name() -> None:
+    parser = build_parser()
+
+    assert parser.prog == "coffee-roaster-mcp"
+
+
+def test_main_returns_success() -> None:
+    assert main() == 0

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -24,3 +24,13 @@ def test_main_prints_version(capsys: pytest.CaptureFixture[str]) -> None:
 
     assert exc_info.value.code == 0
     assert capsys.readouterr().out.strip() == f"coffee-roaster-mcp {__version__}"
+
+
+def test_main_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--help"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "usage: coffee-roaster-mcp" in output
+    assert "RoastPilot" in output


### PR DESCRIPTION
## Summary
- add RoastPilot v0.1 plan and durable state docs
- add GitHub issue index for epics, stories, and spikes
- add initial Python package scaffold for `coffee-roaster-mcp`
- add minimal CLI entrypoint and package smoke tests

## Validation
- `python3 -c 'import pathlib, tomllib; data=tomllib.loads(pathlib.Path("pyproject.toml").read_text()); assert data["project"]["name"] == "coffee-roaster-mcp"; assert data["project"]["scripts"]["coffee-roaster-mcp"] == "coffee_roaster_mcp.cli:main"'`
- `PYTHONPATH=src python3 -c 'from coffee_roaster_mcp import __version__; from coffee_roaster_mcp.cli import build_parser, main; assert __version__ == "0.1.0"; assert build_parser().prog == "coffee-roaster-mcp"; assert main() == 0'`

## Notes
- `pytest` and `uv` are not installed in the ambient environment yet; full dev tooling comes in follow-up stories.
- Leaves untracked local `.vscode/` untouched.

Refs #8
Refs #9