### PR TITLE
[codex] Add pull request CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  checks:
+    name: Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . --group dev
+
+      - name: Run tests
+        run: python -m pytest
+
+      - name: Run lint
+        run: python -m ruff check .
+
+      - name: Run format check
+        run: python -m ruff format --check .
+
+      - name: Run typecheck
+        run: python -m pyright --pythonpath "${pythonLocation}/bin/python"
+
+      - name: Run CLI smoke checks
+        run: |
+          coffee-roaster-mcp --help
+          coffee-roaster-mcp --version
+
+  build-package:
+    name: Build Package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . --group dev
+
+      - name: Build distribution artifacts
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,7 @@ cython_debug/
 #   and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #   you could uncomment the following to ignore the entire vscode folder
 # .vscode/
+.vscode/
 # Temporary file for partial code execution
 tempCodeRunnerFile.py
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,11 @@ The stdio MCP server is not implemented until `E2-S1`. Use this command to verif
 python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
 ```
 
+## Repo-local Workflows
+
+- `.claude/skills/code-quality`: run before marking a story complete or opening a PR.
+- `.claude/skills/mcp-dev`: use for local setup and scaffold-level validation while the MCP runtime is still landing.
+
 ## Codebase Architecture
 
 ```text

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E1-S6`
-- Current target: GitHub Actions for lint, format check, typecheck, tests, and package build
+- Active story: `E1-S7`
+- Current target: Initial README and install/run documentation for local mock usage
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -77,7 +77,7 @@ Goal: create a usable standalone Python project with durable state, dev workflow
 - [x] `E1-S5` Add local dev commands.
   - Done when there are documented commands for lint, format check, typecheck, tests, and mock server run.
 
-- [ ] `E1-S6` Add CI for tests and package build.
+- [x] `E1-S6` Add CI for tests and package build.
   - Done when GitHub Actions runs checks and builds the package on pull requests.
 
 - [ ] `E1-S7` Add initial README and install/run documentation.
@@ -352,6 +352,7 @@ After completing a story:
 - E1-S3 added CLI help/version behavior and smoke coverage.
 - E1-S4 added typed config dataclasses, YAML loading, environment override precedence, config documentation, and focused tests. Copilot review hardening added whitespace/case normalization, empty log-dir validation, conventional runtime type checks, and cached config path existence checks.
 - E1-S5 added one documented local development workflow across `README.md`, `AGENTS.md`, and `.claude/skills/mcp-dev`. The documented commands now cover setup, tests, lint, format check, typecheck, CLI smoke, and a mock-safe bootstrap smoke path until the stdio MCP server lands in `E2-S1`.
+- E1-S6 added a GitHub Actions CI workflow for pull requests plus manual runs. CI now installs project dev dependencies, runs tests, lint, format check, typecheck, CLI smoke checks, and builds sdist plus wheel artifacts. Package build tooling is declared in `pyproject.toml`.
 - E1-S8 started early with `AGENTS.md`, code-quality skill, scaffold-level MCP dev skill, and Copilot review instructions. Remaining runbooks: `mock-roast`, `hottop-validation`, and `release-registry`.
 - Validation run for E1-S2:
   - Parsed `pyproject.toml` with stdlib `tomllib` and confirmed package name plus console script target.
@@ -375,3 +376,11 @@ After completing a story:
   - Ran `/tmp/roastpilot-e1s5-venv/bin/python -m pyright --pythonpath /tmp/roastpilot-e1s5-venv/bin/python`: 0 errors.
   - Ran `/tmp/roastpilot-e1s5-venv/bin/coffee-roaster-mcp --help` and `--version`: passed.
   - Ran the documented bootstrap smoke command and confirmed output `mock disabled int8`.
+- Validation run for E1-S6:
+  - Created a temporary virtualenv at `/tmp/roastpilot-e1s6-venv` and installed the package with dev dependencies.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m pytest`: 17 passed.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m ruff check .`: passed.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m ruff format --check .`: passed.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m pyright --pythonpath /tmp/roastpilot-e1s6-venv/bin/python`: 0 errors.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/coffee-roaster-mcp --help` and `--version`: passed.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m build`: passed when rerun with network access because isolated build environments must fetch `hatchling`.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,8 +22,8 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E1-S5 is complete. RoastPilot now has one documented local development workflow across `README.md`, `AGENTS.md`, and the repo-local `mcp-dev` skill, including setup, lint, format check, typecheck, tests, CLI smoke, and a mock-safe bootstrap smoke command. The full stdio MCP server still starts in `E2-S1`.
+E1-S6 is complete. RoastPilot now has a pull-request CI workflow that installs project dev dependencies, runs tests, lint, format check, typecheck, CLI smoke checks, and builds package artifacts. Package-build tooling is declared in `pyproject.toml` instead of being installed ad hoc in CI.
 
-The next story is E1-S6: add CI for tests and package build.
+The next story is E1-S7: add initial README and install/run documentation.
 
 The first implementation milestone remains a thin mock vertical slice: install the package, start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ coffee-roaster-mcp = "coffee_roaster_mcp.cli:main"
 
 [dependency-groups]
 dev = [
+  "build>=1.2",
   "pytest>=8.0",
   "ruff>=0.8",
   "pyright>=1.1",


### PR DESCRIPTION
## Summary
- add a pull-request CI workflow that installs project dev dependencies and runs tests, lint, format check, typecheck, and CLI smoke commands
- add a package-build job that runs `python -m build` and uploads distribution artifacts
- declare `build` in the dev dependency group and update local state files to mark `E1-S6` complete and move active context to `E1-S7`

## Why
Story `#13` requires automated pull-request checks and package builds. The repo already had one canonical local quality path, so CI should execute the same commands rather than introducing a separate workflow.

## Validation
- `pytest` in `/tmp/roastpilot-e1s6-venv`: 17 passed
- `ruff check .`
- `ruff format --check .`
- `pyright --pythonpath /tmp/roastpilot-e1s6-venv/bin/python`
- `coffee-roaster-mcp --help`
- `coffee-roaster-mcp --version`
- `python -m build`

## Story
- closes #13
