### PR TITLE
[codex] Expand README for local mock usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,33 @@ RoastPilot will provide one local MCP runtime for roaster control, telemetry, fi
 
 The project is currently in bootstrap. See `docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md` and `docs/state/registry.md` for the active plan and state.
 
+## What RoastPilot Is
+
+RoastPilot is the human-facing product name. `coffee-roaster-mcp` is the infrastructure and packaging name used for the repository, Python package, and future distribution.
+
+The v0.1 direction is one local stdio MCP server that will own:
+
+- roaster control
+- roast session timing and events
+- first-crack detection integration
+- derived roast metrics
+- roast log export
+
+The current repo state is still bootstrap. The package scaffold, config loading, local development commands, and pull-request CI are in place. The full MCP runtime and tool surface start in Epic 2.
+
+## Install
+
+For local development today:
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e . --group dev
+```
+
+The future user-facing install target is the `coffee-roaster-mcp` package. PyPI publication is planned later in v0.1 after the runtime and distribution stories land.
+
 ## Local Development
 
 ### Setup
@@ -50,6 +77,18 @@ coffee-roaster-mcp --help
 coffee-roaster-mcp --version
 ```
 
+## Local Mock Run
+
+The default local path is intentionally mock-safe:
+
+- default roaster driver: `mock`
+- default first-crack mode: `disabled`
+- no roaster hardware required
+- no microphone required
+- no model download required
+
+The full stdio MCP server and roast-session tool flow have not landed yet. Until `E2-S1` and later Epic 2 stories are implemented, the practical local mock run is a bootstrap validation flow rather than a real MCP session.
+
 ### Mock-Safe Bootstrap Smoke
 
 The full stdio MCP server lands in `E2-S1`. Until then, use this mock-safe bootstrap smoke to confirm the default local path stays hardware-free and model-free from a guaranteed-empty temporary directory:
@@ -63,6 +102,27 @@ Expected output:
 ```text
 mock disabled int8
 ```
+
+This confirms the bootstrap defaults are still aligned with the mock vertical-slice plan.
+
+## Hottop Configuration Placeholder
+
+Hottop support is planned behind the `RoasterDriver` abstraction. It is not ready for hardware use yet.
+
+When Hottop stories land, configuration will continue to live in `coffee-roaster-mcp.yaml`. The relevant roaster section already has the expected placeholder shape:
+
+```yaml
+roaster:
+  driver: mock
+  port: null
+  baudrate: 115200
+  temperature_unit: celsius
+  command_interval_seconds: 0.3
+```
+
+For future Hottop usage, the expected change is to switch `driver` away from `mock` and set the serial port explicitly. Until the Hottop driver and validation stories are complete, keep local development on the mock driver.
+
+Hardware safety matters here: Hottop command-loop behavior, packet handling, temperature units, drop behavior, cooling behavior, and emergency stop still require explicit implementation plus manual validation before hardware-ready use.
 
 ## Configuration
 
@@ -123,3 +183,38 @@ Supported environment overrides:
 - `HF_HOME`
 
 `HF_HOME` is consumed by Hugging Face tooling directly rather than copied into the RoastPilot config object.
+
+## Hugging Face Model Boundary
+
+This repository does not train, export, sync, or publish first-crack models.
+
+The `coffee-first-crack-detection` repository remains the source of truth for:
+
+- model training
+- ONNX export
+- Hugging Face artifact publishing
+- model cards
+- dataset cards
+
+RoastPilot only consumes released artifacts from `syamaner/coffee-first-crack-detection`. The runtime boundary for this repo is inference-time configuration and model selection, not model lifecycle management.
+
+Current first-crack defaults are kept safe for local development:
+
+- `mode: disabled`
+- `precision: int8`
+- `repo_id: syamaner/coffee-first-crack-detection`
+
+That default keeps local setup free from Hugging Face network access until first-crack runtime stories are implemented.
+
+## Log Export
+
+Roast log export is a planned v0.1 capability, not a completed runtime feature yet.
+
+The intended direction is:
+
+- append-only JSONL during roast
+- CSV export for analysis
+- `summary.json` for session-level metadata
+- output under `logs/roasts/{session_id}/`
+
+Those exports will be produced by the future MCP runtime once roast sessions, telemetry, and export flows are implemented in later epics. They are not available from the current bootstrap CLI yet.

--- a/README.md
+++ b/README.md
@@ -39,12 +39,7 @@ The future user-facing install target is the `coffee-roaster-mcp` package. PyPI 
 
 ### Setup
 
-```bash
-python3.11 -m venv .venv
-source .venv/bin/activate
-python -m pip install --upgrade pip
-python -m pip install -e . --group dev
-```
+Use the commands in the [Install](#install) section, then continue with the checks below.
 
 ### Test
 

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E1-S7`
-- Current target: Initial README and install/run documentation for local mock usage
+- Active story: `E1-S8`
+- Current target: Remaining repo-local workflows for mock-roast, hottop-validation, and release-registry
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -80,7 +80,7 @@ Goal: create a usable standalone Python project with durable state, dev workflow
 - [x] `E1-S6` Add CI for tests and package build.
   - Done when GitHub Actions runs checks and builds the package on pull requests.
 
-- [ ] `E1-S7` Add initial README and install/run documentation.
+- [x] `E1-S7` Add initial README and install/run documentation.
   - Done when README explains RoastPilot, local mock run, Hottop config placeholder, Hugging Face model boundary, and log export.
 
 - [~] `E1-S8` Add repo-local skills or runbooks.
@@ -353,6 +353,7 @@ After completing a story:
 - E1-S4 added typed config dataclasses, YAML loading, environment override precedence, config documentation, and focused tests. Copilot review hardening added whitespace/case normalization, empty log-dir validation, conventional runtime type checks, and cached config path existence checks.
 - E1-S5 added one documented local development workflow across `README.md`, `AGENTS.md`, and `.claude/skills/mcp-dev`. The documented commands now cover setup, tests, lint, format check, typecheck, CLI smoke, and a mock-safe bootstrap smoke path until the stdio MCP server lands in `E2-S1`.
 - E1-S6 added a GitHub Actions CI workflow for pull requests plus manual runs. CI now installs project dev dependencies, runs tests, lint, format check, typecheck, CLI smoke checks, and builds sdist plus wheel artifacts. Package build tooling is declared in `pyproject.toml`.
+- E1-S7 expanded the initial README into a real install and usage entrypoint. It now explains RoastPilot versus `coffee-roaster-mcp`, the local mock path, the current Hottop placeholder, the Hugging Face model boundary, and the planned log-export behavior without claiming unfinished runtime features.
 - E1-S8 started early with `AGENTS.md`, code-quality skill, scaffold-level MCP dev skill, and Copilot review instructions. Remaining runbooks: `mock-roast`, `hottop-validation`, and `release-registry`.
 - Validation run for E1-S2:
   - Parsed `pyproject.toml` with stdlib `tomllib` and confirmed package name plus console script target.
@@ -384,3 +385,9 @@ After completing a story:
   - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m pyright --pythonpath /tmp/roastpilot-e1s6-venv/bin/python`: 0 errors.
   - Ran `/tmp/roastpilot-e1s6-venv/bin/coffee-roaster-mcp --help` and `--version`: passed.
   - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m build`: passed when rerun with network access because isolated build environments must fetch `hatchling`.
+- Validation run for E1-S7:
+  - Reviewed `README.md` against the story acceptance criteria for product naming, local mock run, Hottop placeholder, Hugging Face model boundary, and log export coverage.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m pytest`: 17 passed.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m ruff check .`: passed.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m pyright --pythonpath /tmp/roastpilot-e1s6-venv/bin/python`: 0 errors.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/coffee-roaster-mcp --help` and `--version`: passed.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,8 +22,8 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E1-S6 is complete. RoastPilot now has a pull-request CI workflow that installs project dev dependencies, runs tests, lint, format check, typecheck, CLI smoke checks, and builds package artifacts. Package-build tooling is declared in `pyproject.toml` instead of being installed ad hoc in CI.
+E1-S7 is complete. RoastPilot now has an initial README that explains the product/package naming, local mock usage, Hottop configuration placeholder, Hugging Face model boundary, and the current planned state of roast log export without overstating unimplemented runtime features.
 
-The next story is E1-S7: add initial README and install/run documentation.
+The next story is E1-S8: add the remaining repo-local skills or runbooks.
 
 The first implementation milestone remains a thin mock vertical slice: install the package, start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.


### PR DESCRIPTION
## Summary
- expand `README.md` into the initial install and usage entrypoint for RoastPilot
- document the local mock run path, Hottop configuration placeholder, Hugging Face model boundary, and planned log-export behavior without claiming unfinished runtime features
- update local state files to mark `E1-S7` complete and move active context to `E1-S8`

## Why
Story `#14` requires the README to explain RoastPilot and `coffee-roaster-mcp`, local mock usage, the Hottop placeholder, the Hugging Face model boundary, and log export. The earlier README had setup and config details, but it was still too bootstrap-oriented to serve as the initial install/run entrypoint.

## Validation
- README reviewed against issue acceptance criteria
- `pytest` in `/tmp/roastpilot-e1s6-venv`: 17 passed
- `ruff check .`
- `pyright --pythonpath /tmp/roastpilot-e1s6-venv/bin/python`
- `coffee-roaster-mcp --help`
- `coffee-roaster-mcp --version`

## Story
- closes #14
