### PR TITLE
[codex] Add repo-local workflow runbooks

### DIFF
--- a/.claude/skills/hottop-validation/SKILL.md
+++ b/.claude/skills/hottop-validation/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: hottop-validation
+description: Review the guarded manual validation path for Hottop hardware work. Use when planning or verifying hardware-facing changes without overstating what the repo can currently run.
+---
+
+# Hottop Validation - RoastPilot
+
+Use this skill for Hottop-facing work and release-readiness review.
+
+## Current Scope
+
+- Hottop hardware support is not implemented yet.
+- This workflow is a safety-first validation checklist, not a runnable hardware procedure.
+- Hardware stories are not complete from mock tests alone.
+
+## Pre-Validation Gates
+
+Before any Hottop hardware session:
+
+- Confirm the relevant Hottop implementation stories are complete.
+- Confirm unit and integration coverage exists for the touched behavior.
+- Confirm current defaults still fail closed when behavior is uncertain.
+- Confirm the active operator understands emergency stop and cooling expectations.
+
+Do not proceed on hardware if any of these remain unclear:
+
+- command-loop cadence
+- packet format or checksum behavior
+- temperature unit interpretation
+- drop behavior
+- cooling behavior
+- emergency stop behavior
+
+## Manual Validation Checklist
+
+Use this checklist once the Hottop driver exists:
+
+1. Verify connection and disconnect lifecycle do not leave command loops running.
+2. Verify startup state is conservative: heat off, expected fan state, no unintended cooling or drop action.
+3. Verify packet parsing against known-good captures and implausible input cases.
+4. Verify temperature readings are plausible and unit handling matches the configured mode.
+5. Verify heat and fan changes respect supported ranges and safe defaults.
+6. Verify drop behavior matches the intended compound action.
+7. Verify cooling start and cooling stop leave the roaster in the expected state.
+8. Verify emergency stop turns heat off, records a fault or stop event, and preserves enough state for diagnosis.
+9. Record the exact roaster model, serial settings, observed temperatures, and any deviations from expected behavior.
+
+## Required Notes
+
+For every manual validation run, record:
+
+- roaster model and firmware context if known
+- serial port and configured temperature unit
+- what commands were exercised
+- whether heat, fan, drop, cooling, and emergency stop behaved as expected
+- any uncertainty that keeps the hardware path from being release-ready
+
+## Do Not
+
+- Do not mark Hottop stories complete from mock-only validation.
+- Do not improvise control commands against real hardware.
+- Do not add training, ONNX export, or Hugging Face sync steps here. Those stay in `coffee-first-crack-detection`.

--- a/.claude/skills/mock-roast/SKILL.md
+++ b/.claude/skills/mock-roast/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: mock-roast
+description: Validate the current mock-first RoastPilot path without roaster hardware or model download. Use when checking bootstrap defaults now, and extend it later when the MCP runtime lands.
+---
+
+# Mock Roast - RoastPilot
+
+Use this skill for the mock-first local workflow.
+
+## Current Scope
+
+- The stdio MCP server is not implemented until `E2-S1`.
+- A full mock roast through MCP tools is not implemented until later runtime stories.
+- This workflow validates the current mock-safe bootstrap path without claiming a real roast session exists yet.
+
+## Current Validation
+
+Run from the repository root:
+
+```bash
+python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
+coffee-roaster-mcp --help
+coffee-roaster-mcp --version
+```
+
+Expected bootstrap output:
+
+```text
+mock disabled int8
+```
+
+## What This Confirms
+
+- The default roaster driver stays on `mock`.
+- First-crack detection stays `disabled` by default.
+- Default precision stays `int8`.
+- Local bootstrap does not require roaster hardware, microphone access, or model download.
+
+## Do Not Claim Yet
+
+- Do not claim a working stdio MCP server before `E2-S1`.
+- Do not claim a start-to-export mock roast before `E2-S7` and `E7-S1`.
+- Do not add model download, model export, or Hugging Face sync steps here. Those stay in `coffee-first-crack-detection`.
+
+## Extend Later
+
+Once the MCP runtime exists, extend this workflow with:
+
+- local stdio MCP server startup
+- mock roast session start
+- state polling
+- manual first-crack injection if needed
+- roast log export smoke checks

--- a/.claude/skills/release-registry/SKILL.md
+++ b/.claude/skills/release-registry/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: release-registry
+description: Review the staged PyPI and MCP Registry release workflow for RoastPilot. Use when preparing distribution work and keep current prereqs explicit until release stories land.
+---
+
+# Release Registry - RoastPilot
+
+Use this skill for package and registry release preparation.
+
+## Current Scope
+
+- This is a staged runbook for future release work.
+- `server.json`, registry publishing automation, and full release verification land in later Epic 6 stories.
+- Do not present this workflow as fully runnable until those stories are complete.
+
+## Release Targets
+
+- Package name: `coffee-roaster-mcp`
+- MCP Registry name: `io.github.syamaner/coffee-roaster-mcp`
+- Display title: `RoastPilot`
+
+## Planned Release Flow
+
+1. Confirm the package version is intentional.
+2. Build and validate sdist plus wheel artifacts.
+3. Confirm README contains the MCP verification string when the release story adds it.
+4. Confirm `server.json` exists and matches the package version when the registry metadata story lands.
+5. Publish the package to PyPI.
+6. Install the published package in a clean environment.
+7. Run mock-safe smoke checks against the published package.
+8. Publish MCP Registry metadata.
+9. Verify the registry listing renders the expected package and install metadata.
+
+## Current Review Checklist
+
+Until Epic 6 lands, use this skill to review readiness only:
+
+- package name is still `coffee-roaster-mcp`
+- registry name is still `io.github.syamaner/coffee-roaster-mcp`
+- release docs do not imply hardware-ready support without Hottop validation
+- default first-crack mode remains `disabled` so package install smoke does not require audio or model download
+- version alignment across package metadata, tags, and future `server.json` remains part of the release plan
+
+## Mock-Safe Published Smoke Target
+
+When published package verification becomes available, the minimum smoke target remains:
+
+```bash
+coffee-roaster-mcp --help
+coffee-roaster-mcp --version
+python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
+```
+
+Expected bootstrap output:
+
+```text
+mock disabled int8
+```
+
+## Do Not
+
+- Do not add Hugging Face model sync, model export, model cards, or dataset cards to this release workflow.
+- Do not claim MCP Registry publishing is verified before `server.json`, PyPI verification, and `mcp-publisher` stories are complete.
+- Do not label a release hardware-ready before the Hottop manual validation path passes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,9 @@ python -c "import os, tempfile; from coffee_roaster_mcp.config import load_confi
 
 - `.claude/skills/code-quality`: run before marking a story complete or opening a PR.
 - `.claude/skills/mcp-dev`: use for local setup and scaffold-level validation while the MCP runtime is still landing.
+- `.claude/skills/mock-roast`: use for the current mock-safe bootstrap path and later extend it to real mock roast MCP checks.
+- `.claude/skills/hottop-validation`: use for guarded manual Hottop validation planning and release-readiness review.
+- `.claude/skills/release-registry`: use for staged PyPI and MCP Registry release preparation without implying unimplemented release automation exists.
 
 ## Codebase Architecture
 

--- a/docs/session-summaries/2026-05-03-e1-s5-through-e1-s7-and-e1-s8-prep.md
+++ b/docs/session-summaries/2026-05-03-e1-s5-through-e1-s7-and-e1-s8-prep.md
@@ -1,4 +1,4 @@
-# Session Summary: E1-S5 Through E1-S7 And E1-S8 Prep
+# Session Summary: E1-S5 Through E1-S8
 
 Date: 2026-05-03
 
@@ -15,8 +15,8 @@ The main outcomes were:
 - complete `E1-S5` local development commands
 - complete `E1-S6` pull-request CI and package build automation
 - complete `E1-S7` initial README and install/run documentation
-- sync durable state so `E1-S8` is now the next active story
-- prepare a clean branch for the remaining repo-local workflow/runbook story
+- complete `E1-S8` repo-local workflow and runbook coverage
+- sync durable state so `E2-S1` is now the next active story
 
 This file is intended to preserve enough context for compaction without requiring the full conversational history.
 
@@ -154,6 +154,33 @@ Durable state after completion:
 - `E1-S7` complete
 - `E1-S8` next
 
+### E1-S8: Add repo-local skills or runbooks
+
+Issue: `#15`
+
+PR: `#69`
+
+Branch used: `feature/15-add-repo-local-skills-or-runbooks`
+
+What landed:
+
+- Added `.claude/skills/mock-roast/SKILL.md` for the current mock-safe bootstrap path
+- Added `.claude/skills/hottop-validation/SKILL.md` as a guarded manual hardware validation checklist
+- Added `.claude/skills/release-registry/SKILL.md` as a staged PyPI and MCP Registry release runbook
+- Updated `AGENTS.md` so agents are pointed at the full repo-local workflow set
+- Updated durable state so the active story advanced from `E1-S8` to `E2-S1`
+- Kept model training, ONNX export, and Hugging Face sync explicitly out of this repo
+
+Review follow-up:
+
+- Copilot flagged that this handoff file had gone stale relative to the rest of the PR because it still described `E1-S8` as upcoming work.
+- Fixed by updating the summary to record `E1-S8` as complete and point future sessions at `E2-S1`.
+
+Durable state after completion:
+
+- `E1-S8` complete
+- `E2-S1` next
+
 ## Validation Summary Across The Completed Stories
 
 Reusable validation environment:
@@ -174,6 +201,7 @@ Additional notable validations:
 - E1-S5 bootstrap smoke output: `mock disabled int8`
 - E1-S6 package build: `python -m build` succeeded when rerun with network access
 - E1-S7 README reviewed against story acceptance criteria
+- E1-S8 bootstrap smoke output: `mock disabled int8`
 
 ## Durable State Progression
 
@@ -182,38 +210,32 @@ State progression across this chat:
 1. `E1-S5` completed
 2. `E1-S6` completed
 3. `E1-S7` completed
-4. Active story advanced to `E1-S8`
+4. `E1-S8` completed
+5. Active story advanced to `E2-S1`
 
 Current intended next story:
 
-- `E1-S8` / issue `#15`
-- Remaining repo-local workflows:
-  - `mock-roast`
-  - `hottop-validation`
-  - `release-registry`
+- `E2-S1` / issue `#16`
+- Implement the stdio MCP server entrypoint and expose a minimal tool list
 
-Current branch prepared for that work:
+Current branch at summary close:
 
 - `feature/15-add-repo-local-skills-or-runbooks`
 
-## Current E1-S8 Context
+## Current Resume Context
 
-What already exists locally:
+Repo-local workflows now present:
 
 - `.claude/skills/code-quality/SKILL.md`
 - `.claude/skills/mcp-dev/SKILL.md`
-
-What remains to add:
-
 - `.claude/skills/mock-roast/SKILL.md`
 - `.claude/skills/hottop-validation/SKILL.md`
 - `.claude/skills/release-registry/SKILL.md`
 
-Current readiness assessment:
+Next implementation target:
 
-- `mock-roast`: enough context to write a real current-state workflow now
-- `hottop-validation`: enough context for a safety-first guarded checklist, not a fake fully-operational procedure
-- `release-registry`: enough context for a staged runbook with explicit prereqs and not-yet-implemented gates
+- `E2-S1` should add the first stdio MCP server entrypoint
+- The new runbooks should remain honest about current bootstrap limits until runtime stories land
 
 ## GitHub Workflow Notes
 
@@ -222,6 +244,7 @@ PRs opened and merged in this chat sequence:
 - `#66` for `E1-S5`
 - `#67` for `E1-S6`
 - `#68` for `E1-S7`
+- `#69` for `E1-S8`
 
 Issue comments were posted for each completed story before PR creation.
 
@@ -235,18 +258,19 @@ Notable operational detail:
 If context needs to be compacted, preserve these facts first:
 
 1. `E1-S5`, `E1-S6`, and `E1-S7` were all completed in this chat.
-2. Durable state now points to `E1-S8` as the active story.
-3. The repo already has two repo-local skills:
+2. `E1-S8` was also completed in this chat.
+3. Durable state now points to `E2-S1` as the active story.
+4. The repo now has the full bootstrap repo-local workflow set:
    - `code-quality`
    - `mcp-dev`
-4. The next concrete work is to add:
    - `mock-roast`
    - `hottop-validation`
    - `release-registry`
-5. The repo boundary remains strict:
+5. The next concrete work is the stdio MCP server entrypoint, not more runbook scaffolding.
+6. The repo boundary remains strict:
    - no model training/export/HF sync in this repo
    - consume released artifacts only
-6. The default local path remains:
+7. The default local path remains:
    - roaster driver `mock`
    - first-crack mode `disabled`
 
@@ -258,4 +282,7 @@ If context needs to be compacted, preserve these facts first:
 - `AGENTS.md`
 - `.claude/skills/code-quality/SKILL.md`
 - `.claude/skills/mcp-dev/SKILL.md`
+- `.claude/skills/mock-roast/SKILL.md`
+- `.claude/skills/hottop-validation/SKILL.md`
+- `.claude/skills/release-registry/SKILL.md`
 - `README.md`

--- a/docs/session-summaries/2026-05-03-e1-s5-through-e1-s7-and-e1-s8-prep.md
+++ b/docs/session-summaries/2026-05-03-e1-s5-through-e1-s7-and-e1-s8-prep.md
@@ -1,0 +1,261 @@
+# Session Summary: E1-S5 Through E1-S7 And E1-S8 Prep
+
+Date: 2026-05-03
+
+Repository: `syamaner/coffee-roaster-mcp`
+
+Branch at summary time: `feature/15-add-repo-local-skills-or-runbooks`
+
+## Purpose
+
+This summary captures the work completed after the earlier E1-S4 summary in the same broad rollout sequence.
+
+The main outcomes were:
+
+- complete `E1-S5` local development commands
+- complete `E1-S6` pull-request CI and package build automation
+- complete `E1-S7` initial README and install/run documentation
+- sync durable state so `E1-S8` is now the next active story
+- prepare a clean branch for the remaining repo-local workflow/runbook story
+
+This file is intended to preserve enough context for compaction without requiring the full conversational history.
+
+## Non-PII Codex Status Snapshot (User-Provided Source Of Truth)
+
+Snapshot received from the active Codex UI (PII removed):
+
+- Model: `gpt-5.4`
+- Reasoning: `medium`
+- Summaries: `auto`
+- Directory: `~/git/coffee-roaster-mcp`
+- Permissions: `Workspace (on-request)`
+- `AGENTS.md` loaded in this session: `AGENTS.md`
+- Thread name: `coffee roaster mcp`
+- Collaboration mode: `Default`
+- Context window: `38% left (164K used / 258K)`
+- 5h limit: `97% left` (reset shown as `01:43 on 4 May`)
+- Weekly limit: `99% left` (reset shown as `20:43 on 10 May`)
+- GPT-5.3-Codex-Spark 5h limit: `100% left` (reset shown as `03:58 on 4 May`)
+- GPT-5.3-Codex-Spark weekly limit: `100% left` (reset shown as `22:58 on 10 May`)
+
+Fields intentionally excluded:
+
+- Account identity
+- Session ID
+
+Most important note for future compaction: this chat covered multiple completed stories, not just one.
+
+## Stories Completed In This Chat
+
+### E1-S5: Add local dev commands
+
+Issue: `#12`
+
+PR: `#66`
+
+Branch used: `feature/12-add-local-dev-commands`
+
+What landed:
+
+- Added one canonical local development command set across:
+  - `README.md`
+  - `AGENTS.md`
+  - `.claude/skills/mcp-dev/SKILL.md`
+- Documented:
+  - setup
+  - tests
+  - lint
+  - format check
+  - typecheck
+  - CLI smoke
+  - mock-safe bootstrap smoke
+- Clarified that the real stdio MCP server is still an Epic 2 deliverable.
+
+Review follow-up:
+
+- Copilot flagged that the bootstrap smoke was not deterministic because `load_config()` would still read `coffee-roaster-mcp.yaml` from the working directory if present.
+- Fixed by running the smoke command from a guaranteed-empty temporary directory in:
+  - `README.md`
+  - `AGENTS.md`
+  - `.claude/skills/mcp-dev/SKILL.md`
+
+Durable state after completion:
+
+- `E1-S5` complete
+- `E1-S6` next
+
+### E1-S6: Add CI for tests and package build
+
+Issue: `#13`
+
+PR: `#67`
+
+Branch used: `feature/13-add-ci-for-tests-and-package-build`
+
+What landed:
+
+- Added `.github/workflows/ci.yml`
+- CI runs on:
+  - `pull_request`
+  - `workflow_dispatch`
+- Checks job runs:
+  - `pytest`
+  - `ruff check .`
+  - `ruff format --check .`
+  - `pyright`
+  - `coffee-roaster-mcp --help`
+  - `coffee-roaster-mcp --version`
+- Package build job runs:
+  - `python -m build`
+  - uploads `dist/` artifacts
+- Added `build>=1.2` to the dev dependency group in `pyproject.toml`
+- Added `.vscode/` to `.gitignore`
+- Added a short `AGENTS.md` pointer section for repo-local workflows:
+  - `.claude/skills/code-quality`
+  - `.claude/skills/mcp-dev`
+
+Important build note:
+
+- Local `python -m build` initially failed inside the sandbox because isolated build environments needed network access to fetch `hatchling`.
+- The build passed when rerun with network access, which matched the real CI expectation.
+
+Durable state after completion:
+
+- `E1-S6` complete
+- `E1-S7` next
+
+### E1-S7: Add initial README and install/run documentation
+
+Issue: `#14`
+
+PR: `#68`
+
+Branch used: `feature/14-add-initial-readme-and-install-run-documentation`
+
+What landed:
+
+- Expanded `README.md` into the initial install/run entrypoint
+- Added:
+  - product/package naming explanation
+  - install guidance
+  - local mock run section
+  - Hottop configuration placeholder
+  - Hugging Face model boundary
+  - planned log-export behavior
+- Kept documentation honest about unimplemented runtime features
+
+Review follow-up:
+
+- Copilot flagged duplicated install commands between `Install` and `Local Development -> Setup`.
+- Fixed by keeping `Install` as the source of truth and turning `Setup` into a pointer.
+
+Durable state after completion:
+
+- `E1-S7` complete
+- `E1-S8` next
+
+## Validation Summary Across The Completed Stories
+
+Reusable validation environment:
+
+- `/tmp/roastpilot-e1s5-venv`
+- `/tmp/roastpilot-e1s6-venv`
+
+Checks repeatedly confirmed during this chat:
+
+- `pytest`: `17 passed`
+- `ruff check .`: passed
+- `pyright --pythonpath /tmp/.../bin/python`: `0 errors`
+- `coffee-roaster-mcp --help`: passed
+- `coffee-roaster-mcp --version`: passed
+
+Additional notable validations:
+
+- E1-S5 bootstrap smoke output: `mock disabled int8`
+- E1-S6 package build: `python -m build` succeeded when rerun with network access
+- E1-S7 README reviewed against story acceptance criteria
+
+## Durable State Progression
+
+State progression across this chat:
+
+1. `E1-S5` completed
+2. `E1-S6` completed
+3. `E1-S7` completed
+4. Active story advanced to `E1-S8`
+
+Current intended next story:
+
+- `E1-S8` / issue `#15`
+- Remaining repo-local workflows:
+  - `mock-roast`
+  - `hottop-validation`
+  - `release-registry`
+
+Current branch prepared for that work:
+
+- `feature/15-add-repo-local-skills-or-runbooks`
+
+## Current E1-S8 Context
+
+What already exists locally:
+
+- `.claude/skills/code-quality/SKILL.md`
+- `.claude/skills/mcp-dev/SKILL.md`
+
+What remains to add:
+
+- `.claude/skills/mock-roast/SKILL.md`
+- `.claude/skills/hottop-validation/SKILL.md`
+- `.claude/skills/release-registry/SKILL.md`
+
+Current readiness assessment:
+
+- `mock-roast`: enough context to write a real current-state workflow now
+- `hottop-validation`: enough context for a safety-first guarded checklist, not a fake fully-operational procedure
+- `release-registry`: enough context for a staged runbook with explicit prereqs and not-yet-implemented gates
+
+## GitHub Workflow Notes
+
+PRs opened and merged in this chat sequence:
+
+- `#66` for `E1-S5`
+- `#67` for `E1-S6`
+- `#68` for `E1-S7`
+
+Issue comments were posted for each completed story before PR creation.
+
+Notable operational detail:
+
+- GitHub app write permissions were insufficient for some comment/PR actions, so `gh` CLI with authenticated access was used where needed.
+- Interactive `gh auth login` had to be completed in-session using the browser/device flow.
+
+## Practical Notes For Context Compaction
+
+If context needs to be compacted, preserve these facts first:
+
+1. `E1-S5`, `E1-S6`, and `E1-S7` were all completed in this chat.
+2. Durable state now points to `E1-S8` as the active story.
+3. The repo already has two repo-local skills:
+   - `code-quality`
+   - `mcp-dev`
+4. The next concrete work is to add:
+   - `mock-roast`
+   - `hottop-validation`
+   - `release-registry`
+5. The repo boundary remains strict:
+   - no model training/export/HF sync in this repo
+   - consume released artifacts only
+6. The default local path remains:
+   - roaster driver `mock`
+   - first-crack mode `disabled`
+
+## Files Most Relevant To Resume Work
+
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+- `docs/state/github-issues.md`
+- `AGENTS.md`
+- `.claude/skills/code-quality/SKILL.md`
+- `.claude/skills/mcp-dev/SKILL.md`
+- `README.md`

--- a/docs/session-summaries/2026-05-03-e1-s5-through-e1-s7-and-e1-s8-prep.md
+++ b/docs/session-summaries/2026-05-03-e1-s5-through-e1-s7-and-e1-s8-prep.md
@@ -22,7 +22,7 @@ This file is intended to preserve enough context for compaction without requirin
 
 ## Non-PII Codex Status Snapshot (User-Provided Source Of Truth)
 
-Snapshot received from the active Codex UI (PII removed):
+Snapshot received from the active Codex UI:
 
 - Model: `gpt-5.4`
 - Reasoning: `medium`
@@ -37,6 +37,23 @@ Snapshot received from the active Codex UI (PII removed):
 - Weekly limit: `99% left` (reset shown as `20:43 on 10 May`)
 - GPT-5.3-Codex-Spark 5h limit: `100% left` (reset shown as `03:58 on 4 May`)
 - GPT-5.3-Codex-Spark weekly limit: `100% left` (reset shown as `22:58 on 10 May`)
+
+Later snapshot received from the active Codex UI after compaction and Epic 1 completion work:
+
+- Model: `gpt-5.4`
+- Reasoning: `medium`
+- Summaries: `auto`
+- Directory: `~/git/coffee-roaster-mcp`
+- Permissions: `Workspace (on-request)`
+- `AGENTS.md` loaded in this session: `AGENTS.md`
+- Thread name: `coffee roaster mcp`
+- Collaboration mode: `Default`
+- Context window: `67% left (93.9K used / 258K)`
+- 5h limit: `96% left` (reset shown as `01:43 on 4 May`)
+- Weekly limit: `99% left` (reset shown as `20:43 on 10 May`)
+- GPT-5.3-Codex-Spark 5h limit: `100% left` (reset shown as `04:05 on 4 May`)
+- GPT-5.3-Codex-Spark weekly limit: `100% left` (reset shown as `23:05 on 10 May`)
+- Warning: limits may be stale; run `/status` again shortly
 
 Fields intentionally excluded:
 

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E1-S8`
-- Current target: Remaining repo-local workflows for mock-roast, hottop-validation, and release-registry
+- Active story: `E2-S1`
+- Current target: Implement the stdio MCP server entrypoint and expose a minimal tool list
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -37,7 +37,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - This repo consumes released Hugging Face artifacts only.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
-- Agent rules and code-quality runbooks are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, and Copilot review instructions should be kept current as story workflow changes.
+- Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 
 ## Current Risks
 
@@ -83,7 +83,7 @@ Goal: create a usable standalone Python project with durable state, dev workflow
 - [x] `E1-S7` Add initial README and install/run documentation.
   - Done when README explains RoastPilot, local mock run, Hottop config placeholder, Hugging Face model boundary, and log export.
 
-- [~] `E1-S8` Add repo-local skills or runbooks.
+- [x] `E1-S8` Add repo-local skills or runbooks.
   - Done when `mcp-dev`, `mock-roast`, `hottop-validation`, and `release-registry` workflows exist as repo-local docs or skills.
 
 ### Epic Acceptance Criteria
@@ -354,7 +354,17 @@ After completing a story:
 - E1-S5 added one documented local development workflow across `README.md`, `AGENTS.md`, and `.claude/skills/mcp-dev`. The documented commands now cover setup, tests, lint, format check, typecheck, CLI smoke, and a mock-safe bootstrap smoke path until the stdio MCP server lands in `E2-S1`.
 - E1-S6 added a GitHub Actions CI workflow for pull requests plus manual runs. CI now installs project dev dependencies, runs tests, lint, format check, typecheck, CLI smoke checks, and builds sdist plus wheel artifacts. Package build tooling is declared in `pyproject.toml`.
 - E1-S7 expanded the initial README into a real install and usage entrypoint. It now explains RoastPilot versus `coffee-roaster-mcp`, the local mock path, the current Hottop placeholder, the Hugging Face model boundary, and the planned log-export behavior without claiming unfinished runtime features.
-- E1-S8 started early with `AGENTS.md`, code-quality skill, scaffold-level MCP dev skill, and Copilot review instructions. Remaining runbooks: `mock-roast`, `hottop-validation`, and `release-registry`.
+- E1-S8 completed the repo-local workflow set. The repo now has skills for code quality, scaffold-level MCP setup, mock roast bootstrap validation, guarded Hottop validation, and staged registry release preparation. Those runbooks explicitly keep model training, ONNX export, and Hugging Face sync out of this repo.
+- Validation run for E1-S8:
+  - Reviewed issue #15 acceptance criteria against `AGENTS.md`, the active epic, and the overall plan.
+  - Added `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, and `.claude/skills/release-registry` using the existing repo-local skill format.
+  - Confirmed the new runbooks keep model training, ONNX export, and Hugging Face sync in `coffee-first-crack-detection`.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m pytest`: 17 passed.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m ruff check .`: passed.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m ruff format --check .`: passed.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m pyright --pythonpath /tmp/roastpilot-e1s6-venv/bin/python`: 0 errors.
+  - Ran `/tmp/roastpilot-e1s6-venv/bin/coffee-roaster-mcp --help` and `--version`: passed.
+  - Ran the mock-safe bootstrap smoke command and confirmed output `mock disabled int8`.
 - Validation run for E1-S2:
   - Parsed `pyproject.toml` with stdlib `tomllib` and confirmed package name plus console script target.
   - Ran `PYTHONPATH=src` package import and CLI parser smoke check successfully.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,8 +22,8 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E1-S7 is complete. RoastPilot now has an initial README that explains the product/package naming, local mock usage, Hottop configuration placeholder, Hugging Face model boundary, and the current planned state of roast log export without overstating unimplemented runtime features.
+E1-S8 is complete. RoastPilot now has repo-local workflow docs for code quality, scaffold-level MCP development, mock roast bootstrap validation, guarded Hottop hardware validation, and staged PyPI plus MCP Registry release preparation.
 
-The next story is E1-S8: add the remaining repo-local skills or runbooks.
+The next story is E2-S1: implement the stdio MCP server entrypoint.
 
 The first implementation milestone remains a thin mock vertical slice: install the package, start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.


### PR DESCRIPTION
## Summary
- add repo-local workflows for \, \, and \
- update \ to point agents at the full workflow set
- update durable state to mark \ complete and move active context to \
- add a session summary handoff file covering the recent multi-story rollout

## Why
Story \ requires the remaining repo-local runbooks so agents do not improvise commands. The new workflows keep the current bootstrap state honest, preserve the Hottop safety boundary, and keep model training, ONNX export, and Hugging Face sync explicitly out of this repository.

## Validation
- \.................                                                        [100%]
17 passed in 0.02s
- \All checks passed!
- \5 files already formatted
- \0 errors, 0 warnings, 0 informations
- \usage: coffee-roaster-mcp [-h] [--version]

RoastPilot: a spec-driven MCP server for autonomous coffee roasting.

options:
  -h, --help  show this help message and exit
  --version   show program's version number and exit
- \coffee-roaster-mcp 0.1.0
- mock-safe bootstrap smoke output: \

## Story
- closes #15