### PR TITLE
[codex] Implement RoastSession lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,9 +77,11 @@ src/coffee_roaster_mcp/
   cli.py          - console entrypoint
   config.py       - typed configuration loading from defaults, YAML, and env vars
   mcp_server.py   - FastMCP stdio entrypoint and bootstrap-safe tools
+  session.py      - authoritative roast session lifecycle and active-session owner
 tests/
   test_package.py - package and CLI smoke coverage
   test_config.py  - config defaults, YAML, env override, and validation coverage
+  test_session.py - roast session lifecycle and active-session ownership coverage
 docs/state/
   registry.md     - active project state pointer
   epics/          - durable epic and story state

--- a/docs/session-summaries/2026-05-04-e2-s1-e2-s2-code-review-summary.md
+++ b/docs/session-summaries/2026-05-04-e2-s1-e2-s2-code-review-summary.md
@@ -1,0 +1,202 @@
+# Code Review Summary: E2-S1 And E2-S2
+
+Date: 2026-05-04
+
+Repository: `syamaner/coffee-roaster-mcp`
+
+## Scope
+
+This summary captures the code review findings and fixes for:
+
+- PR `#70` - `Implement stdio MCP server entrypoint`
+- PR `#71` - `Implement RoastSession lifecycle`
+
+The goal is to preserve the review history in a compact durable form, especially the behavioral issues that changed code shape rather than just tests.
+
+## PR #70: E2-S1 Review Summary
+
+Story:
+
+- `E2-S1`
+- issue `#16`
+
+PR outcome:
+
+- merged
+
+### Main review themes
+
+1. MCP startup test determinism
+2. CLI no-arg behavior
+3. bootstrap-safe semantics
+4. runtime-vs-config transport accuracy
+5. timeout and environment hardening in MCP smoke tests
+6. blanket type-suppression cleanup
+
+### Important review findings and fixes
+
+Deterministic stdio smoke startup:
+
+- Review found the stdio test inherited local `COFFEE_*` overrides and repo-root config state.
+- Fix:
+  - temp working directory
+  - scrubbed `COFFEE_*` env vars
+  - later narrowed to a minimal selected subprocess environment
+
+No-arg CLI behavior:
+
+- Review found `coffee-roaster-mcp` with no subcommand silently returned success without output.
+- Fix:
+  - `main([])` now prints help and returns `0`
+  - tests updated to assert the help output
+
+Bootstrap-safe manual mode:
+
+- Review found `bootstrap_safe` incorrectly returned `False` for mock + `first_crack.mode=manual`
+- Fix:
+  - `manual` now counts as bootstrap-safe
+  - MCP-level smoke coverage added for public `get_server_info`
+
+Transport reporting:
+
+- Review found `get_server_info.transport` reported config transport rather than actual runtime transport
+- Fix:
+  - runtime transport moved into `ServerContext`
+  - public response now reports real runtime transport
+
+MCP smoke test hang risk:
+
+- Review found no timeout around `initialize`, `list_tools`, and `call_tool`
+- Fix:
+  - wrapped these awaits in `asyncio.wait_for(...)`
+
+Pyright suppression scope:
+
+- Review found blanket file-level suppressions in runtime and test modules
+- Fix:
+  - removed module-wide suppressions
+  - kept targeted ignores only for `@mcp.tool()` decorator interaction
+  - used narrow casts at MCP client interaction points in tests
+
+### Review-driven commits for PR #70
+
+1. `893abb0` - `test: harden stdio startup smoke`
+2. `497fe5d` - `test: tighten mcp startup coverage`
+3. `f1670f5` - `test: narrow pyright suppressions`
+
+### Final E2-S1 quality gate
+
+- `pytest`: 20 passed
+- `ruff check .`: passed
+- `ruff format --check .`: passed
+- `pyright`: 0 errors
+
+## PR #71: E2-S2 Review Summary
+
+Story:
+
+- `E2-S2`
+- issue `#17`
+
+PR state at summary time:
+
+- open
+- mergeable
+
+### Main review themes
+
+1. invalid retention-parameter handling
+2. log-root propagation from config
+3. thread-safety and mutation-boundary clarity
+4. stop-session contract accuracy
+5. latest-vs-active session ownership naming
+6. lifecycle tests that lock in restart behavior
+
+### Important review findings and fixes
+
+Negative telemetry buffer limit:
+
+- Review found `telemetry_buffer_limit < 0` could crash during trimming.
+- Fix:
+  - `RoastSessionStore.__init__` rejects negative values with `ValueError`
+
+Configured log root propagation:
+
+- Review found `RoastSessionStore` was seeded with a hardcoded default, ignoring `logging.log_dir`
+- Fix:
+  - added `build_server_context(...)`
+  - session store now uses `config.logging.log_dir / "roasts"`
+  - test coverage added
+
+Thread-safety contract:
+
+- Review found the mutable `RoastSession` object could be mutated outside store locking
+- Fix:
+  - documented `RoastSession` as mutable and not independently thread-safe
+  - documented the store as the authoritative mutation boundary
+  - later moved telemetry writes behind the store API
+
+Negative `max_samples` in telemetry append:
+
+- Review found per-call retention limits could be invalid
+- Intermediate fix:
+  - rejected negative `max_samples`
+- Final structural fix:
+  - removed public caller-controlled telemetry retention from the session object
+  - replaced it with `RoastSessionStore.append_telemetry(...)`
+
+Repeated `stop_session()` behavior:
+
+- Review found repeated stop calls still returned the latest stopped session, conflicting with method contract
+- Fix:
+  - `stop_session()` now returns `None` when there is no active session left
+  - coverage added
+
+Misleading internal field name:
+
+- Review found `_active_session` was misleading because it still pointed at the latest stopped session after stop
+- Fix:
+  - renamed internal field to `_latest_session`
+  - aligned related checks and doc semantics
+
+Test clarity and lifecycle restart:
+
+- Review found one test name overstated what was cleared on stop
+- Review also asked for restart-after-stop coverage
+- Fix:
+  - renamed the test to match actual behavior
+  - added restart-after-stop coverage
+
+### Review-driven commits for PR #71
+
+1. `603cbdf` - `test: harden session lifecycle edges`
+2. `a8084e2` - `test: tighten session store lifecycle`
+3. `a0869c7` - `refactor: clarify latest session ownership`
+
+### Final E2-S2 quality gate
+
+- `pytest`: 29 passed
+- `ruff check .`: passed
+- `ruff format --check .`: passed
+- `pyright`: 0 errors
+
+## Cross-Story Lessons
+
+Important implementation lessons from these review cycles:
+
+- public introspection fields must reflect runtime truth, not just configuration intent
+- bootstrap-safe behavior needs explicit test coverage at the MCP response level
+- store-owned mutation boundaries matter early, even before concurrency-heavy tool flows exist
+- internal naming must match lifecycle semantics, especially when “active” and “latest” diverge
+- broad static-analysis suppressions are easy to add and expensive to clean up later; targeted ignores are worth the extra effort
+
+## Suggested Future Use
+
+When starting `E2-S3` or later runtime stories, re-read this file before changing:
+
+- session lifecycle semantics
+- telemetry write paths
+- stop behavior
+- MCP startup smoke tests
+
+Those areas already had real review churn and are the most likely to regress if later stories shortcut the current boundaries.

--- a/docs/session-summaries/2026-05-04-e2-s1-e2-s2-runtime-and-review-cycle.md
+++ b/docs/session-summaries/2026-05-04-e2-s1-e2-s2-runtime-and-review-cycle.md
@@ -1,0 +1,208 @@
+# Session Summary: E2-S1 And E2-S2 Runtime Buildout
+
+Date: 2026-05-04
+
+Repository: `syamaner/coffee-roaster-mcp`
+
+Branch at summary time: `feature/17-implement-roastsession-lifecycle`
+
+## Purpose
+
+This summary captures the Epic 2 runtime work completed after Epic 1 closed.
+
+The main outcomes were:
+
+- complete `E2-S1` stdio MCP server entrypoint
+- complete `E2-S2` authoritative `RoastSession` lifecycle
+- process the PR review cycles for both stories through follow-up commits
+- preserve current local review and branch state before further compaction
+
+This file is intended to keep enough context for future compaction and restart without requiring the full chat transcript.
+
+## Non-PII Codex Status Snapshot (User-Provided Source Of Truth)
+
+Snapshot received from the active Codex UI:
+
+- Model: `gpt-5.4`
+- Reasoning: `medium`
+- Summaries: `auto`
+- Directory: `~/git/coffee-roaster-mcp`
+- Permissions: `Workspace (on-request)`
+- `AGENTS.md` loaded in this session: `AGENTS.md`
+- Thread name: `coffee roaster mcp`
+- Collaboration mode: `Default`
+- Context window: `23% left (203K used / 258K)`
+- 5h limit: `93% left` (reset shown as `01:43`)
+- Weekly limit: `99% left` (reset shown as `20:43 on 10 May`)
+- GPT-5.3-Codex-Spark 5h limit: `100% left` (reset shown as `05:32`)
+- GPT-5.3-Codex-Spark weekly limit: `100% left` (reset shown as `00:32 on 11 May`)
+- Warning: limits may be stale; run `/status` again shortly
+
+Fields intentionally excluded:
+
+- Account identity
+- Session ID
+
+Most important note for future compaction: this chat covered both `E2-S1` and `E2-S2`, plus multiple review-fix commits across PRs `#70` and `#71`.
+
+## Story Completion Summary
+
+### E2-S1: Implement stdio MCP server entrypoint
+
+Issue: `#16`
+
+PR: `#70`
+
+Branch used: `feature/16-implement-stdio-mcp-server-entrypoint`
+
+Merged state:
+
+- merged to `main`
+- merge commit on `main`: `b66aae0`
+
+What landed:
+
+- Added `src/coffee_roaster_mcp/mcp_server.py`
+- Added `coffee-roaster-mcp serve` through `src/coffee_roaster_mcp/cli.py`
+- Declared runtime dependency `mcp>=1.0.0,<2`
+- Added bootstrap-safe introspection tools:
+  - `get_server_info`
+  - `get_runtime_config`
+- Added stdio MCP startup smoke coverage in `tests/test_package.py`
+- Added the Epic 2 crosswalk:
+  - `docs/plans/e2-runtime-crosswalk-from-coffee-roasting-poc.md`
+
+Important design constraint:
+
+- `E2-S1` stayed intentionally transport-focused
+- it did not yet add roast-session lifecycle or roast-control tools
+
+Durable state after completion:
+
+- `E2-S1` complete
+- `E2-S2` next
+
+### E2-S2: Implement RoastSession lifecycle
+
+Issue: `#17`
+
+PR: `#71`
+
+Branch used: `feature/17-implement-roastsession-lifecycle`
+
+PR state at summary time:
+
+- open
+- mergeable
+
+What landed:
+
+- Added `src/coffee_roaster_mcp/session.py`
+- Added:
+  - `RoastSession`
+  - `RoastEvent`
+  - `TelemetrySample`
+  - `LogWriterReference`
+  - `SessionLifecycleError`
+  - `RoastSessionStore`
+- Wired one authoritative in-process session owner into MCP server lifespan
+- Session lifecycle now includes:
+  - stable session ids
+  - monotonic start/stop timing
+  - explicit roast phase
+  - event timeline storage
+  - telemetry retention
+  - log-writer references
+  - one-active-session ownership semantics
+- Added `tests/test_session.py`
+
+Important lifecycle decisions after review:
+
+- `stop_session()` now returns `None` when nothing active remains
+- telemetry retention policy moved behind `RoastSessionStore.append_telemetry(...)`
+- store internal pointer renamed from `_active_session` to `_latest_session` so naming matches post-stop semantics
+- `RoastSession` is documented as mutable and not independently thread-safe
+
+Durable state after implementation:
+
+- `E2-S2` complete locally on the branch
+- active context points to `E2-S3` next
+
+## Commit Timeline
+
+### E2-S1 / PR #70
+
+1. `a91e211` - `feat: add stdio mcp server entrypoint`
+2. `893abb0` - `test: harden stdio startup smoke`
+3. `497fe5d` - `test: tighten mcp startup coverage`
+4. `f1670f5` - `test: narrow pyright suppressions`
+
+Merged to `main` as:
+
+- `b66aae0` - `[codex] Add stdio MCP server entrypoint (#70)`
+
+### E2-S2 / PR #71
+
+1. `052d633` - `feat: implement roast session lifecycle`
+2. `603cbdf` - `test: harden session lifecycle edges`
+3. `a8084e2` - `test: tighten session store lifecycle`
+4. `a0869c7` - `refactor: clarify latest session ownership`
+
+## Validation Summary
+
+Validation after the final `E2-S1` review cycle:
+
+- `./.venv/bin/python -m pytest`: 20 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: passed
+
+Validation after the final `E2-S2` review cycle:
+
+- `./.venv/bin/python -m pytest`: 29 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+
+## Current Durable State
+
+Current local durable state says:
+
+- `E2-S1` complete
+- `E2-S2` complete
+- `E2-S3` next
+
+Primary state files:
+
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+## Current Resume Context
+
+Current branch:
+
+- `feature/17-implement-roastsession-lifecycle`
+
+Current PR:
+
+- `#71`
+- `Implement RoastSession lifecycle`
+
+Important restart facts:
+
+- `E2-S1` is already merged on `main`
+- `E2-S2` is implemented on the feature branch and has gone through several review-fix rounds
+- the remaining work after `#71` is merge and then move to `E2-S3`
+
+## Compaction Guidance
+
+If context needs to be compacted again, the minimal restart instruction should be:
+
+1. read this summary
+2. read `docs/state/registry.md`
+3. read `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+4. check whether PR `#71` is merged
+5. if merged, sync `main` and start `E2-S3`
+6. if not merged, continue from PR `#71`

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E2-S2`
-- Current target: Implement `RoastSession` lifecycle with one authoritative session owner
+- Active story: `E2-S3`
+- Current target: Implement the core event timeline on the authoritative RoastSession
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -32,6 +32,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - Default roaster driver is `mock`.
 - First-crack mode defaults to `disabled` so mock install and registry smoke tests do not require audio hardware or model download.
 - `E2-S1` keeps the initial MCP tool surface bootstrap-safe with `get_server_info` and `get_runtime_config`. Roast-session lifecycle and roast-control tools remain later Epic 2 work.
+- `E2-S2` uses one in-process `RoastSessionStore` with at most one active `RoastSession` at a time. Session state now owns monotonic timing, phase, event timeline storage, telemetry retention, and log-writer references before tool wiring lands.
 - ONNX INT8 is the default real model backend.
 - ONNX FP32 is supported by config.
 - The `coffee-first-crack-detection` repo remains the source of truth for training, ONNX export, Hugging Face sync, model cards, and dataset cards.
@@ -104,7 +105,7 @@ Goal: implement one authoritative roast session runtime and MCP tool surface.
 - [x] `E2-S1` Implement stdio MCP server entrypoint.
   - Done when the server starts locally and exposes a minimal tool list.
 
-- [ ] `E2-S2` Implement `RoastSession` lifecycle.
+- [x] `E2-S2` Implement `RoastSession` lifecycle.
   - Done when sessions have id, monotonic clock, phase, event timeline, telemetry buffer, and log writer references.
 
 - [ ] `E2-S3` Implement core event timeline.
@@ -359,6 +360,7 @@ After completing a story:
 - E1-S8 completed the repo-local workflow set. The repo now has skills for code quality, scaffold-level MCP setup, mock roast bootstrap validation, guarded Hottop validation, and staged registry release preparation. Those runbooks explicitly keep model training, ONNX export, and Hugging Face sync out of this repo.
 - Epic 2 planning now has a local crosswalk for the old `coffee-roasting` POC. It identifies the old stdio entrypoint, tool registration, session manager, and roast tracker as the main implementation references while explicitly rejecting the old split-server and orchestration architecture.
 - E2-S1 added the first local stdio FastMCP entrypoint, `coffee-roaster-mcp serve`, and a bootstrap-safe runtime tool surface with `get_server_info` and `get_runtime_config`. It keeps roast-session lifecycle and roast-control tools out of the entrypoint story.
+- E2-S2 added `session.py` with an authoritative `RoastSession` model and `RoastSessionStore`. Session lifecycle now has stable ids, monotonic start/stop timing, explicit phase, event-timeline storage, telemetry-buffer retention, log-writer references, and clean single-owner start/stop behavior.
 - Validation run for E1-S8:
   - Reviewed issue #15 acceptance criteria against `AGENTS.md`, the active epic, and the overall plan.
   - Added `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, and `.claude/skills/release-registry` using the existing repo-local skill format.
@@ -415,3 +417,11 @@ After completing a story:
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.
   - Ran `./.venv/bin/coffee-roaster-mcp --help` and `--version`: passed.
+- Validation run for E2-S2:
+  - Added `src/coffee_roaster_mcp/session.py` with `RoastSession`, `RoastEvent`, `TelemetrySample`, `LogWriterReference`, `SessionLifecycleError`, and `RoastSessionStore`.
+  - Wired the MCP server lifespan to own one authoritative `RoastSessionStore` for later tool stories.
+  - Added `tests/test_session.py` covering session creation, single-owner enforcement, clean stop semantics, and rolling telemetry retention.
+  - Ran `./.venv/bin/python -m pytest`: 24 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,9 +22,9 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E2-S1 is complete. RoastPilot now has its first local stdio MCP server entrypoint plus a minimal bootstrap-safe tool surface for runtime introspection.
+E2-S2 is complete. RoastPilot now has an authoritative in-process RoastSession lifecycle with one active-session owner, monotonic timing, telemetry retention, and log-writer references ready for later runtime stories.
 
-The next story is E2-S2: implement the RoastSession lifecycle.
+The next story is E2-S3: implement the core event timeline.
 
 The first implementation milestone remains a thin mock vertical slice: install the package, start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -18,6 +18,7 @@ from mcp.server.session import ServerSession
 
 from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.config import AppConfig, load_config
+from coffee_roaster_mcp.session import RoastSessionStore
 
 
 @dataclass(frozen=True)
@@ -27,11 +28,13 @@ class ServerContext:
     Attributes:
         config: Loaded RoastPilot configuration.
         transport: Actual MCP transport used by this server process.
+        session_store: Authoritative in-process roast session owner.
         started_at_utc: UTC time when the MCP process initialized.
     """
 
     config: AppConfig
     transport: str
+    session_store: RoastSessionStore
     started_at_utc: datetime
 
 
@@ -120,6 +123,7 @@ def create_mcp_server(
         yield ServerContext(
             config=load_config(path=config_path),
             transport=transport,
+            session_store=RoastSessionStore(),
             started_at_utc=datetime.now(UTC),
         )
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -102,6 +102,29 @@ class RuntimeConfigSnapshot:
     auto_t0_detection_enabled: bool
 
 
+def build_server_context(
+    *,
+    config_path: str | Path | None = None,
+    transport: str = "stdio",
+) -> ServerContext:
+    """Build the MCP server lifecycle context from config and runtime transport.
+
+    Args:
+        config_path: Optional explicit config path.
+        transport: Actual MCP transport used by this server instance.
+
+    Returns:
+        The initialized server context used by the MCP lifespan.
+    """
+    config = load_config(path=config_path)
+    return ServerContext(
+        config=config,
+        transport=transport,
+        session_store=RoastSessionStore(default_log_dir=config.logging.log_dir / "roasts"),
+        started_at_utc=datetime.now(UTC),
+    )
+
+
 def create_mcp_server(
     config_path: str | Path | None = None,
     transport: str = "stdio",
@@ -120,12 +143,7 @@ def create_mcp_server(
     @asynccontextmanager
     async def server_lifespan(_: FastMCP) -> AsyncGenerator[ServerContext, None]:
         """Load typed config once for the MCP process lifetime."""
-        yield ServerContext(
-            config=load_config(path=config_path),
-            transport=transport,
-            session_store=RoastSessionStore(),
-            started_at_utc=datetime.now(UTC),
-        )
+        yield build_server_context(config_path=config_path, transport=transport)
 
     mcp = FastMCP(
         name="RoastPilot",

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -1,0 +1,290 @@
+"""Roast session lifecycle models for RoastPilot."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from threading import RLock
+from typing import Literal
+from uuid import uuid4
+
+RoastPhase = Literal[
+    "pre_roast",
+    "roasting",
+    "development",
+    "dropped",
+    "cooling",
+    "complete",
+    "fault",
+]
+
+RoastEventKind = Literal[
+    "beans_added",
+    "first_crack_detected",
+    "beans_dropped",
+    "cooling_started",
+    "cooling_stopped",
+    "fault",
+]
+EventPayloadValue = str | int | float | bool | None
+
+
+def _event_payload_default() -> dict[str, EventPayloadValue]:
+    """Return an empty typed event payload mapping."""
+    return {}
+
+
+def _event_timeline_default() -> list[RoastEvent]:
+    """Return an empty typed event timeline."""
+    return []
+
+
+def _telemetry_buffer_default() -> deque[TelemetrySample]:
+    """Return an empty typed telemetry buffer."""
+    return deque()
+
+
+@dataclass(frozen=True)
+class LogWriterReference:
+    """Reference to the append-only roast log target.
+
+    Attributes:
+        session_id: Session identifier that owns the log target.
+        log_dir: Base directory for this session's log exports.
+    """
+
+    session_id: str
+    log_dir: Path
+
+
+@dataclass(frozen=True)
+class RoastEvent:
+    """Recorded roast event placeholder for the authoritative session timeline.
+
+    Attributes:
+        kind: Event type.
+        recorded_at_utc: Wall-clock timestamp when the event was recorded.
+        monotonic_seconds: Monotonic seconds since session start.
+        payload: Optional structured event details.
+    """
+
+    kind: RoastEventKind
+    recorded_at_utc: datetime
+    monotonic_seconds: float
+    payload: dict[str, EventPayloadValue] = field(default_factory=_event_payload_default)
+
+
+@dataclass(frozen=True)
+class TelemetrySample:
+    """Normalized telemetry sample placeholder for later metrics work.
+
+    Attributes:
+        recorded_at_utc: Wall-clock timestamp for the sample.
+        monotonic_seconds: Monotonic seconds since session start.
+        bean_temp_c: Optional normalized bean temperature.
+        env_temp_c: Optional normalized environment temperature.
+        heat_level_percent: Optional heat control level.
+        fan_level_percent: Optional fan control level.
+        cooling_on: Optional cooling state.
+    """
+
+    recorded_at_utc: datetime
+    monotonic_seconds: float
+    bean_temp_c: float | None = None
+    env_temp_c: float | None = None
+    heat_level_percent: int | None = None
+    fan_level_percent: int | None = None
+    cooling_on: bool | None = None
+
+
+@dataclass
+class RoastSession:
+    """Authoritative in-process roast session state.
+
+    Attributes:
+        id: Stable unique session identifier.
+        created_at_utc: Wall-clock UTC creation time.
+        monotonic_start: Monotonic clock value captured when the session starts.
+        phase: Current roast phase.
+        event_timeline: Shared ordered event timeline for future runtime stories.
+        telemetry_buffer: Rolling telemetry sample buffer.
+        log_writer: Append-only log writer reference when available.
+        stopped_at_utc: Wall-clock UTC stop time once the session is stopped.
+        monotonic_stop: Monotonic clock value captured when the session stops.
+    """
+
+    id: str
+    created_at_utc: datetime
+    monotonic_start: float
+    phase: RoastPhase = "pre_roast"
+    event_timeline: list[RoastEvent] = field(default_factory=_event_timeline_default)
+    telemetry_buffer: deque[TelemetrySample] = field(default_factory=_telemetry_buffer_default)
+    log_writer: LogWriterReference | None = None
+    stopped_at_utc: datetime | None = None
+    monotonic_stop: float | None = None
+
+    @property
+    def active(self) -> bool:
+        """Return whether the session is still active."""
+        return self.monotonic_stop is None
+
+    def elapsed_monotonic_seconds(
+        self,
+        monotonic_now: Callable[[], float],
+    ) -> float:
+        """Return monotonic elapsed seconds for this session.
+
+        Args:
+            monotonic_now: Monotonic clock supplier for active sessions.
+
+        Returns:
+            Elapsed monotonic seconds from session start to now or stop time.
+        """
+        end_value = self.monotonic_stop if self.monotonic_stop is not None else monotonic_now()
+        return max(0.0, end_value - self.monotonic_start)
+
+    def stop(
+        self,
+        *,
+        utc_now: Callable[[], datetime],
+        monotonic_now: Callable[[], float],
+        phase: RoastPhase = "complete",
+    ) -> None:
+        """Stop the session cleanly if it is still active.
+
+        Args:
+            utc_now: Wall-clock UTC timestamp supplier.
+            monotonic_now: Monotonic clock supplier.
+            phase: Final phase to set when stopping the session.
+        """
+        if not self.active:
+            return
+        self.stopped_at_utc = utc_now()
+        self.monotonic_stop = monotonic_now()
+        self.phase = phase
+
+    def append_telemetry(
+        self,
+        sample: TelemetrySample,
+        *,
+        max_samples: int,
+    ) -> None:
+        """Append one sample and retain only the most recent entries.
+
+        Args:
+            sample: Telemetry sample to append.
+            max_samples: Maximum samples to keep in the rolling buffer.
+        """
+        self.telemetry_buffer.append(sample)
+        while len(self.telemetry_buffer) > max_samples:
+            self.telemetry_buffer.popleft()
+
+
+class SessionLifecycleError(RuntimeError):
+    """Raised when a roast session lifecycle transition is invalid."""
+
+
+class RoastSessionStore:
+    """Single-owner in-process roast session registry.
+
+    This keeps the active-session ownership explicit for Epic 2 while allowing
+    tests and later tool stories to resolve the latest session state cleanly.
+    """
+
+    def __init__(
+        self,
+        *,
+        telemetry_buffer_limit: int = 300,
+        utc_now: Callable[[], datetime] | None = None,
+        monotonic_now: Callable[[], float] | None = None,
+        session_id_factory: Callable[[], str] | None = None,
+        default_log_dir: Path = Path("./logs/roasts"),
+    ) -> None:
+        """Initialize the single-session store.
+
+        Args:
+            telemetry_buffer_limit: Maximum retained telemetry samples per session.
+            utc_now: Optional UTC timestamp supplier.
+            monotonic_now: Optional monotonic clock supplier.
+            session_id_factory: Optional session id supplier.
+            default_log_dir: Base directory for future log writer references.
+        """
+        import time
+
+        self._telemetry_buffer_limit = telemetry_buffer_limit
+        self._utc_now = utc_now or (lambda: datetime.now(UTC))
+        self._monotonic_now = monotonic_now or time.monotonic
+        self._session_id_factory = session_id_factory or _generate_session_id
+        self._default_log_dir = default_log_dir
+        self._lock = RLock()
+        self._active_session: RoastSession | None = None
+
+    def start_session(self) -> RoastSession:
+        """Start one new active session.
+
+        Returns:
+            The created active roast session.
+
+        Raises:
+            SessionLifecycleError: If an active session already exists.
+        """
+        with self._lock:
+            if self._active_session is not None and self._active_session.active:
+                raise SessionLifecycleError("An active roast session already exists.")
+
+            session_id = self._session_id_factory()
+            session = RoastSession(
+                id=session_id,
+                created_at_utc=self._utc_now(),
+                monotonic_start=self._monotonic_now(),
+                log_writer=LogWriterReference(
+                    session_id=session_id,
+                    log_dir=self._default_log_dir / session_id,
+                ),
+            )
+            self._active_session = session
+            return session
+
+    def stop_session(self, *, phase: RoastPhase = "complete") -> RoastSession | None:
+        """Stop the active session if one exists.
+
+        Args:
+            phase: Final phase to set on the stopped session.
+
+        Returns:
+            The active session after stopping, or `None` when no session exists.
+        """
+        with self._lock:
+            if self._active_session is None:
+                return None
+            self._active_session.stop(
+                utc_now=self._utc_now,
+                monotonic_now=self._monotonic_now,
+                phase=phase,
+            )
+            return self._active_session
+
+    def get_active_session(self) -> RoastSession | None:
+        """Return the current active session when present."""
+        with self._lock:
+            if self._active_session is None or not self._active_session.active:
+                return None
+            return self._active_session
+
+    def get_latest_session(self) -> RoastSession | None:
+        """Return the latest session whether active or stopped."""
+        with self._lock:
+            return self._active_session
+
+    @property
+    def telemetry_buffer_limit(self) -> int:
+        """Return the per-session telemetry retention limit."""
+        return self._telemetry_buffer_limit
+
+
+def _generate_session_id() -> str:
+    """Return a stable opaque session identifier."""
+    return uuid4().hex

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -230,7 +230,7 @@ class RoastSessionStore:
         self._session_id_factory = session_id_factory or _generate_session_id
         self._default_log_dir = default_log_dir
         self._lock = RLock()
-        self._active_session: RoastSession | None = None
+        self._latest_session: RoastSession | None = None
 
     def start_session(self) -> RoastSession:
         """Start one new active session.
@@ -242,7 +242,7 @@ class RoastSessionStore:
             SessionLifecycleError: If an active session already exists.
         """
         with self._lock:
-            if self._active_session is not None and self._active_session.active:
+            if self._latest_session is not None and self._latest_session.active:
                 raise SessionLifecycleError("An active roast session already exists.")
 
             session_id = self._session_id_factory()
@@ -255,7 +255,7 @@ class RoastSessionStore:
                     log_dir=self._default_log_dir / session_id,
                 ),
             )
-            self._active_session = session
+            self._latest_session = session
             return session
 
     def stop_session(self, *, phase: RoastPhase = "complete") -> RoastSession | None:
@@ -268,14 +268,14 @@ class RoastSessionStore:
             The active session after stopping, or `None` when no active session exists.
         """
         with self._lock:
-            if self._active_session is None or not self._active_session.active:
+            if self._latest_session is None or not self._latest_session.active:
                 return None
-            self._active_session.stop(
+            self._latest_session.stop(
                 utc_now=self._utc_now,
                 monotonic_now=self._monotonic_now,
                 phase=phase,
             )
-            return self._active_session
+            return self._latest_session
 
     def append_telemetry(
         self,
@@ -292,7 +292,7 @@ class RoastSessionStore:
             SessionLifecycleError: If the session is not the latest session in this store.
         """
         with self._lock:
-            if self._active_session is not session:
+            if self._latest_session is not session:
                 raise SessionLifecycleError("Telemetry can only be appended to the latest session.")
             _append_telemetry_with_limit(
                 session,
@@ -303,14 +303,14 @@ class RoastSessionStore:
     def get_active_session(self) -> RoastSession | None:
         """Return the current active session when present."""
         with self._lock:
-            if self._active_session is None or not self._active_session.active:
+            if self._latest_session is None or not self._latest_session.active:
                 return None
-            return self._active_session
+            return self._latest_session
 
     def get_latest_session(self) -> RoastSession | None:
         """Return the latest session whether active or stopped."""
         with self._lock:
-            return self._active_session
+            return self._latest_session
 
     @property
     def telemetry_buffer_limit(self) -> int:

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -47,6 +47,20 @@ def _telemetry_buffer_default() -> deque[TelemetrySample]:
     return deque()
 
 
+def _append_telemetry_with_limit(
+    session: RoastSession,
+    sample: TelemetrySample,
+    *,
+    max_samples: int,
+) -> None:
+    """Append telemetry to one session with an explicit retention limit."""
+    if max_samples < 0:
+        raise ValueError("max_samples must be >= 0.")
+    session.telemetry_buffer.append(sample)
+    while len(session.telemetry_buffer) > max_samples:
+        session.telemetry_buffer.popleft()
+
+
 @dataclass(frozen=True)
 class LogWriterReference:
     """Reference to the append-only roast log target.
@@ -170,27 +184,6 @@ class RoastSession:
         self.monotonic_stop = monotonic_now()
         self.phase = phase
 
-    def append_telemetry(
-        self,
-        sample: TelemetrySample,
-        *,
-        max_samples: int,
-    ) -> None:
-        """Append one sample and retain only the most recent entries.
-
-        Args:
-            sample: Telemetry sample to append.
-            max_samples: Maximum samples to keep in the rolling buffer.
-
-        Raises:
-            ValueError: If `max_samples` is negative.
-        """
-        if max_samples < 0:
-            raise ValueError("max_samples must be >= 0.")
-        self.telemetry_buffer.append(sample)
-        while len(self.telemetry_buffer) > max_samples:
-            self.telemetry_buffer.popleft()
-
 
 class SessionLifecycleError(RuntimeError):
     """Raised when a roast session lifecycle transition is invalid."""
@@ -272,10 +265,10 @@ class RoastSessionStore:
             phase: Final phase to set on the stopped session.
 
         Returns:
-            The active session after stopping, or `None` when no session exists.
+            The active session after stopping, or `None` when no active session exists.
         """
         with self._lock:
-            if self._active_session is None:
+            if self._active_session is None or not self._active_session.active:
                 return None
             self._active_session.stop(
                 utc_now=self._utc_now,
@@ -283,6 +276,29 @@ class RoastSessionStore:
                 phase=phase,
             )
             return self._active_session
+
+    def append_telemetry(
+        self,
+        session: RoastSession,
+        sample: TelemetrySample,
+    ) -> None:
+        """Append telemetry under store-owned locking and retention policy.
+
+        Args:
+            session: Session to mutate.
+            sample: Telemetry sample to append.
+
+        Raises:
+            SessionLifecycleError: If the session is not the latest session in this store.
+        """
+        with self._lock:
+            if self._active_session is not session:
+                raise SessionLifecycleError("Telemetry can only be appended to the latest session.")
+            _append_telemetry_with_limit(
+                session,
+                sample,
+                max_samples=self._telemetry_buffer_limit,
+            )
 
     def get_active_session(self) -> RoastSession | None:
         """Return the current active session when present."""

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -104,6 +104,10 @@ class TelemetrySample:
 class RoastSession:
     """Authoritative in-process roast session state.
 
+    This object is mutable and not thread-safe by itself. Runtime code should
+    mutate it through `RoastSessionStore` methods so store-owned locking stays
+    authoritative as concurrent MCP tool handlers are added.
+
     Attributes:
         id: Stable unique session identifier.
         created_at_utc: Wall-clock UTC creation time.
@@ -177,7 +181,12 @@ class RoastSession:
         Args:
             sample: Telemetry sample to append.
             max_samples: Maximum samples to keep in the rolling buffer.
+
+        Raises:
+            ValueError: If `max_samples` is negative.
         """
+        if max_samples < 0:
+            raise ValueError("max_samples must be >= 0.")
         self.telemetry_buffer.append(sample)
         while len(self.telemetry_buffer) > max_samples:
             self.telemetry_buffer.popleft()
@@ -192,6 +201,11 @@ class RoastSessionStore:
 
     This keeps the active-session ownership explicit for Epic 2 while allowing
     tests and later tool stories to resolve the latest session state cleanly.
+
+    `RoastSession` instances returned from this store are not independently
+    thread-safe. Callers should treat this store as the authoritative mutation
+    boundary and use store-owned methods for lifecycle and future event or
+    telemetry writes.
     """
 
     def __init__(
@@ -213,6 +227,9 @@ class RoastSessionStore:
             default_log_dir: Base directory for future log writer references.
         """
         import time
+
+        if telemetry_buffer_limit < 0:
+            raise ValueError("telemetry_buffer_limit must be >= 0.")
 
         self._telemetry_buffer_limit = telemetry_buffer_limit
         self._utc_now = utc_now or (lambda: datetime.now(UTC))

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -13,6 +13,7 @@ from mcp.client.stdio import stdio_client
 
 from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.cli import build_parser, main
+from coffee_roaster_mcp.mcp_server import build_server_context
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 _T = TypeVar("_T")
@@ -105,6 +106,17 @@ async def _assert_manual_mode_bootstrap_safe(tmp_path: Path) -> None:
         assert server_info.structuredContent is not None
         assert server_info.structuredContent["first_crack_mode"] == "manual"
         assert server_info.structuredContent["bootstrap_safe"] is True
+
+
+def test_stdio_server_uses_configured_log_root_for_session_store(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("logging:\n  log_dir: ./custom-logs\n", encoding="utf-8")
+
+    server_context = build_server_context(config_path=config_path)
+    session = server_context.session_store.start_session()
+
+    assert session.log_writer is not None
+    assert session.log_writer.log_dir == Path("custom-logs/roasts") / session.id
 
 
 def _build_clean_server_env(overrides: dict[str, str] | None = None) -> dict[str, str]:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -63,7 +63,7 @@ def test_start_session_rejects_second_active_session() -> None:
         store.start_session()
 
 
-def test_stop_session_marks_session_complete_and_clears_active_reference() -> None:
+def test_stop_session_marks_session_complete_and_clears_active_session() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(
         utc_now=clock.utc_now,
@@ -91,6 +91,26 @@ def test_stop_session_is_clean_when_no_session_exists() -> None:
     assert store.stop_session() is None
 
 
+def test_negative_telemetry_buffer_limit_is_rejected() -> None:
+    with pytest.raises(ValueError, match="telemetry_buffer_limit"):
+        RoastSessionStore(telemetry_buffer_limit=-1)
+
+
+def test_session_append_telemetry_rejects_negative_max_samples() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    with pytest.raises(ValueError, match="max_samples"):
+        session.append_telemetry(
+            TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=1.0),
+            max_samples=-1,
+        )
+
+
 def test_session_telemetry_buffer_retains_only_recent_samples() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(
@@ -116,3 +136,29 @@ def test_session_telemetry_buffer_retains_only_recent_samples() -> None:
     samples = list(session.telemetry_buffer)
     assert len(samples) == 2
     assert [sample.monotonic_seconds for sample in samples] == [2.0, 3.0]
+
+
+def test_start_session_allows_new_session_after_previous_stop() -> None:
+    clock = ClockHarness()
+    issued_ids = iter(["session-001", "session-002"])
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        session_id_factory=lambda: next(issued_ids),
+    )
+
+    first_session = store.start_session()
+    clock.utc_value = datetime(2026, 5, 4, 12, 5, tzinfo=UTC)
+    clock.monotonic_value = 120.0
+    store.stop_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 6, tzinfo=UTC)
+    clock.monotonic_value = 121.0
+    second_session = store.start_session()
+
+    assert first_session.id == "session-001"
+    assert first_session.active is False
+    assert second_session.id == "session-002"
+    assert second_session.active is True
+    assert store.get_active_session() is second_session
+    assert store.get_latest_session() is second_session

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -96,19 +96,16 @@ def test_negative_telemetry_buffer_limit_is_rejected() -> None:
         RoastSessionStore(telemetry_buffer_limit=-1)
 
 
-def test_session_append_telemetry_rejects_negative_max_samples() -> None:
+def test_stop_session_returns_none_after_session_already_stopped() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(
         utc_now=clock.utc_now,
         monotonic_now=clock.monotonic_now,
     )
-    session = store.start_session()
+    store.start_session()
+    store.stop_session()
 
-    with pytest.raises(ValueError, match="max_samples"):
-        session.append_telemetry(
-            TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=1.0),
-            max_samples=-1,
-        )
+    assert store.stop_session() is None
 
 
 def test_session_telemetry_buffer_retains_only_recent_samples() -> None:
@@ -120,17 +117,17 @@ def test_session_telemetry_buffer_retains_only_recent_samples() -> None:
     )
     session = store.start_session()
 
-    session.append_telemetry(
+    store.append_telemetry(
+        session,
         TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=1.0, bean_temp_c=100.0),
-        max_samples=store.telemetry_buffer_limit,
     )
-    session.append_telemetry(
+    store.append_telemetry(
+        session,
         TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=2.0, bean_temp_c=101.0),
-        max_samples=store.telemetry_buffer_limit,
     )
-    session.append_telemetry(
+    store.append_telemetry(
+        session,
         TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=3.0, bean_temp_c=102.0),
-        max_samples=store.telemetry_buffer_limit,
     )
 
     samples = list(session.telemetry_buffer)
@@ -162,3 +159,29 @@ def test_start_session_allows_new_session_after_previous_stop() -> None:
     assert second_session.active is True
     assert store.get_active_session() is second_session
     assert store.get_latest_session() is second_session
+
+
+def test_store_append_telemetry_rejects_non_latest_session() -> None:
+    clock = ClockHarness()
+    issued_ids = iter(["session-001", "session-002"])
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        session_id_factory=lambda: next(issued_ids),
+    )
+
+    first_session = store.start_session()
+    store.stop_session()
+    second_session = store.start_session()
+
+    with pytest.raises(SessionLifecycleError, match="latest session"):
+        store.append_telemetry(
+            first_session,
+            TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=1.0),
+        )
+
+    store.append_telemetry(
+        second_session,
+        TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=2.0),
+    )
+    assert [sample.monotonic_seconds for sample in second_session.telemetry_buffer] == [2.0]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from coffee_roaster_mcp.session import (
+    RoastSessionStore,
+    SessionLifecycleError,
+    TelemetrySample,
+)
+
+
+class ClockHarness:
+    """Deterministic wall-clock and monotonic clock supplier for session tests."""
+
+    def __init__(self) -> None:
+        self.utc_value = datetime(2026, 5, 4, 12, 0, tzinfo=UTC)
+        self.monotonic_value = 100.0
+
+    def utc_now(self) -> datetime:
+        return self.utc_value
+
+    def monotonic_now(self) -> float:
+        return self.monotonic_value
+
+
+def test_start_session_creates_active_roast_session() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        session_id_factory=lambda: "session-001",
+        default_log_dir=Path("/tmp/roasts"),
+    )
+
+    session = store.start_session()
+
+    assert session.id == "session-001"
+    assert session.created_at_utc == clock.utc_value
+    assert session.monotonic_start == 100.0
+    assert session.phase == "pre_roast"
+    assert session.active is True
+    assert session.event_timeline == []
+    assert list(session.telemetry_buffer) == []
+    assert session.log_writer is not None
+    assert session.log_writer.session_id == "session-001"
+    assert session.log_writer.log_dir == Path("/tmp/roasts/session-001")
+    assert store.get_active_session() is session
+    assert store.get_latest_session() is session
+
+
+def test_start_session_rejects_second_active_session() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    store.start_session()
+
+    with pytest.raises(SessionLifecycleError, match="already exists"):
+        store.start_session()
+
+
+def test_stop_session_marks_session_complete_and_clears_active_reference() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 7, tzinfo=UTC)
+    clock.monotonic_value = 142.5
+    stopped = store.stop_session()
+
+    assert stopped is session
+    assert session.active is False
+    assert session.phase == "complete"
+    assert session.stopped_at_utc == clock.utc_value
+    assert session.monotonic_stop == 142.5
+    assert session.elapsed_monotonic_seconds(clock.monotonic_now) == 42.5
+    assert store.get_active_session() is None
+    assert store.get_latest_session() is session
+
+
+def test_stop_session_is_clean_when_no_session_exists() -> None:
+    store = RoastSessionStore()
+
+    assert store.stop_session() is None
+
+
+def test_session_telemetry_buffer_retains_only_recent_samples() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        telemetry_buffer_limit=2,
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    session.append_telemetry(
+        TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=1.0, bean_temp_c=100.0),
+        max_samples=store.telemetry_buffer_limit,
+    )
+    session.append_telemetry(
+        TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=2.0, bean_temp_c=101.0),
+        max_samples=store.telemetry_buffer_limit,
+    )
+    session.append_telemetry(
+        TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=3.0, bean_temp_c=102.0),
+        max_samples=store.telemetry_buffer_limit,
+    )
+
+    samples = list(session.telemetry_buffer)
+    assert len(samples) == 2
+    assert [sample.monotonic_seconds for sample in samples] == [2.0, 3.0]


### PR DESCRIPTION
## Summary
- add the authoritative RoastSession core and single-owner RoastSessionStore
- wire the MCP server lifespan to own the in-process session store
- add unit coverage for session creation, stop behavior, single-owner enforcement, and telemetry retention
- update durable state and AGENTS.md to mark E2-S2 complete and move active context to E2-S3

## Why
Story #17 requires one authoritative RoastSession lifecycle before event-timeline and tool stories can land cleanly. This change keeps the scope on session ownership, timing, retention, and stop behavior without prematurely wiring the full MCP control surface.

## Validation
- ./.venv/bin/python -m pytest
- ./.venv/bin/python -m ruff check .
- ./.venv/bin/python -m ruff format --check .
- ./.venv/bin/python -m pyright

## Story
- closes #17