### PR TITLE
[codex] Add local development commands

### DIFF
--- a/.claude/skills/mcp-dev/SKILL.md
+++ b/.claude/skills/mcp-dev/SKILL.md
@@ -27,9 +27,9 @@ coffee-roaster-mcp --help
 coffee-roaster-mcp --version
 ```
 
-## Config Smoke
+## Mock-Safe Bootstrap Smoke
 
-Default config should require no roaster hardware, no microphone, and no model download:
+The stdio MCP server is not implemented until `E2-S1`. For bootstrap work, confirm the default config still requires no roaster hardware, no microphone, and no model download:
 
 ```bash
 python -c "from coffee_roaster_mcp.config import load_config; c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision)"
@@ -45,4 +45,3 @@ mock disabled int8
 
 - The full MCP server and mock roast flow are not implemented yet.
 - Once E2 stories land, extend this skill with mock MCP server startup and basic tool-call smoke tests.
-

--- a/.claude/skills/mcp-dev/SKILL.md
+++ b/.claude/skills/mcp-dev/SKILL.md
@@ -29,10 +29,10 @@ coffee-roaster-mcp --version
 
 ## Mock-Safe Bootstrap Smoke
 
-The stdio MCP server is not implemented until `E2-S1`. For bootstrap work, confirm the default config still requires no roaster hardware, no microphone, and no model download:
+The stdio MCP server is not implemented until `E2-S1`. For bootstrap work, confirm the default config still requires no roaster hardware, no microphone, and no model download from a guaranteed-empty temporary directory:
 
 ```bash
-python -c "from coffee_roaster_mcp.config import load_config; c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision)"
+python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
 ```
 
 Expected output:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,10 +55,10 @@ coffee-roaster-mcp --version
 
 ### Mock-Safe Bootstrap Smoke
 
-The stdio MCP server is not implemented until `E2-S1`. Use this command to verify the default local path stays on the mock driver with first-crack detection disabled:
+The stdio MCP server is not implemented until `E2-S1`. Use this command to verify the default local path stays on the mock driver with first-crack detection disabled from a guaranteed-empty temporary directory:
 
 ```bash
-python -c "from coffee_roaster_mcp.config import load_config; c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision)"
+python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
 ```
 
 ## Codebase Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,14 @@ coffee-roaster-mcp --help
 coffee-roaster-mcp --version
 ```
 
+### Mock-Safe Bootstrap Smoke
+
+The stdio MCP server is not implemented until `E2-S1`. Use this command to verify the default local path stays on the mock driver with first-crack detection disabled:
+
+```bash
+python -c "from coffee_roaster_mcp.config import load_config; c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision)"
+```
+
 ## Codebase Architecture
 
 ```text

--- a/README.md
+++ b/README.md
@@ -8,6 +8,62 @@ RoastPilot will provide one local MCP runtime for roaster control, telemetry, fi
 
 The project is currently in bootstrap. See `docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md` and `docs/state/registry.md` for the active plan and state.
 
+## Local Development
+
+### Setup
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e . --group dev
+```
+
+### Test
+
+```bash
+python -m pytest
+```
+
+### Lint
+
+```bash
+python -m ruff check .
+```
+
+### Format Check
+
+```bash
+python -m ruff format --check .
+```
+
+### Typecheck
+
+```bash
+python -m pyright
+```
+
+### CLI Smoke
+
+```bash
+coffee-roaster-mcp --help
+coffee-roaster-mcp --version
+```
+
+### Mock-Safe Bootstrap Smoke
+
+The full stdio MCP server lands in `E2-S1`. Until then, use this mock-safe bootstrap smoke to confirm the default local path stays hardware-free and model-free:
+
+```bash
+python -c "from coffee_roaster_mcp.config import load_config; c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision)"
+```
+
+Expected output:
+
+```text
+mock disabled int8
+```
+
 ## Configuration
 
 RoastPilot loads configuration from `coffee-roaster-mcp.yaml` in the current directory by default. If the file is absent, mock-safe defaults are used so local development does not require roaster hardware, audio hardware, or model downloads.

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ coffee-roaster-mcp --version
 
 ### Mock-Safe Bootstrap Smoke
 
-The full stdio MCP server lands in `E2-S1`. Until then, use this mock-safe bootstrap smoke to confirm the default local path stays hardware-free and model-free:
+The full stdio MCP server lands in `E2-S1`. Until then, use this mock-safe bootstrap smoke to confirm the default local path stays hardware-free and model-free from a guaranteed-empty temporary directory:
 
 ```bash
-python -c "from coffee_roaster_mcp.config import load_config; c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision)"
+python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
 ```
 
 Expected output:

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E1-S5`
-- Current target: Local dev commands for lint, format check, typecheck, tests, and mock server run
+- Active story: `E1-S6`
+- Current target: GitHub Actions for lint, format check, typecheck, tests, and package build
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -74,7 +74,7 @@ Goal: create a usable standalone Python project with durable state, dev workflow
 - [x] `E1-S4` Add config loading from YAML and environment variables.
   - Done when config defaults allow a local mock run with no config file and documented env overrides are supported.
 
-- [ ] `E1-S5` Add local dev commands.
+- [x] `E1-S5` Add local dev commands.
   - Done when there are documented commands for lint, format check, typecheck, tests, and mock server run.
 
 - [ ] `E1-S6` Add CI for tests and package build.
@@ -351,6 +351,7 @@ After completing a story:
 - E1-S2 added the initial Python package scaffold, console entrypoint declaration, package module, CLI module, and package smoke tests.
 - E1-S3 added CLI help/version behavior and smoke coverage.
 - E1-S4 added typed config dataclasses, YAML loading, environment override precedence, config documentation, and focused tests. Copilot review hardening added whitespace/case normalization, empty log-dir validation, conventional runtime type checks, and cached config path existence checks.
+- E1-S5 added one documented local development workflow across `README.md`, `AGENTS.md`, and `.claude/skills/mcp-dev`. The documented commands now cover setup, tests, lint, format check, typecheck, CLI smoke, and a mock-safe bootstrap smoke path until the stdio MCP server lands in `E2-S1`.
 - E1-S8 started early with `AGENTS.md`, code-quality skill, scaffold-level MCP dev skill, and Copilot review instructions. Remaining runbooks: `mock-roast`, `hottop-validation`, and `release-registry`.
 - Validation run for E1-S2:
   - Parsed `pyproject.toml` with stdlib `tomllib` and confirmed package name plus console script target.
@@ -365,3 +366,12 @@ After completing a story:
   - Ran `/tmp/roastpilot-e1s4-venv/bin/python -m ruff check .`: passed.
   - Ran `/tmp/roastpilot-e1s4-venv/bin/python -m pyright --pythonpath /tmp/roastpilot-e1s4-venv/bin/python`: 0 errors.
   - PR #65 remains open and mergeable. GitHub issue #11 remains open until PR merge.
+- Validation run for E1-S5:
+  - Reviewed the documented commands against `pyproject.toml`, `AGENTS.md`, `README.md`, and `.claude/skills/mcp-dev`.
+  - Created a temporary virtualenv at `/tmp/roastpilot-e1s5-venv` and installed the package with dev dependencies.
+  - Ran `/tmp/roastpilot-e1s5-venv/bin/python -m pytest`: 17 passed.
+  - Ran `/tmp/roastpilot-e1s5-venv/bin/python -m ruff check .`: passed.
+  - Ran `/tmp/roastpilot-e1s5-venv/bin/python -m ruff format --check .`: passed.
+  - Ran `/tmp/roastpilot-e1s5-venv/bin/python -m pyright --pythonpath /tmp/roastpilot-e1s5-venv/bin/python`: 0 errors.
+  - Ran `/tmp/roastpilot-e1s5-venv/bin/coffee-roaster-mcp --help` and `--version`: passed.
+  - Ran the documented bootstrap smoke command and confirmed output `mock disabled int8`.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,8 +22,8 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E1-S4 is complete. RoastPilot now has typed configuration loading from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and documented environment overrides. First-crack mode defaults to `disabled`.
+E1-S5 is complete. RoastPilot now has one documented local development workflow across `README.md`, `AGENTS.md`, and the repo-local `mcp-dev` skill, including setup, lint, format check, typecheck, tests, CLI smoke, and a mock-safe bootstrap smoke command. The full stdio MCP server still starts in `E2-S1`.
 
-The next story is E1-S5: add local dev commands for lint, format check, typecheck, tests, and mock server run.
+The next story is E1-S6: add CI for tests and package build.
 
 The first implementation milestone remains a thin mock vertical slice: install the package, start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.


### PR DESCRIPTION
## Summary
- document one canonical local development workflow across `README.md`, `AGENTS.md`, and `.claude/skills/mcp-dev`
- add a mock-safe bootstrap smoke command that reflects current bootstrap reality until the stdio MCP server lands in `E2-S1`
- update local state files to mark `E1-S5` complete and move active context to `E1-S6`

## Why
Story `#12` requires exact repeatable commands for local development that match the project tooling in `pyproject.toml`. The repo already had pieces of this workflow, but they were split across surfaces and the story needed one consistent source of truth.

## Validation
- `pytest` in `/tmp/roastpilot-e1s5-venv`: 17 passed
- `ruff check .`
- `ruff format --check .`
- `pyright --pythonpath /tmp/roastpilot-e1s5-venv/bin/python`
- `coffee-roaster-mcp --help`
- `coffee-roaster-mcp --version`
- bootstrap smoke output: `mock disabled int8`

## Story
- closes #12
