### PR TITLE
[codex] Add roast event timeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ src/coffee_roaster_mcp/
   cli.py          - console entrypoint
   config.py       - typed configuration loading from defaults, YAML, and env vars
   mcp_server.py   - FastMCP stdio entrypoint and bootstrap-safe tools
-  session.py      - authoritative roast session lifecycle and active-session owner
+  session.py      - authoritative roast session lifecycle, event timeline, and active-session owner
 tests/
   test_package.py - package and CLI smoke coverage
   test_config.py  - config defaults, YAML, env override, and validation coverage

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E2-S3`
-- Current target: Implement the core event timeline on the authoritative RoastSession
+- Active story: `E2-S4`
+- Current target: Implement the first roast-session MCP tools on top of the authoritative session core
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -33,6 +33,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - First-crack mode defaults to `disabled` so mock install and registry smoke tests do not require audio hardware or model download.
 - `E2-S1` keeps the initial MCP tool surface bootstrap-safe with `get_server_info` and `get_runtime_config`. Roast-session lifecycle and roast-control tools remain later Epic 2 work.
 - `E2-S2` uses one in-process `RoastSessionStore` with at most one active `RoastSession` at a time. Session state now owns monotonic timing, phase, event timeline storage, telemetry retention, and log-writer references before tool wiring lands.
+- `E2-S3` keeps event writes behind `RoastSessionStore.record_event(...)`. The session timeline now records deterministic append order, authoritative UTC plus monotonic timestamps for core roast events, and idempotent singleton handling for beans added, first crack, bean drop, and cooling transitions.
 - ONNX INT8 is the default real model backend.
 - ONNX FP32 is supported by config.
 - The `coffee-first-crack-detection` repo remains the source of truth for training, ONNX export, Hugging Face sync, model cards, and dataset cards.
@@ -108,7 +109,7 @@ Goal: implement one authoritative roast session runtime and MCP tool surface.
 - [x] `E2-S2` Implement `RoastSession` lifecycle.
   - Done when sessions have id, monotonic clock, phase, event timeline, telemetry buffer, and log writer references.
 
-- [ ] `E2-S3` Implement core event timeline.
+- [x] `E2-S3` Implement core event timeline.
   - Done when `beans_added`, `first_crack_detected`, `beans_dropped`, `cooling_started`, `cooling_stopped`, and `fault` can be recorded with timestamps.
 
 - [ ] `E2-S4` Implement core MCP tools.
@@ -361,6 +362,7 @@ After completing a story:
 - Epic 2 planning now has a local crosswalk for the old `coffee-roasting` POC. It identifies the old stdio entrypoint, tool registration, session manager, and roast tracker as the main implementation references while explicitly rejecting the old split-server and orchestration architecture.
 - E2-S1 added the first local stdio FastMCP entrypoint, `coffee-roaster-mcp serve`, and a bootstrap-safe runtime tool surface with `get_server_info` and `get_runtime_config`. It keeps roast-session lifecycle and roast-control tools out of the entrypoint story.
 - E2-S2 added `session.py` with an authoritative `RoastSession` model and `RoastSessionStore`. Session lifecycle now has stable ids, monotonic start/stop timing, explicit phase, event-timeline storage, telemetry-buffer retention, log-writer references, and clean single-owner start/stop behavior.
+- E2-S3 extended `session.py` with store-owned event recording. The authoritative session now records `beans_added`, `first_crack_detected`, `beans_dropped`, `cooling_started`, `cooling_stopped`, and `fault` in deterministic timeline order while also keeping authoritative UTC and monotonic timestamps for core roast milestones.
 - Validation run for E1-S8:
   - Reviewed issue #15 acceptance criteria against `AGENTS.md`, the active epic, and the overall plan.
   - Added `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, and `.claude/skills/release-registry` using the existing repo-local skill format.
@@ -422,6 +424,14 @@ After completing a story:
   - Wired the MCP server lifespan to own one authoritative `RoastSessionStore` for later tool stories.
   - Added `tests/test_session.py` covering session creation, single-owner enforcement, clean stop semantics, and rolling telemetry retention.
   - Ran `./.venv/bin/python -m pytest`: 24 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E2-S3:
+  - Extended `src/coffee_roaster_mcp/session.py` with authoritative per-event timestamp fields and store-owned `record_event(...)`.
+  - Kept singleton event writes idempotent for `beans_added`, `first_crack_detected`, `beans_dropped`, `cooling_started`, and `cooling_stopped` while allowing `fault` timeline rows.
+  - Added `tests/test_session.py` coverage for deterministic event ordering, authoritative timestamp updates, singleton idempotency, and rejecting stopped-session event writes.
+  - Ran `./.venv/bin/python -m pytest`: 32 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,9 +22,9 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E2-S2 is complete. RoastPilot now has an authoritative in-process RoastSession lifecycle with one active-session owner, monotonic timing, telemetry retention, and log-writer references ready for later runtime stories.
+E2-S3 is complete. RoastPilot now records the core roast event timeline inside the authoritative in-process RoastSession with deterministic ordering, authoritative per-event timestamps, and store-owned idempotent singleton event handling.
 
-The next story is E2-S3: implement the core event timeline.
+The next story is E2-S4: implement the core MCP tools.
 
 The first implementation milestone remains a thin mock vertical slice: install the package, start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -326,8 +326,7 @@ class RoastSessionStore:
             SessionLifecycleError: If the session is not the latest session in this store.
         """
         with self._lock:
-            if self._latest_session is not session:
-                raise SessionLifecycleError("Telemetry can only be appended to the latest session.")
+            self._assert_latest_active_session(session)
             _append_telemetry_with_limit(
                 session,
                 sample,

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -1,4 +1,4 @@
-"""Roast session lifecycle models for RoastPilot."""
+"""Roast session lifecycle and event-timeline models for RoastPilot."""
 
 from __future__ import annotations
 
@@ -30,6 +30,16 @@ RoastEventKind = Literal[
     "fault",
 ]
 EventPayloadValue = str | int | float | bool | None
+
+_SINGLETON_EVENT_KINDS: frozenset[RoastEventKind] = frozenset(
+    {
+        "beans_added",
+        "first_crack_detected",
+        "beans_dropped",
+        "cooling_started",
+        "cooling_stopped",
+    }
+)
 
 
 def _event_payload_default() -> dict[str, EventPayloadValue]:
@@ -127,6 +137,18 @@ class RoastSession:
         created_at_utc: Wall-clock UTC creation time.
         monotonic_start: Monotonic clock value captured when the session starts.
         phase: Current roast phase.
+        beans_added_at_utc: Wall-clock UTC timestamp for the authoritative T0 event.
+        beans_added_monotonic_seconds: Monotonic elapsed seconds for T0.
+        first_crack_at_utc: Wall-clock UTC timestamp for the first-crack event.
+        first_crack_monotonic_seconds: Monotonic elapsed seconds for first crack.
+        beans_dropped_at_utc: Wall-clock UTC timestamp for bean drop.
+        beans_dropped_monotonic_seconds: Monotonic elapsed seconds for bean drop.
+        cooling_started_at_utc: Wall-clock UTC timestamp for cooling start.
+        cooling_started_monotonic_seconds: Monotonic elapsed seconds for cooling start.
+        cooling_stopped_at_utc: Wall-clock UTC timestamp for cooling stop.
+        cooling_stopped_monotonic_seconds: Monotonic elapsed seconds for cooling stop.
+        faulted_at_utc: Wall-clock UTC timestamp for the first recorded fault.
+        faulted_monotonic_seconds: Monotonic elapsed seconds for the first fault.
         event_timeline: Shared ordered event timeline for future runtime stories.
         telemetry_buffer: Rolling telemetry sample buffer.
         log_writer: Append-only log writer reference when available.
@@ -138,6 +160,18 @@ class RoastSession:
     created_at_utc: datetime
     monotonic_start: float
     phase: RoastPhase = "pre_roast"
+    beans_added_at_utc: datetime | None = None
+    beans_added_monotonic_seconds: float | None = None
+    first_crack_at_utc: datetime | None = None
+    first_crack_monotonic_seconds: float | None = None
+    beans_dropped_at_utc: datetime | None = None
+    beans_dropped_monotonic_seconds: float | None = None
+    cooling_started_at_utc: datetime | None = None
+    cooling_started_monotonic_seconds: float | None = None
+    cooling_stopped_at_utc: datetime | None = None
+    cooling_stopped_monotonic_seconds: float | None = None
+    faulted_at_utc: datetime | None = None
+    faulted_monotonic_seconds: float | None = None
     event_timeline: list[RoastEvent] = field(default_factory=_event_timeline_default)
     telemetry_buffer: deque[TelemetrySample] = field(default_factory=_telemetry_buffer_default)
     log_writer: LogWriterReference | None = None
@@ -300,6 +334,47 @@ class RoastSessionStore:
                 max_samples=self._telemetry_buffer_limit,
             )
 
+    def record_event(
+        self,
+        session: RoastSession,
+        kind: RoastEventKind,
+        *,
+        payload: dict[str, EventPayloadValue] | None = None,
+    ) -> RoastEvent:
+        """Record one authoritative session event under store-owned locking.
+
+        Args:
+            session: Session to mutate.
+            kind: Event kind to record.
+            payload: Optional structured event details.
+
+        Returns:
+            The recorded event. For singleton event kinds, repeated calls return
+            the already-recorded event instead of appending a duplicate row.
+
+        Raises:
+            SessionLifecycleError: If the session is not the latest active
+                session in this store.
+        """
+        with self._lock:
+            self._assert_latest_active_session(session)
+
+            existing_event = self._get_existing_singleton_event(session, kind)
+            if existing_event is not None:
+                return existing_event
+
+            recorded_at_utc = self._utc_now()
+            monotonic_seconds = session.elapsed_monotonic_seconds(self._monotonic_now)
+            event = RoastEvent(
+                kind=kind,
+                recorded_at_utc=recorded_at_utc,
+                monotonic_seconds=monotonic_seconds,
+                payload={} if payload is None else dict(payload),
+            )
+            session.event_timeline.append(event)
+            _apply_event_timestamp(session, event)
+            return event
+
     def get_active_session(self) -> RoastSession | None:
         """Return the current active session when present."""
         with self._lock:
@@ -316,6 +391,53 @@ class RoastSessionStore:
     def telemetry_buffer_limit(self) -> int:
         """Return the per-session telemetry retention limit."""
         return self._telemetry_buffer_limit
+
+    def _assert_latest_active_session(self, session: RoastSession) -> None:
+        """Validate that one session is the current mutable active session."""
+        if self._latest_session is not session:
+            raise SessionLifecycleError("Only the latest session can be mutated.")
+        if not session.active:
+            raise SessionLifecycleError("Stopped sessions cannot be mutated.")
+
+    def _get_existing_singleton_event(
+        self,
+        session: RoastSession,
+        kind: RoastEventKind,
+    ) -> RoastEvent | None:
+        """Return an existing singleton event when this kind is idempotent."""
+        if kind not in _SINGLETON_EVENT_KINDS:
+            return None
+        for event in session.event_timeline:
+            if event.kind == kind:
+                return event
+        return None
+
+
+def _apply_event_timestamp(session: RoastSession, event: RoastEvent) -> None:
+    """Update authoritative event timestamp fields from one timeline event."""
+    if event.kind == "beans_added":
+        session.beans_added_at_utc = event.recorded_at_utc
+        session.beans_added_monotonic_seconds = event.monotonic_seconds
+        return
+    if event.kind == "first_crack_detected":
+        session.first_crack_at_utc = event.recorded_at_utc
+        session.first_crack_monotonic_seconds = event.monotonic_seconds
+        return
+    if event.kind == "beans_dropped":
+        session.beans_dropped_at_utc = event.recorded_at_utc
+        session.beans_dropped_monotonic_seconds = event.monotonic_seconds
+        return
+    if event.kind == "cooling_started":
+        session.cooling_started_at_utc = event.recorded_at_utc
+        session.cooling_started_monotonic_seconds = event.monotonic_seconds
+        return
+    if event.kind == "cooling_stopped":
+        session.cooling_stopped_at_utc = event.recorded_at_utc
+        session.cooling_stopped_monotonic_seconds = event.monotonic_seconds
+        return
+    if event.kind == "fault" and session.faulted_at_utc is None:
+        session.faulted_at_utc = event.recorded_at_utc
+        session.faulted_monotonic_seconds = event.monotonic_seconds
 
 
 def _generate_session_id() -> str:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -191,6 +191,22 @@ def test_store_append_telemetry_rejects_non_latest_session() -> None:
     assert [sample.monotonic_seconds for sample in second_session.telemetry_buffer] == [2.0]
 
 
+def test_store_append_telemetry_rejects_stopped_session() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+    store.stop_session()
+
+    with pytest.raises(SessionLifecycleError, match="Stopped sessions"):
+        store.append_telemetry(
+            session,
+            TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=1.0),
+        )
+
+
 def test_record_event_updates_timeline_order_and_authoritative_timestamps() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(
@@ -284,3 +300,27 @@ def test_record_event_rejects_stopped_session() -> None:
 
     with pytest.raises(SessionLifecycleError, match="Stopped sessions"):
         store.record_event(session, "beans_added")
+
+
+def test_record_event_preserves_first_fault_timestamp_across_multiple_faults() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    clock.monotonic_value = 105.0
+    first_fault = store.record_event(session, "fault", payload={"code": "sensor-timeout"})
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 2, tzinfo=UTC)
+    clock.monotonic_value = 115.0
+    second_fault = store.record_event(session, "fault", payload={"code": "driver-disconnect"})
+
+    assert [event.kind for event in session.event_timeline] == ["fault", "fault"]
+    assert first_fault is not second_fault
+    assert session.faulted_at_utc == datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    assert session.faulted_monotonic_seconds == 5.0
+    assert session.event_timeline[0].payload["code"] == "sensor-timeout"
+    assert session.event_timeline[1].payload["code"] == "driver-disconnect"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from coffee_roaster_mcp.session import (
+    RoastEventKind,
     RoastSessionStore,
     SessionLifecycleError,
     TelemetrySample,
@@ -42,6 +43,9 @@ def test_start_session_creates_active_roast_session() -> None:
     assert session.monotonic_start == 100.0
     assert session.phase == "pre_roast"
     assert session.active is True
+    assert session.beans_added_at_utc is None
+    assert session.first_crack_at_utc is None
+    assert session.beans_dropped_at_utc is None
     assert session.event_timeline == []
     assert list(session.telemetry_buffer) == []
     assert session.log_writer is not None
@@ -185,3 +189,98 @@ def test_store_append_telemetry_rejects_non_latest_session() -> None:
         TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=2.0),
     )
     assert [sample.monotonic_seconds for sample in second_session.telemetry_buffer] == [2.0]
+
+
+def test_record_event_updates_timeline_order_and_authoritative_timestamps() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    event_steps: list[tuple[RoastEventKind, datetime, float]] = [
+        ("beans_added", datetime(2026, 5, 4, 12, 1, tzinfo=UTC), 105.0),
+        ("first_crack_detected", datetime(2026, 5, 4, 12, 7, tzinfo=UTC), 140.0),
+        ("beans_dropped", datetime(2026, 5, 4, 12, 8, tzinfo=UTC), 150.0),
+        ("cooling_started", datetime(2026, 5, 4, 12, 8, 30, tzinfo=UTC), 160.0),
+        ("cooling_stopped", datetime(2026, 5, 4, 12, 11, tzinfo=UTC), 190.0),
+        ("fault", datetime(2026, 5, 4, 12, 12, tzinfo=UTC), 200.0),
+    ]
+
+    for kind, utc_value, monotonic_value in event_steps:
+        clock.utc_value = utc_value
+        clock.monotonic_value = monotonic_value
+        store.record_event(session, kind, payload={"source": kind})
+
+    assert [event.kind for event in session.event_timeline] == [
+        "beans_added",
+        "first_crack_detected",
+        "beans_dropped",
+        "cooling_started",
+        "cooling_stopped",
+        "fault",
+    ]
+    assert [event.monotonic_seconds for event in session.event_timeline] == [
+        5.0,
+        40.0,
+        50.0,
+        60.0,
+        90.0,
+        100.0,
+    ]
+    assert session.beans_added_at_utc == datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    assert session.beans_added_monotonic_seconds == 5.0
+    assert session.first_crack_at_utc == datetime(2026, 5, 4, 12, 7, tzinfo=UTC)
+    assert session.first_crack_monotonic_seconds == 40.0
+    assert session.beans_dropped_at_utc == datetime(2026, 5, 4, 12, 8, tzinfo=UTC)
+    assert session.beans_dropped_monotonic_seconds == 50.0
+    assert session.cooling_started_at_utc == datetime(2026, 5, 4, 12, 8, 30, tzinfo=UTC)
+    assert session.cooling_started_monotonic_seconds == 60.0
+    assert session.cooling_stopped_at_utc == datetime(2026, 5, 4, 12, 11, tzinfo=UTC)
+    assert session.cooling_stopped_monotonic_seconds == 90.0
+    assert session.faulted_at_utc == datetime(2026, 5, 4, 12, 12, tzinfo=UTC)
+    assert session.faulted_monotonic_seconds == 100.0
+    assert [event.payload["source"] for event in session.event_timeline] == [
+        "beans_added",
+        "first_crack_detected",
+        "beans_dropped",
+        "cooling_started",
+        "cooling_stopped",
+        "fault",
+    ]
+
+
+def test_record_event_is_idempotent_for_singleton_event_kinds() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    clock.monotonic_value = 105.0
+    first_event = store.record_event(session, "beans_added")
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 2, tzinfo=UTC)
+    clock.monotonic_value = 115.0
+    second_event = store.record_event(session, "beans_added")
+
+    assert second_event is first_event
+    assert len(session.event_timeline) == 1
+    assert session.beans_added_at_utc == datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    assert session.beans_added_monotonic_seconds == 5.0
+
+
+def test_record_event_rejects_stopped_session() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+    store.stop_session()
+
+    with pytest.raises(SessionLifecycleError, match="Stopped sessions"):
+        store.record_event(session, "beans_added")


### PR DESCRIPTION
## Summary
- add store-owned roast event recording to the authoritative session runtime
- keep singleton roast events idempotent while preserving deterministic timeline ordering and timestamps
- update durable state to mark E2-S3 complete and move active context to E2-S4

## Why
Story #18 requires the core roast event timeline before MCP tools can safely mutate roast state. This change keeps event writes behind RoastSessionStore, preserves one-session ownership from E2-S2, and makes the session itself the authoritative holder of key roast milestone timestamps.

## Validation
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`

## Story
- closes #18