### PR TITLE
[codex] Add stdio MCP server entrypoint

### DIFF
--- a/.claude/skills/mcp-dev/SKILL.md
+++ b/.claude/skills/mcp-dev/SKILL.md
@@ -25,11 +25,12 @@ python -m ruff format --check .
 python -m pyright
 coffee-roaster-mcp --help
 coffee-roaster-mcp --version
+coffee-roaster-mcp serve
 ```
 
 ## Mock-Safe Bootstrap Smoke
 
-The stdio MCP server is not implemented until `E2-S1`. For bootstrap work, confirm the default config still requires no roaster hardware, no microphone, and no model download from a guaranteed-empty temporary directory:
+For bootstrap work, confirm the default config still requires no roaster hardware, no microphone, and no model download from a guaranteed-empty temporary directory:
 
 ```bash
 python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
@@ -43,5 +44,5 @@ mock disabled int8
 
 ## Notes
 
-- The full MCP server and mock roast flow are not implemented yet.
-- Once E2 stories land, extend this skill with mock MCP server startup and basic tool-call smoke tests.
+- `E2-S1` adds the first stdio MCP server entrypoint with bootstrap-safe introspection tools only.
+- The full mock roast flow is still pending later Epic 2 stories.

--- a/.claude/skills/mock-roast/SKILL.md
+++ b/.claude/skills/mock-roast/SKILL.md
@@ -9,7 +9,7 @@ Use this skill for the mock-first local workflow.
 
 ## Current Scope
 
-- The stdio MCP server is not implemented until `E2-S1`.
+- `E2-S1` provides a real stdio MCP server entrypoint.
 - A full mock roast through MCP tools is not implemented until later runtime stories.
 - This workflow validates the current mock-safe bootstrap path without claiming a real roast session exists yet.
 
@@ -21,6 +21,7 @@ Run from the repository root:
 python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
 coffee-roaster-mcp --help
 coffee-roaster-mcp --version
+coffee-roaster-mcp serve
 ```
 
 Expected bootstrap output:
@@ -38,7 +39,6 @@ mock disabled int8
 
 ## Do Not Claim Yet
 
-- Do not claim a working stdio MCP server before `E2-S1`.
 - Do not claim a start-to-export mock roast before `E2-S7` and `E7-S1`.
 - Do not add model download, model export, or Hugging Face sync steps here. Those stay in `coffee-first-crack-detection`.
 
@@ -46,7 +46,6 @@ mock disabled int8
 
 Once the MCP runtime exists, extend this workflow with:
 
-- local stdio MCP server startup
 - mock roast session start
 - state polling
 - manual first-crack injection if needed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ coffee-roaster-mcp --version
 
 ### Mock-Safe Bootstrap Smoke
 
-The stdio MCP server is not implemented until `E2-S1`. Use this command to verify the default local path stays on the mock driver with first-crack detection disabled from a guaranteed-empty temporary directory:
+`E2-S1` now provides `coffee-roaster-mcp serve` with a minimal bootstrap-safe tool list. Use this command to verify the default local path stays on the mock driver with first-crack detection disabled from a guaranteed-empty temporary directory:
 
 ```bash
 python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
@@ -64,8 +64,8 @@ python -c "import os, tempfile; from coffee_roaster_mcp.config import load_confi
 ## Repo-local Workflows
 
 - `.claude/skills/code-quality`: run before marking a story complete or opening a PR.
-- `.claude/skills/mcp-dev`: use for local setup and scaffold-level validation while the MCP runtime is still landing.
-- `.claude/skills/mock-roast`: use for the current mock-safe bootstrap path and later extend it to real mock roast MCP checks.
+- `.claude/skills/mcp-dev`: use for local setup, stdio MCP startup, and scaffold-level validation while the runtime is still landing.
+- `.claude/skills/mock-roast`: use for the current mock-safe bootstrap path and early stdio MCP checks before the full roast-session flow lands.
 - `.claude/skills/hottop-validation`: use for guarded manual Hottop validation planning and release-readiness review.
 - `.claude/skills/release-registry`: use for staged PyPI and MCP Registry release preparation without implying unimplemented release automation exists.
 
@@ -76,6 +76,7 @@ src/coffee_roaster_mcp/
   __init__.py     - package version
   cli.py          - console entrypoint
   config.py       - typed configuration loading from defaults, YAML, and env vars
+  mcp_server.py   - FastMCP stdio entrypoint and bootstrap-safe tools
 tests/
   test_package.py - package and CLI smoke coverage
   test_config.py  - config defaults, YAML, env override, and validation coverage

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The v0.1 direction is one local stdio MCP server that will own:
 - derived roast metrics
 - roast log export
 
-The current repo state is still bootstrap. The package scaffold, config loading, local development commands, and pull-request CI are in place. The full MCP runtime and tool surface start in Epic 2.
+The current repo state is still bootstrap. The package scaffold, config loading, local development commands, pull-request CI, and the first stdio MCP entrypoint are in place. The full roast-session runtime and control surface continue through Epic 2.
 
 ## Install
 
@@ -82,11 +82,22 @@ The default local path is intentionally mock-safe:
 - no microphone required
 - no model download required
 
-The full stdio MCP server and roast-session tool flow have not landed yet. Until `E2-S1` and later Epic 2 stories are implemented, the practical local mock run is a bootstrap validation flow rather than a real MCP session.
+`E2-S1` now provides a real local stdio MCP server entrypoint with a minimal bootstrap-safe tool list. Later Epic 2 stories still need to add the authoritative roast-session lifecycle and the roast-control tool surface.
+
+### Start The Local MCP Server
+
+```bash
+coffee-roaster-mcp serve
+```
+
+The current `E2-S1` tool list is intentionally narrow:
+
+- `get_server_info`
+- `get_runtime_config`
 
 ### Mock-Safe Bootstrap Smoke
 
-The full stdio MCP server lands in `E2-S1`. Until then, use this mock-safe bootstrap smoke to confirm the default local path stays hardware-free and model-free from a guaranteed-empty temporary directory:
+Use this mock-safe bootstrap smoke to confirm the default local path stays hardware-free and model-free from a guaranteed-empty temporary directory:
 
 ```bash
 python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"

--- a/docs/plans/e2-runtime-crosswalk-from-coffee-roasting-poc.md
+++ b/docs/plans/e2-runtime-crosswalk-from-coffee-roasting-poc.md
@@ -1,0 +1,233 @@
+# Epic 2 Runtime Crosswalk From `coffee-roasting` POC
+
+## Purpose
+
+This note maps the old `coffee-roasting` proof of concept to the new `coffee-roaster-mcp` Epic 2 implementation work.
+
+Use it to recover proven runtime behavior from the old codebase without carrying forward the old two-server plus orchestration architecture.
+
+## Source Of Truth
+
+For this repository:
+
+- The target architecture remains `docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md`
+- The active implementation state remains `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+The old `coffee-roasting` repository is a behavioral reference only.
+
+## Old POC Boundaries
+
+The old proof of concept split responsibilities across:
+
+- `src/mcp_servers/roaster_control`
+- `src/mcp_servers/first_crack_detection`
+- orchestration and remote access layers around them
+
+That split is exactly what the new repo is removing.
+
+Carry forward:
+
+- roast-session semantics
+- roast metrics semantics
+- basic stdio MCP server bootstrap patterns
+- proven tool behavior where it matches the new single-server plan
+
+Do not carry forward:
+
+- two MCP server ownership
+- cross-server synchronization
+- Auth0 middleware
+- SSE or HTTP transport
+- `n8n` orchestration assumptions
+- observability or deployment glue that only existed for the old remote setup
+
+## Most Useful Old Modules
+
+### Strong behavioral references
+
+- `coffee-roasting/src/mcp_servers/roaster_control/roast_tracker.py`
+- `coffee-roasting/src/mcp_servers/roaster_control/session_manager.py`
+- `coffee-roasting/src/mcp_servers/roaster_control/models.py`
+
+These are the best references for:
+
+- T0 and roast timing semantics
+- first crack and drop event handling
+- development time and RoR behavior
+- session state shape
+
+### Useful bootstrap references
+
+- `coffee-roasting/src/mcp_servers/roaster_control/mcp_server.py`
+- `coffee-roasting/src/mcp_servers/roaster_control/server.py`
+- `coffee-roasting/src/mcp_servers/first_crack_detection/server.py`
+
+These are useful for:
+
+- stdio MCP startup shape
+- tool registration shape
+- initialization and clean shutdown patterns
+
+### Reference only, not to be ported directly
+
+- `coffee-roasting/src/mcp_servers/*/sse_server.py`
+- `coffee-roasting/src/mcp_servers/auth0_middleware.py`
+- `coffee-roasting/src/mcp_servers/shared/auth0_middleware.py`
+- `coffee-roasting/docs/03-phase-3/*`
+- old agent-platform and `n8n` setup docs
+
+## Crosswalk By Epic 2 Story
+
+### `E2-S1` Implement stdio MCP server entrypoint
+
+Primary old references:
+
+- `roaster_control/mcp_server.py`
+- `roaster_control/server.py`
+- `first_crack_detection/server.py`
+
+What to carry forward:
+
+- use stdio transport
+- keep startup logic explicit and testable
+- keep logging off stdout and stderr where it can interfere with MCP transport
+- make initialization and shutdown deterministic
+
+What to change for the new repo:
+
+- one server only
+- no separate detector server
+- no HTTP or SSE transport
+- no Auth0 or remote access middleware
+- no old `USE_MOCK_HARDWARE` or `ROASTER_MOCK_MODE` bootstrap flags unless the new config model requires them
+
+Recommended scope for `E2-S1`:
+
+- prove local stdio startup
+- expose only a minimal bootstrap-safe tool list
+- do not pull full roast control behavior into the entrypoint story
+
+### `E2-S2` Implement `RoastSession` lifecycle
+
+Primary old references:
+
+- `roaster_control/session_manager.py`
+- `roaster_control/models.py`
+
+What to carry forward:
+
+- one active runtime owner for session state
+- explicit session start and stop lifecycle
+- clear latest-state access pattern
+
+What to change for the new repo:
+
+- replace thread-oriented session manager naming with `RoastSession` ownership
+- move from old hardware-first orchestration toward session-first orchestration
+- avoid hard-coding the old roaster-control tool boundaries into the session object
+
+### `E2-S3` Implement core event timeline
+
+Primary old references:
+
+- `roaster_control/roast_tracker.py`
+- old tool names and event behavior in `roaster_control/server.py`
+
+What to carry forward:
+
+- idempotent recording of first crack and drop
+- event timestamps as explicit state, not inferred ad hoc later
+
+What to change for the new repo:
+
+- use the new event names from the plan
+- make the event timeline the single shared record across roast control and first-crack integration
+
+### `E2-S4` Implement core MCP tools
+
+Primary old references:
+
+- `roaster_control/server.py`
+- `docs/MCP_TOOLS_REFERENCE.md`
+
+What to carry forward:
+
+- tool validation discipline
+- clear status-returning tool behavior
+- conservative control commands
+
+What to change for the new repo:
+
+- collapse old roaster-control and first-crack tool interactions into one server surface
+- use the new tool names from the current plan, not the old two-server names
+- keep the tool surface aligned with the single authoritative session
+
+### `E2-S5` Implement phase transitions
+
+Primary old references:
+
+- `roaster_control/roast_tracker.py`
+- old roast workflow docs and examples
+
+What to carry forward:
+
+- roast progression semantics around beans added, first crack, and drop
+
+What to change for the new repo:
+
+- phase must be explicit state in the session core
+- phase should not depend on multiple MCP servers staying synchronized
+
+### `E2-S6` Implement emergency stop and fault recording
+
+Primary old references:
+
+- old roaster-control command behavior
+- old hardware-control safety intent
+
+What to carry forward:
+
+- fail closed
+- keep stop behavior operator-visible
+
+What to change for the new repo:
+
+- record fault or emergency-stop state in the single event timeline
+- make the active driver contract responsible for the safety call
+
+### `E2-S7` Complete thin vertical slice spike
+
+Primary old references:
+
+- old mock roast workflow examples in `roaster_control/README.md`
+- old tool flow in `docs/MCP_TOOLS_REFERENCE.md`
+
+What to carry forward:
+
+- start to drop workflow expectations
+- state polling and summary expectations
+
+What to change for the new repo:
+
+- one process only
+- no detector-server coordination
+- no orchestration dependency
+
+## Immediate Guidance For `E2-S1`
+
+Before writing code:
+
+1. Use the old `roaster_control/mcp_server.py` and `server.py` only for stdio startup and tool-registration patterns.
+2. Treat `roast_tracker.py` as the main behavioral reference for later session semantics, not as an entrypoint dependency to wire in immediately.
+3. Keep `E2-S1` transport-focused. Do not prematurely implement the whole roast lifecycle inside the entrypoint story.
+4. Prefer the new repo config model and package layout even when old code solved a similar problem differently.
+
+## Decision Summary
+
+The old POC is useful, but only in slices:
+
+- entrypoint and MCP registration patterns for `E2-S1`
+- session and roast-metric semantics for later Epic 2 stories
+- Hottop and remote orchestration code only as historical context
+
+The new repo should look like one coherent MCP runtime, not like two old servers pasted into one package.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E2-S1`
-- Current target: Implement the stdio MCP server entrypoint and expose a minimal tool list
+- Active story: `E2-S2`
+- Current target: Implement `RoastSession` lifecycle with one authoritative session owner
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -31,6 +31,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - Agent and n8n orchestration are out of scope.
 - Default roaster driver is `mock`.
 - First-crack mode defaults to `disabled` so mock install and registry smoke tests do not require audio hardware or model download.
+- `E2-S1` keeps the initial MCP tool surface bootstrap-safe with `get_server_info` and `get_runtime_config`. Roast-session lifecycle and roast-control tools remain later Epic 2 work.
 - ONNX INT8 is the default real model backend.
 - ONNX FP32 is supported by config.
 - The `coffee-first-crack-detection` repo remains the source of truth for training, ONNX export, Hugging Face sync, model cards, and dataset cards.
@@ -38,6 +39,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
+- The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
 
 ## Current Risks
 
@@ -99,7 +101,7 @@ Goal: implement one authoritative roast session runtime and MCP tool surface.
 
 ### Stories
 
-- [ ] `E2-S1` Implement stdio MCP server entrypoint.
+- [x] `E2-S1` Implement stdio MCP server entrypoint.
   - Done when the server starts locally and exposes a minimal tool list.
 
 - [ ] `E2-S2` Implement `RoastSession` lifecycle.
@@ -355,6 +357,8 @@ After completing a story:
 - E1-S6 added a GitHub Actions CI workflow for pull requests plus manual runs. CI now installs project dev dependencies, runs tests, lint, format check, typecheck, CLI smoke checks, and builds sdist plus wheel artifacts. Package build tooling is declared in `pyproject.toml`.
 - E1-S7 expanded the initial README into a real install and usage entrypoint. It now explains RoastPilot versus `coffee-roaster-mcp`, the local mock path, the current Hottop placeholder, the Hugging Face model boundary, and the planned log-export behavior without claiming unfinished runtime features.
 - E1-S8 completed the repo-local workflow set. The repo now has skills for code quality, scaffold-level MCP setup, mock roast bootstrap validation, guarded Hottop validation, and staged registry release preparation. Those runbooks explicitly keep model training, ONNX export, and Hugging Face sync out of this repo.
+- Epic 2 planning now has a local crosswalk for the old `coffee-roasting` POC. It identifies the old stdio entrypoint, tool registration, session manager, and roast tracker as the main implementation references while explicitly rejecting the old split-server and orchestration architecture.
+- E2-S1 added the first local stdio FastMCP entrypoint, `coffee-roaster-mcp serve`, and a bootstrap-safe runtime tool surface with `get_server_info` and `get_runtime_config`. It keeps roast-session lifecycle and roast-control tools out of the entrypoint story.
 - Validation run for E1-S8:
   - Reviewed issue #15 acceptance criteria against `AGENTS.md`, the active epic, and the overall plan.
   - Added `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, and `.claude/skills/release-registry` using the existing repo-local skill format.
@@ -401,3 +405,13 @@ After completing a story:
   - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m ruff check .`: passed.
   - Ran `/tmp/roastpilot-e1s6-venv/bin/python -m pyright --pythonpath /tmp/roastpilot-e1s6-venv/bin/python`: 0 errors.
   - Ran `/tmp/roastpilot-e1s6-venv/bin/coffee-roaster-mcp --help` and `--version`: passed.
+- Validation run for E2-S1:
+  - Added `mcp>=1.0.0,<2` as a declared runtime dependency and configured local pyright venv resolution.
+  - Added `src/coffee_roaster_mcp/mcp_server.py` with a FastMCP stdio server and bootstrap-safe introspection tools only.
+  - Added `coffee-roaster-mcp serve` and a module `__main__` guard so the entrypoint works through both the console script and `python -m coffee_roaster_mcp.cli serve`.
+  - Updated `README.md`, `AGENTS.md`, `.claude/skills/mcp-dev`, and `.claude/skills/mock-roast` so they no longer claim the stdio server is missing.
+  - Ran `./.venv/bin/python -m pytest`: 18 passed, including a stdio startup smoke test that initialized the server and listed tools over MCP.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help` and `--version`: passed.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,8 +22,10 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E1-S8 is complete. RoastPilot now has repo-local workflow docs for code quality, scaffold-level MCP development, mock roast bootstrap validation, guarded Hottop hardware validation, and staged PyPI plus MCP Registry release preparation.
+E2-S1 is complete. RoastPilot now has its first local stdio MCP server entrypoint plus a minimal bootstrap-safe tool surface for runtime introspection.
 
-The next story is E2-S1: implement the stdio MCP server entrypoint.
+The next story is E2-S2: implement the RoastSession lifecycle.
 
 The first implementation milestone remains a thin mock vertical slice: install the package, start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
+
+For Epic 2 implementation, the old `coffee-roasting` repository is a behavioral reference only. Reuse proven roast-session and stdio MCP patterns, but do not recreate the old two-server, Auth0, SSE, or `n8n` architecture.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence"
 ]
 dependencies = [
+  "mcp>=1.0.0,<2",
   "PyYAML>=6.0.2"
 ]
 
@@ -70,3 +71,5 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 pythonVersion = "3.11"
 typeCheckingMode = "strict"
 include = ["src", "tests"]
+venvPath = "."
+venv = ".venv"

--- a/src/coffee_roaster_mcp/cli.py
+++ b/src/coffee_roaster_mcp/cli.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Sequence
+from pathlib import Path
 
 from coffee_roaster_mcp import __version__
+from coffee_roaster_mcp.mcp_server import run_stdio_server
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -19,11 +21,29 @@ def build_parser() -> argparse.ArgumentParser:
         action="version",
         version=f"%(prog)s {__version__}",
     )
+    subparsers = parser.add_subparsers(dest="command")
+
+    serve_parser = subparsers.add_parser(
+        "serve",
+        help="Run the RoastPilot MCP server over stdio.",
+    )
+    serve_parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Optional path to a coffee-roaster-mcp YAML config file.",
+    )
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the RoastPilot CLI."""
     parser = build_parser()
-    parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if args.command == "serve":
+        run_stdio_server(config_path=args.config)
     return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/coffee_roaster_mcp/cli.py
+++ b/src/coffee_roaster_mcp/cli.py
@@ -40,6 +40,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Run the RoastPilot CLI."""
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.command is None:
+        parser.print_help()
+        return 0
     if args.command == "serve":
         run_stdio_server(config_path=args.config)
     return 0

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -1,0 +1,190 @@
+"""FastMCP stdio server entrypoint for RoastPilot.
+
+This module implements the first local MCP server runtime for RoastPilot.
+The `E2-S1` scope is intentionally narrow: start cleanly over stdio, load the
+existing typed configuration, and expose a minimal bootstrap-safe tool list.
+"""
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownParameterType=false, reportUntypedFunctionDecorator=false, reportUnusedFunction=false
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
+
+from coffee_roaster_mcp import __version__
+from coffee_roaster_mcp.config import AppConfig, load_config
+
+
+@dataclass(frozen=True)
+class ServerContext:
+    """Server bootstrap context.
+
+    Attributes:
+        config: Loaded RoastPilot configuration.
+        started_at_utc: UTC time when the MCP process initialized.
+    """
+
+    config: AppConfig
+    started_at_utc: datetime
+
+
+@dataclass(frozen=True)
+class ServerInfo:
+    """Structured metadata about the running RoastPilot server.
+
+    Attributes:
+        product_name: Human-facing product name.
+        package_name: Python package and PyPI package name.
+        version: Installed package version.
+        transport: Active MCP transport.
+        current_phase: Current project/runtime phase label.
+        roaster_driver: Configured roaster driver.
+        first_crack_mode: Configured first-crack mode.
+        bootstrap_safe: Whether the current defaults stay hardware-free.
+        available_bootstrap_tools: Minimal tool surface exposed in `E2-S1`.
+        started_at_utc: UTC timestamp when this server process started.
+    """
+
+    product_name: str
+    package_name: str
+    version: str
+    transport: str
+    current_phase: str
+    roaster_driver: str
+    first_crack_mode: str
+    bootstrap_safe: bool
+    available_bootstrap_tools: tuple[str, ...]
+    started_at_utc: str
+
+
+@dataclass(frozen=True)
+class RuntimeConfigSnapshot:
+    """Minimal runtime configuration snapshot for bootstrap validation.
+
+    Attributes:
+        config_source: Config file path when loaded from disk, else `None`.
+        roaster_driver: Configured roaster driver.
+        roaster_port: Optional roaster serial port.
+        roaster_baudrate: Configured roaster baudrate.
+        temperature_unit: Configured roaster temperature unit.
+        command_interval_seconds: Driver command cadence in seconds.
+        first_crack_mode: First-crack mode.
+        model_repo_id: Hugging Face repo used for first-crack artifacts.
+        model_precision: ONNX precision selection.
+        allow_manual_override: Whether manual first-crack override is allowed.
+        log_dir: Configured log directory.
+        sample_interval_seconds: Telemetry sample interval in seconds.
+        auto_t0_detection_enabled: Whether automatic T0 detection is enabled.
+    """
+
+    config_source: str | None
+    roaster_driver: str
+    roaster_port: str | None
+    roaster_baudrate: int
+    temperature_unit: str
+    command_interval_seconds: float
+    first_crack_mode: str
+    model_repo_id: str
+    model_precision: str
+    allow_manual_override: bool
+    log_dir: str
+    sample_interval_seconds: float
+    auto_t0_detection_enabled: bool
+
+
+def create_mcp_server(config_path: str | Path | None = None) -> FastMCP:
+    """Create the RoastPilot FastMCP server.
+
+    Args:
+        config_path: Optional explicit config path. When omitted, the standard
+            config loading rules apply.
+
+    Returns:
+        A configured FastMCP server instance.
+    """
+
+    @asynccontextmanager
+    async def server_lifespan(_: FastMCP) -> AsyncGenerator[ServerContext, None]:
+        """Load typed config once for the MCP process lifetime."""
+        yield ServerContext(
+            config=load_config(path=config_path),
+            started_at_utc=datetime.now(UTC),
+        )
+
+    mcp = FastMCP(
+        name="RoastPilot",
+        instructions=(
+            "Bootstrap-safe RoastPilot MCP server. "
+            "This E2-S1 tool surface exposes runtime introspection only."
+        ),
+        lifespan=server_lifespan,
+    )
+
+    @mcp.tool()
+    def get_server_info(ctx: Context[ServerSession, ServerContext]) -> ServerInfo:
+        """Return structured metadata about the running MCP server."""
+        server_context = ctx.request_context.lifespan_context
+        config = server_context.config
+        return ServerInfo(
+            product_name="RoastPilot",
+            package_name="coffee-roaster-mcp",
+            version=__version__,
+            transport=config.transport.type,
+            current_phase="bootstrap",
+            roaster_driver=config.roaster.driver,
+            first_crack_mode=config.first_crack.mode,
+            bootstrap_safe=_is_bootstrap_safe(config),
+            available_bootstrap_tools=("get_server_info", "get_runtime_config"),
+            started_at_utc=server_context.started_at_utc.isoformat(),
+        )
+
+    @mcp.tool()
+    def get_runtime_config(
+        ctx: Context[ServerSession, ServerContext],
+    ) -> RuntimeConfigSnapshot:
+        """Return a bootstrap-safe summary of the active RoastPilot config."""
+        config = ctx.request_context.lifespan_context.config
+        return RuntimeConfigSnapshot(
+            config_source=str(config.source_path) if config.source_path is not None else None,
+            roaster_driver=config.roaster.driver,
+            roaster_port=config.roaster.port,
+            roaster_baudrate=config.roaster.baudrate,
+            temperature_unit=config.roaster.temperature_unit,
+            command_interval_seconds=config.roaster.command_interval_seconds,
+            first_crack_mode=config.first_crack.mode,
+            model_repo_id=config.first_crack.repo_id,
+            model_precision=config.first_crack.precision,
+            allow_manual_override=config.first_crack.allow_manual_override,
+            log_dir=str(config.logging.log_dir),
+            sample_interval_seconds=config.logging.sample_interval_seconds,
+            auto_t0_detection_enabled=config.session.auto_t0_detection_enabled,
+        )
+
+    return mcp
+
+
+def run_stdio_server(config_path: str | Path | None = None) -> None:
+    """Run RoastPilot over stdio transport.
+
+    Args:
+        config_path: Optional explicit config path.
+    """
+    create_mcp_server(config_path=config_path).run(transport="stdio")
+
+
+def _is_bootstrap_safe(config: AppConfig) -> bool:
+    """Return whether the active config matches bootstrap-safe defaults.
+
+    Args:
+        config: Loaded RoastPilot configuration.
+
+    Returns:
+        True when the config stays on the mock driver and disabled detector mode.
+    """
+    return config.roaster.driver == "mock" and config.first_crack.mode == "disabled"

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -4,7 +4,6 @@ This module implements the first local MCP server runtime for RoastPilot.
 The `E2-S1` scope is intentionally narrow: start cleanly over stdio, load the
 existing typed configuration, and expose a minimal bootstrap-safe tool list.
 """
-# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownParameterType=false, reportUntypedFunctionDecorator=false, reportUnusedFunction=false
 
 from __future__ import annotations
 
@@ -134,7 +133,9 @@ def create_mcp_server(
     )
 
     @mcp.tool()
-    def get_server_info(ctx: Context[ServerSession, ServerContext]) -> ServerInfo:
+    def get_server_info(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
+        ctx: Context[ServerSession, ServerContext],
+    ) -> ServerInfo:
         """Return structured metadata about the running MCP server."""
         server_context = ctx.request_context.lifespan_context
         config = server_context.config
@@ -152,11 +153,12 @@ def create_mcp_server(
         )
 
     @mcp.tool()
-    def get_runtime_config(
+    def get_runtime_config(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
         ctx: Context[ServerSession, ServerContext],
     ) -> RuntimeConfigSnapshot:
         """Return a bootstrap-safe summary of the active RoastPilot config."""
-        config = ctx.request_context.lifespan_context.config
+        server_context = ctx.request_context.lifespan_context
+        config = server_context.config
         return RuntimeConfigSnapshot(
             config_source=str(config.source_path) if config.source_path is not None else None,
             roaster_driver=config.roaster.driver,

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -27,10 +27,12 @@ class ServerContext:
 
     Attributes:
         config: Loaded RoastPilot configuration.
+        transport: Actual MCP transport used by this server process.
         started_at_utc: UTC time when the MCP process initialized.
     """
 
     config: AppConfig
+    transport: str
     started_at_utc: datetime
 
 
@@ -98,12 +100,16 @@ class RuntimeConfigSnapshot:
     auto_t0_detection_enabled: bool
 
 
-def create_mcp_server(config_path: str | Path | None = None) -> FastMCP:
+def create_mcp_server(
+    config_path: str | Path | None = None,
+    transport: str = "stdio",
+) -> FastMCP:
     """Create the RoastPilot FastMCP server.
 
     Args:
         config_path: Optional explicit config path. When omitted, the standard
             config loading rules apply.
+        transport: Actual MCP transport used by this server instance.
 
     Returns:
         A configured FastMCP server instance.
@@ -114,6 +120,7 @@ def create_mcp_server(config_path: str | Path | None = None) -> FastMCP:
         """Load typed config once for the MCP process lifetime."""
         yield ServerContext(
             config=load_config(path=config_path),
+            transport=transport,
             started_at_utc=datetime.now(UTC),
         )
 
@@ -135,7 +142,7 @@ def create_mcp_server(config_path: str | Path | None = None) -> FastMCP:
             product_name="RoastPilot",
             package_name="coffee-roaster-mcp",
             version=__version__,
-            transport=config.transport.type,
+            transport=server_context.transport,
             current_phase="bootstrap",
             roaster_driver=config.roaster.driver,
             first_crack_mode=config.first_crack.mode,
@@ -175,7 +182,7 @@ def run_stdio_server(config_path: str | Path | None = None) -> None:
     Args:
         config_path: Optional explicit config path.
     """
-    create_mcp_server(config_path=config_path).run(transport="stdio")
+    create_mcp_server(config_path=config_path, transport="stdio").run(transport="stdio")
 
 
 def _is_bootstrap_safe(config: AppConfig) -> bool:
@@ -185,6 +192,10 @@ def _is_bootstrap_safe(config: AppConfig) -> bool:
         config: Loaded RoastPilot configuration.
 
     Returns:
-        True when the config stays on the mock driver and disabled detector mode.
+        True when the config stays on the mock driver and uses a first-crack mode
+        that does not require audio capture or model startup.
     """
-    return config.roaster.driver == "mock" and config.first_crack.mode == "disabled"
+    return config.roaster.driver == "mock" and config.first_crack.mode in {
+        "disabled",
+        "manual",
+    }

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,12 +1,11 @@
 """Package and CLI smoke coverage for RoastPilot."""
-# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownParameterType=false
 
 import asyncio
 import os
 import sys
 from collections.abc import Awaitable
 from pathlib import Path
-from typing import TypeVar
+from typing import Any, TypeVar, cast
 
 import pytest
 from mcp import ClientSession, StdioServerParameters
@@ -69,17 +68,19 @@ async def _assert_stdio_server_tools(tmp_path: Path) -> None:
     async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
         await _call_with_timeout(session.initialize())
 
-        tools = await _call_with_timeout(session.list_tools())
+        tools = cast(Any, await _call_with_timeout(session.list_tools()))
         tool_names = {tool.name for tool in tools.tools}
         assert tool_names == {"get_server_info", "get_runtime_config"}
 
-        server_info = await _call_with_timeout(session.call_tool("get_server_info", {}))
+        server_info = cast(Any, await _call_with_timeout(session.call_tool("get_server_info", {})))
         assert server_info.structuredContent is not None
         assert server_info.structuredContent["product_name"] == "RoastPilot"
         assert server_info.structuredContent["transport"] == "stdio"
         assert server_info.structuredContent["bootstrap_safe"] is True
 
-        runtime_config = await _call_with_timeout(session.call_tool("get_runtime_config", {}))
+        runtime_config = cast(
+            Any, await _call_with_timeout(session.call_tool("get_runtime_config", {}))
+        )
         assert runtime_config.structuredContent is not None
         assert runtime_config.structuredContent["roaster_driver"] == "mock"
         assert runtime_config.structuredContent["first_crack_mode"] == "disabled"
@@ -100,7 +101,7 @@ async def _assert_manual_mode_bootstrap_safe(tmp_path: Path) -> None:
     async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
         await _call_with_timeout(session.initialize())
 
-        server_info = await _call_with_timeout(session.call_tool("get_server_info", {}))
+        server_info = cast(Any, await _call_with_timeout(session.call_tool("get_server_info", {})))
         assert server_info.structuredContent is not None
         assert server_info.structuredContent["first_crack_mode"] == "manual"
         assert server_info.structuredContent["bootstrap_safe"] is True

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,7 +1,19 @@
+"""Package and CLI smoke coverage for RoastPilot."""
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownParameterType=false
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
 import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
 
 from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.cli import build_parser, main
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_version_is_defined() -> None:
@@ -34,3 +46,36 @@ def test_main_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
     output = capsys.readouterr().out
     assert "usage: coffee-roaster-mcp" in output
     assert "RoastPilot" in output
+
+
+def test_stdio_server_starts_and_exposes_bootstrap_tools() -> None:
+    asyncio.run(_assert_stdio_server_tools())
+
+
+async def _assert_stdio_server_tools() -> None:
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "coffee_roaster_mcp.cli", "serve"],
+        env={
+            **os.environ,
+            "PYTHONPATH": str(REPO_ROOT / "src"),
+        },
+    )
+
+    async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
+        await session.initialize()
+
+        tools = await session.list_tools()
+        tool_names = {tool.name for tool in tools.tools}
+        assert tool_names == {"get_server_info", "get_runtime_config"}
+
+        server_info = await session.call_tool("get_server_info", {})
+        assert server_info.structuredContent is not None
+        assert server_info.structuredContent["product_name"] == "RoastPilot"
+        assert server_info.structuredContent["transport"] == "stdio"
+        assert server_info.structuredContent["bootstrap_safe"] is True
+
+        runtime_config = await session.call_tool("get_runtime_config", {})
+        assert runtime_config.structuredContent is not None
+        assert runtime_config.structuredContent["roaster_driver"] == "mock"
+        assert runtime_config.structuredContent["first_crack_mode"] == "disabled"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -4,7 +4,9 @@
 import asyncio
 import os
 import sys
+from collections.abc import Awaitable
 from pathlib import Path
+from typing import TypeVar
 
 import pytest
 from mcp import ClientSession, StdioServerParameters
@@ -14,6 +16,7 @@ from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.cli import build_parser, main
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+_T = TypeVar("_T")
 
 
 def test_version_is_defined() -> None:
@@ -24,10 +27,6 @@ def test_cli_parser_program_name() -> None:
     parser = build_parser()
 
     assert parser.prog == "coffee-roaster-mcp"
-
-
-def test_main_returns_success() -> None:
-    assert main([]) == 0
 
 
 def test_main_without_subcommand_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
@@ -68,28 +67,63 @@ async def _assert_stdio_server_tools(tmp_path: Path) -> None:
     )
 
     async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
-        await session.initialize()
+        await _call_with_timeout(session.initialize())
 
-        tools = await session.list_tools()
+        tools = await _call_with_timeout(session.list_tools())
         tool_names = {tool.name for tool in tools.tools}
         assert tool_names == {"get_server_info", "get_runtime_config"}
 
-        server_info = await session.call_tool("get_server_info", {})
+        server_info = await _call_with_timeout(session.call_tool("get_server_info", {}))
         assert server_info.structuredContent is not None
         assert server_info.structuredContent["product_name"] == "RoastPilot"
         assert server_info.structuredContent["transport"] == "stdio"
         assert server_info.structuredContent["bootstrap_safe"] is True
 
-        runtime_config = await session.call_tool("get_runtime_config", {})
+        runtime_config = await _call_with_timeout(session.call_tool("get_runtime_config", {}))
         assert runtime_config.structuredContent is not None
         assert runtime_config.structuredContent["roaster_driver"] == "mock"
         assert runtime_config.structuredContent["first_crack_mode"] == "disabled"
 
 
-def _build_clean_server_env() -> dict[str, str]:
-    """Return a deterministic subprocess environment for MCP startup tests."""
-    return {
-        key: value
-        for key, value in {**os.environ, "PYTHONPATH": str(REPO_ROOT / "src")}.items()
-        if not key.startswith("COFFEE_")
-    }
+def test_stdio_server_reports_manual_mode_as_bootstrap_safe(tmp_path: Path) -> None:
+    asyncio.run(_assert_manual_mode_bootstrap_safe(tmp_path))
+
+
+async def _assert_manual_mode_bootstrap_safe(tmp_path: Path) -> None:
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "coffee_roaster_mcp.cli", "serve"],
+        env=_build_clean_server_env({"COFFEE_FIRST_CRACK_MODE": "manual"}),
+        cwd=tmp_path,
+    )
+
+    async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
+        await _call_with_timeout(session.initialize())
+
+        server_info = await _call_with_timeout(session.call_tool("get_server_info", {}))
+        assert server_info.structuredContent is not None
+        assert server_info.structuredContent["first_crack_mode"] == "manual"
+        assert server_info.structuredContent["bootstrap_safe"] is True
+
+
+def _build_clean_server_env(overrides: dict[str, str] | None = None) -> dict[str, str]:
+    """Return a minimal subprocess environment for MCP startup tests."""
+    pythonpath_parts = [str(REPO_ROOT / "src")]
+    existing_pythonpath = os.environ.get("PYTHONPATH")
+    if existing_pythonpath:
+        pythonpath_parts.append(existing_pythonpath)
+
+    base_env = {"PYTHONPATH": os.pathsep.join(pythonpath_parts)}
+    for key in ("PATH", "HOME", "LANG", "LC_ALL", "TMPDIR", "SYSTEMROOT"):
+        value = os.environ.get(key)
+        if value is not None:
+            base_env[key] = value
+
+    if overrides is not None:
+        base_env.update(overrides)
+    return base_env
+
+
+async def _call_with_timeout(awaitable: Awaitable[_T], timeout_seconds: float = 5.0) -> _T:
+    """Fail fast if the MCP smoke test subprocess stops responding."""
+    return await asyncio.wait_for(awaitable, timeout=timeout_seconds)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -30,6 +30,13 @@ def test_main_returns_success() -> None:
     assert main([]) == 0
 
 
+def test_main_without_subcommand_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main([]) == 0
+    output = capsys.readouterr().out
+    assert "usage: coffee-roaster-mcp" in output
+    assert "{serve}" in output
+
+
 def test_main_prints_version(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as exc_info:
         main(["--version"])
@@ -48,18 +55,16 @@ def test_main_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
     assert "RoastPilot" in output
 
 
-def test_stdio_server_starts_and_exposes_bootstrap_tools() -> None:
-    asyncio.run(_assert_stdio_server_tools())
+def test_stdio_server_starts_and_exposes_bootstrap_tools(tmp_path: Path) -> None:
+    asyncio.run(_assert_stdio_server_tools(tmp_path))
 
 
-async def _assert_stdio_server_tools() -> None:
+async def _assert_stdio_server_tools(tmp_path: Path) -> None:
     server_params = StdioServerParameters(
         command=sys.executable,
         args=["-m", "coffee_roaster_mcp.cli", "serve"],
-        env={
-            **os.environ,
-            "PYTHONPATH": str(REPO_ROOT / "src"),
-        },
+        env=_build_clean_server_env(),
+        cwd=tmp_path,
     )
 
     async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
@@ -79,3 +84,12 @@ async def _assert_stdio_server_tools() -> None:
         assert runtime_config.structuredContent is not None
         assert runtime_config.structuredContent["roaster_driver"] == "mock"
         assert runtime_config.structuredContent["first_crack_mode"] == "disabled"
+
+
+def _build_clean_server_env() -> dict[str, str]:
+    """Return a deterministic subprocess environment for MCP startup tests."""
+    return {
+        key: value
+        for key, value in {**os.environ, "PYTHONPATH": str(REPO_ROOT / "src")}.items()
+        if not key.startswith("COFFEE_")
+    }


### PR DESCRIPTION
## Summary
- add the first local stdio FastMCP server entrypoint and 
- keep the E2-S1 tool surface bootstrap-safe with  and 
- add a stdio startup smoke test and declare the                                                                                 
 Usage: mcp [OPTIONS] COMMAND [ARGS]...                                         
                                                                                
 MCP development tools                                                          
                                                                                
╭─ Options ────────────────────────────────────────────────────────────────────╮
│ --help          Show this message and exit.                                  │
╰──────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ───────────────────────────────────────────────────────────────────╮
│ version  Show the MCP version.                                               │
│ dev      Run a MCP server with the MCP Inspector.                            │
│ run      Run a MCP server.                                                   │
│ install  Install a MCP server in the Claude desktop app.                     │
╰──────────────────────────────────────────────────────────────────────────────╯ runtime dependency
- add the Epic 2 crosswalk doc and update local docs and durable state for the new runtime reality

## Why
Story  requires a real local stdio MCP server entrypoint with a minimal tool list. This keeps the scope tight to transport and bootstrap validation without prematurely pulling the full roast-session lifecycle or roast-control tools into the entrypoint story.

## Validation
- ..................                                                       [100%]
18 passed in 0.44s
- All checks passed!
- 6 files already formatted
- 0 errors, 0 warnings, 0 informations
- usage: coffee-roaster-mcp [-h] [--version] {serve} ...

RoastPilot: a spec-driven MCP server for autonomous coffee roasting.

positional arguments:
  {serve}
    serve     Run the RoastPilot MCP server over stdio.

options:
  -h, --help  show this help message and exit
  --version   show program's version number and exit
- coffee-roaster-mcp 0.1.0

## Story
- closes #16