### PR TITLE
[codex] Add core MCP tools

### DIFF
--- a/.claude/skills/mock-roast/SKILL.md
+++ b/.claude/skills/mock-roast/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mock-roast
-description: Validate the current mock-first RoastPilot path without roaster hardware or model download. Use when checking bootstrap defaults now, and extend it later when the MCP runtime lands.
+description: Validate the current mock-first RoastPilot path without roaster hardware or model download. Use for bootstrap checks now and for the early MCP tool flow while the full vertical slice is still landing.
 ---
 
 # Mock Roast - RoastPilot
@@ -10,8 +10,8 @@ Use this skill for the mock-first local workflow.
 ## Current Scope
 
 - `E2-S1` provides a real stdio MCP server entrypoint.
-- A full mock roast through MCP tools is not implemented until later runtime stories.
-- This workflow validates the current mock-safe bootstrap path without claiming a real roast session exists yet.
+- `E2-S4` now provides the first roast-session MCP tool surface on the mock path.
+- This workflow validates the mock-safe bootstrap path and the early in-process tool flow without claiming the final export/logging slice is done yet.
 
 ## Current Validation
 
@@ -36,17 +36,35 @@ mock disabled int8
 - First-crack detection stays `disabled` by default.
 - Default precision stays `int8`.
 - Local bootstrap does not require roaster hardware, microphone access, or model download.
+- The MCP server now exposes the first session-control tool surface for the mock path.
 
 ## Do Not Claim Yet
 
-- Do not claim a start-to-export mock roast before `E2-S7` and `E7-S1`.
+- Do not claim a fully exported mock roast before `E2-S7`, `E5`, and `E7-S1`.
 - Do not add model download, model export, or Hugging Face sync steps here. Those stay in `coffee-first-crack-detection`.
+
+## Current MCP Tool Flow
+
+The current mock-path tools are:
+
+- `start_roast_session`
+- `get_roast_state`
+- `set_heat`
+- `set_fan`
+- `mark_beans_added`
+- `mark_first_crack`
+- `drop_beans`
+- `start_cooling`
+- `stop_cooling`
+- `export_roast_log`
+- `emergency_stop`
+
+`export_roast_log` currently returns the planned export manifest only. The real JSONL, CSV, and summary writers land in Epic 5.
 
 ## Extend Later
 
 Once the MCP runtime exists, extend this workflow with:
 
-- mock roast session start
-- state polling
-- manual first-crack injection if needed
-- roast log export smoke checks
+- full mock roast start-to-export smoke checks
+- log file content validation
+- MCP client fixture reuse across runtime stories

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The default local path is intentionally mock-safe:
 - no microphone required
 - no model download required
 
-`E2-S1` now provides a real local stdio MCP server entrypoint with a minimal bootstrap-safe tool list. Later Epic 2 stories still need to add the authoritative roast-session lifecycle and the roast-control tool surface.
+RoastPilot now provides a real local stdio MCP server entrypoint plus the first mock-safe roast-session tool surface. Later Epic 2 stories still need to refine phase transitions, emergency-stop semantics, and the real log writers.
 
 ### Start The Local MCP Server
 
@@ -90,10 +90,23 @@ The default local path is intentionally mock-safe:
 coffee-roaster-mcp serve
 ```
 
-The current `E2-S1` tool list is intentionally narrow:
+The current MCP tool surface includes:
 
 - `get_server_info`
 - `get_runtime_config`
+- `start_roast_session`
+- `get_roast_state`
+- `set_heat`
+- `set_fan`
+- `mark_beans_added`
+- `mark_first_crack`
+- `drop_beans`
+- `start_cooling`
+- `stop_cooling`
+- `export_roast_log`
+- `emergency_stop`
+
+`export_roast_log` currently returns the planned export manifest only. The real JSONL, CSV, and summary writers land in Epic 5.
 
 ### Mock-Safe Bootstrap Smoke
 

--- a/docs/session-summaries/2026-05-04-e2-s3-e2-s4-code-review-summary.md
+++ b/docs/session-summaries/2026-05-04-e2-s3-e2-s4-code-review-summary.md
@@ -1,0 +1,180 @@
+# Code Review Summary: E2-S3 And E2-S4
+
+Date: 2026-05-04
+
+Repository: `syamaner/coffee-roaster-mcp`
+
+## Scope
+
+This summary captures the code review findings and fixes for:
+
+- PR `#72` - `Add roast event timeline`
+- PR `#73` - `Add core MCP tools`
+
+The goal is to preserve the review history in a compact durable form, especially the behavior and lifecycle corrections that materially changed the runtime design.
+
+## PR #72: E2-S3 Review Summary
+
+Story:
+
+- `E2-S3`
+- issue `#18`
+
+PR outcome:
+
+- merged
+
+### Main review themes
+
+1. stopped-session telemetry mutation
+2. first-fault timestamp stability
+
+### Important review findings and fixes
+
+Stopped-session telemetry mutation:
+
+- Review found `append_telemetry(...)` still allowed writes after a session stopped.
+- Fix:
+  - moved telemetry writes behind the same active-session guard used for event writes
+  - added regression coverage that appending telemetry to a stopped session raises `SessionLifecycleError`
+
+First-fault timestamp stability:
+
+- Review found the code needed explicit coverage that multiple `fault` rows do not overwrite the authoritative first-fault timestamp fields.
+- Fix:
+  - added unit coverage that multiple `fault` events remain in the timeline
+  - `faulted_at_utc` and `faulted_monotonic_seconds` stay anchored to the first fault
+
+### Review-driven commits for PR #72
+
+1. `e795536` - `test: harden event timeline mutation rules`
+
+### Final E2-S3 quality gate
+
+- `pytest`: 34 passed
+- `ruff check .`: passed
+- `ruff format --check .`: passed
+- `pyright`: 0 errors
+
+## PR #73: E2-S4 Review Summary
+
+Story:
+
+- `E2-S4`
+- issue `#19`
+
+PR state at summary time:
+
+- open
+- review fixes pushed
+
+### Main review themes
+
+1. cooling lifecycle correctness
+2. completed-session finalization
+3. manual first-crack override enforcement
+4. emergency-stop lifecycle correctness
+5. fail-closed control behavior after fault
+6. snapshot serialization under store locking
+7. read-only export behavior
+8. control-type validation
+
+### Important review findings and fixes
+
+Cooling completion left the roast active:
+
+- Review found `stop_cooling()` moved the phase to `complete` without actually stopping the session.
+- Fix:
+  - `stop_cooling()` now records `stopped_at_utc` and `monotonic_stop`
+  - completed roasts are no longer left active
+  - later `start_roast_session()` calls succeed in the same process
+
+Cooling before bean drop:
+
+- Review found cooling could start before drop, producing impossible roast timelines.
+- Fix:
+  - `start_cooling()` now rejects calls before `beans_dropped`
+  - `stop_cooling()` also rejects invalid out-of-order calls
+
+Manual first-crack override ignored config:
+
+- Review found `mark_first_crack` ignored `first_crack.allow_manual_override`
+- Fix:
+  - the MCP tool now returns an error result when manual override is disabled
+  - MCP-level config-driven test coverage added
+
+Emergency stop left the session active:
+
+- Review found `emergency_stop` recorded a fault but left the session active, which blocked later roasts
+- Fix:
+  - emergency stop is now store-owned
+  - it forces fail-closed mock state and stops the session with phase `fault`
+  - a later roast can start cleanly
+
+Reheating after fault:
+
+- Review found `set_heat` still allowed non-zero heat after a fault
+- Fix:
+  - heat cannot be increased after a fault
+  - faulted sessions are stopped, so normal mutation attempts fail through the active-session guard
+
+Phase changes after fault:
+
+- Review found later non-fault events could overwrite `phase` after a `fault`
+- Fix:
+  - fault is terminal for later non-fault event writes
+
+Snapshot serialization outside the store lock:
+
+- Review found MCP responses were iterating mutable `RoastSession` state outside the documented mutation boundary
+- Fix:
+  - added store-owned deep-copied session snapshots
+  - MCP tools now serialize from snapshot copies instead of from live mutable objects
+
+Export tool side effects:
+
+- Review found `export_roast_log` claimed to be a manifest-only tool but still created directories
+- Fix:
+  - removed the `mkdir(...)` side effect
+  - the tool now only returns the planned paths
+
+Control-type validation:
+
+- Review found `_validate_control_percent()` accepted values like `bool` and `float`
+- Fix:
+  - explicit runtime rejection for non-`int` values and `bool`
+  - added unit coverage
+
+### Review-driven commits for PR #73
+
+1. `e19f867` - `fix: harden mock tool lifecycle`
+
+### Final E2-S4 quality gate
+
+- `pytest`: 43 passed
+- `ruff check .`: passed
+- `ruff format --check .`: passed
+- `pyright`: 0 errors
+
+## Cross-Story Lessons
+
+Important implementation lessons from these review cycles:
+
+- completing a phase is not enough; session active/stopped state must also be finalized explicitly
+- phase preconditions matter even in a mock-only runtime, otherwise later stories inherit impossible timelines
+- configuration flags like manual override need MCP-surface enforcement, not just documentation
+- emergency stop should be a terminal lifecycle action, not just an event append
+- once the repo documents the store as the concurrency boundary, serialization must honor that contract too
+- read-only tools should stay free of hidden filesystem side effects
+
+## Suggested Future Use
+
+When starting `E2-S5` or later runtime stories, re-read this file before changing:
+
+- phase transitions
+- terminal fault behavior
+- emergency-stop semantics
+- snapshot/state serialization
+- export behavior
+
+Those areas already had real review churn and are the most likely places for regressions if later stories shortcut the current boundaries.

--- a/docs/session-summaries/2026-05-04-e2-s3-e2-s4-code-review-summary.md
+++ b/docs/session-summaries/2026-05-04-e2-s3-e2-s4-code-review-summary.md
@@ -78,6 +78,11 @@ PR state at summary time:
 6. snapshot serialization under store locking
 7. read-only export behavior
 8. control-type validation
+9. event-response determinism for idempotent commands
+10. session lookup after later session rollover
+11. event payload visibility in MCP responses
+12. bounded session history and lightweight read snapshots
+13. absolute export-path clarity for MCP clients
 
 ### Important review findings and fixes
 
@@ -131,6 +136,48 @@ Snapshot serialization outside the store lock:
   - added store-owned deep-copied session snapshots
   - MCP tools now serialize from snapshot copies instead of from live mutable objects
 
+Idempotent event-response mismatches:
+
+- Review found repeated singleton event commands could return the wrong event because the MCP layer serialized the latest timeline row instead of the event actually produced or resolved by the command
+- Fix:
+  - event-command tools now serialize the exact `RoastEvent` returned by the store mutation
+  - repeated `mark_beans_added`, `mark_first_crack`, and `drop_beans` calls now return stable command-aligned event results
+
+Session lookup after rollover:
+
+- Review found `get_session_snapshot(session_id=...)` only worked for the latest session, which broke reads and exports for completed sessions after a new roast started
+- Fix:
+  - added bounded retained session history addressable by `session_id`
+  - completed sessions remain readable after rollover within the in-process retained history window
+
+Event payload visibility:
+
+- Review found MCP responses dropped `RoastEvent.payload`, which hid fault reasons and future event metadata from clients
+- Fix:
+  - `EventSnapshot` now includes `payload`
+  - fault reasons from `emergency_stop` now appear in MCP event and session-state responses
+
+Atomic mutation-and-snapshot responses:
+
+- Review found tool handlers could mutate session state and then snapshot it under a later lock acquisition, allowing interleaving changes to leak into the response
+- Fix:
+  - added store-owned mutation-plus-snapshot helpers
+  - MCP tool responses now reflect the command that just happened rather than a later mutation
+
+Lightweight read snapshots:
+
+- Review found session snapshots were still copying more state than needed and holding the lock through full copies
+- Fix:
+  - read snapshots now omit telemetry buffer retention
+  - the final helper avoids copying telemetry only to discard it afterward
+
+Export path ambiguity:
+
+- Review found relative export paths were ambiguous for MCP clients because they depended on server process `cwd`
+- Fix:
+  - export manifest paths are now returned as absolute server-resolved paths
+  - tests now assert absolute paths directly
+
 Export tool side effects:
 
 - Review found `export_roast_log` claimed to be a manifest-only tool but still created directories
@@ -148,10 +195,16 @@ Control-type validation:
 ### Review-driven commits for PR #73
 
 1. `e19f867` - `fix: harden mock tool lifecycle`
+2. `cb4f23a` - `fix: return stable mcp event results`
+3. `cba13c4` - `fix: harden mcp snapshot semantics`
+4. `d53b70b` - `fix: expose event payloads and session history`
+5. `2fb63b2` - `fix: bound session history and atomic snapshots`
+6. `e0e52e0` - `test: tighten snapshot and export coverage`
+7. `e3b8379` - `fix: clarify export path responses`
 
 ### Final E2-S4 quality gate
 
-- `pytest`: 43 passed
+- `pytest`: 47 passed
 - `ruff check .`: passed
 - `ruff format --check .`: passed
 - `pyright`: 0 errors

--- a/docs/session-summaries/2026-05-04-e2-s3-e2-s4-runtime-and-review-cycle.md
+++ b/docs/session-summaries/2026-05-04-e2-s3-e2-s4-runtime-and-review-cycle.md
@@ -1,0 +1,220 @@
+# Session Summary: E2-S3 And E2-S4 Runtime And Review Cycle
+
+Date: 2026-05-04
+
+Repository: `syamaner/coffee-roaster-mcp`
+
+Branch at summary time: `feature/19-implement-core-mcp-tools`
+
+## Purpose
+
+This summary captures the next Epic 2 runtime slice after the earlier `E2-S1` and `E2-S2` work.
+
+The main outcomes were:
+
+- complete `E2-S3` core roast event timeline
+- complete `E2-S4` first roast-session MCP tool surface
+- process the review cycles for PR `#72` and PR `#73`
+- preserve the current pre-compaction handoff state with `E2-S5` next
+
+This file is intended to keep enough context for future compaction and restart without requiring the full chat transcript.
+
+## Non-PII Codex Status Snapshots
+
+Earlier snapshot received from the active Codex UI during the `E2-S1` and `E2-S2` work:
+
+- Model: `gpt-5.4`
+- Reasoning: `medium`
+- Summaries: `auto`
+- Directory: `~/git/coffee-roaster-mcp`
+- Permissions: `Workspace (on-request)`
+- `AGENTS.md` loaded in this session: `AGENTS.md`
+- Thread name: `coffee roaster mcp`
+- Collaboration mode: `Default`
+- Context window: `23% left (203K used / 258K)`
+- 5h limit: `93% left` (reset shown as `01:43`)
+- Weekly limit: `99% left` (reset shown as `20:43 on 10 May`)
+- GPT-5.3-Codex-Spark 5h limit: `100% left` (reset shown as `05:32`)
+- GPT-5.3-Codex-Spark weekly limit: `100% left` (reset shown as `00:32 on 11 May`)
+- Warning: limits may be stale; run `/status` again shortly
+
+Later snapshot received from the active Codex UI before this compaction point:
+
+- Model: `gpt-5.4`
+- Reasoning: `medium`
+- Summaries: `auto`
+- Directory: `~/git/coffee-roaster-mcp`
+- Permissions: `Workspace (on-request)`
+- `AGENTS.md` loaded in this session: `AGENTS.md`
+- Thread name: `coffee roaster mcp`
+- Collaboration mode: `Default`
+- Context window: `31% left (183K used / 258K)`
+- 5h limit: `99% left` (reset shown as `06:43`)
+- Weekly limit: `98% left` (reset shown as `20:43 on 10 May`)
+- GPT-5.3-Codex-Spark 5h limit: `100% left` (reset shown as `06:31`)
+- GPT-5.3-Codex-Spark weekly limit: `100% left` (reset shown as `01:31 on 11 May`)
+- Warning: limits may be stale; run `/status` again shortly
+
+Fields intentionally excluded:
+
+- Account identity
+- Session ID
+
+Most important note for future compaction: this chat covered `E2-S3`, `E2-S4`, two full PR review cycles, and the current branch is now the `E2-S4` PR branch with state already advanced to `E2-S5`.
+
+## Story Completion Summary
+
+### E2-S3: Implement core event timeline
+
+Issue: `#18`
+
+PR: `#72`
+
+Branch used: `feature/18-implement-core-event-timeline`
+
+Merged state:
+
+- merged to `main`
+
+What landed:
+
+- Extended `src/coffee_roaster_mcp/session.py` with authoritative per-event UTC and monotonic timestamp fields
+- Added store-owned `record_event(...)`
+- Added deterministic ordered event timeline handling for:
+  - `beans_added`
+  - `first_crack_detected`
+  - `beans_dropped`
+  - `cooling_started`
+  - `cooling_stopped`
+  - `fault`
+- Kept singleton event kinds idempotent while preserving repeatable `fault` rows
+- Added event-order and authoritative-timestamp coverage in `tests/test_session.py`
+
+Important design constraint:
+
+- Event writes stay behind `RoastSessionStore`
+- The session timeline is the one shared source of truth for roast milestone timestamps
+
+Durable state after completion:
+
+- `E2-S3` complete
+- `E2-S4` next
+
+### E2-S4: Implement core MCP tools
+
+Issue: `#19`
+
+PR: `#73`
+
+Branch used: `feature/19-implement-core-mcp-tools`
+
+PR state at summary time:
+
+- open
+- review fixes already pushed
+
+What landed:
+
+- Extended `src/coffee_roaster_mcp/mcp_server.py` with the first real mock-path tool surface:
+  - `start_roast_session`
+  - `get_roast_state`
+  - `set_heat`
+  - `set_fan`
+  - `mark_beans_added`
+  - `mark_first_crack`
+  - `drop_beans`
+  - `start_cooling`
+  - `stop_cooling`
+  - `export_roast_log`
+  - `emergency_stop`
+- Extended `src/coffee_roaster_mcp/session.py` with in-memory mock control state and store-owned helpers for heat, fan, cooling, and emergency stop
+- Added stdio MCP tool registration and end-to-end mock flow coverage in `tests/test_package.py`
+- Updated `README.md` and `.claude/skills/mock-roast/SKILL.md`
+
+Important lifecycle decisions after review:
+
+- `stop_cooling()` now finalizes the session so completed roasts are no longer left active
+- Cooling cannot start before bean drop
+- Manual first-crack override now respects config
+- Emergency stop is store-owned, faulted sessions are stopped, and a new roast can start afterward
+- Fault is terminal for later non-fault events
+- MCP state serialization now uses store-owned deep-copied snapshots
+- `export_roast_log` is read-only and no longer creates directories as a side effect
+- Heat control now rejects non-integer values and cannot raise heat after a fault
+
+Durable state after implementation:
+
+- `E2-S4` complete locally on this branch
+- active context points to `E2-S5` next
+
+## Commit Timeline
+
+### E2-S3 / PR #72
+
+1. `3713aef` - `feat: add roast event timeline`
+2. `e795536` - `test: harden event timeline mutation rules`
+
+### E2-S4 / PR #73
+
+1. `e5a8472` - `feat: add core mcp tools`
+2. `e19f867` - `fix: harden mock tool lifecycle`
+
+## Validation Summary
+
+Validation after the final `E2-S3` review cycle:
+
+- `./.venv/bin/python -m pytest`: 34 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+
+Validation after the final `E2-S4` review cycle:
+
+- `./.venv/bin/python -m pytest`: 43 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+
+## Current Durable State
+
+Current local durable state says:
+
+- `E2-S1` complete
+- `E2-S2` complete
+- `E2-S3` complete
+- `E2-S4` complete
+- `E2-S5` next
+
+Primary state files:
+
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+## Current Resume Context
+
+Current branch:
+
+- `feature/19-implement-core-mcp-tools`
+
+Current PR:
+
+- `#73`
+- `Add core MCP tools`
+
+Important restart facts:
+
+- `E2-S3` is already merged on `main`
+- `E2-S4` is implemented on the feature branch and has gone through review-fix rounds
+- state files on this branch already point to `E2-S5`
+- if PR `#73` merges, the next move is sync `main` and start `E2-S5`
+
+## Compaction Guidance
+
+If context needs to be compacted again, the minimal restart instruction should be:
+
+1. read this summary
+2. read `docs/state/registry.md`
+3. read `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+4. check whether PR `#73` is merged
+5. if merged, sync `main` and start `E2-S5`
+6. if not merged, continue from PR `#73`

--- a/docs/session-summaries/2026-05-04-e2-s4-pr73-copilot-review-assessment.md
+++ b/docs/session-summaries/2026-05-04-e2-s4-pr73-copilot-review-assessment.md
@@ -1,0 +1,130 @@
+# Copilot Review Assessment: E2-S4 PR 73
+
+Date: 2026-05-04
+
+Repository: `syamaner/coffee-roaster-mcp`
+
+PR:
+
+- `#73`
+- `Add core MCP tools`
+
+## Purpose
+
+This note captures the practical quality of the Copilot review signal on PR `#73`.
+
+The goal is not just to list comments again, but to assess which review themes were genuinely useful, which ones drove meaningful runtime changes, and what this implies for future Epic 2 stories.
+
+## Overall Assessment
+
+Copilot review was useful on this PR.
+
+The signal quality was high enough to catch several real MCP runtime problems that would have been easy to miss in a fast story-by-story implementation flow:
+
+- invalid roast lifecycle transitions
+- responses that did not always match the command that triggered them
+- missing event payload visibility
+- concurrency gaps between mutation and response snapshotting
+- read-surface assumptions that were correct for one active session but broke after later session rollover
+- a test bug that checked the wrong filesystem location
+
+The review also created some churn, because the issues arrived across many rounds and increasingly focused on deeper invariants rather than the initial functional slice. That meant the story expanded from “core tools work” into “core tools have durable MCP semantics under repeated calls and later session rollover”.
+
+Even with that churn, the review was worth it.
+
+## What Copilot Caught Well
+
+### 1. Lifecycle correctness, not just happy-path behavior
+
+Some of the strongest review findings were about roast lifecycle edges:
+
+- `stop_cooling()` marking phase `complete` without actually stopping the session
+- cooling being allowed before bean drop
+- faulted sessions still being mutable
+- emergency stop needing to terminate the session and allow later sessions to start
+
+These were real correctness issues, not style feedback.
+
+### 2. MCP response semantics
+
+The review repeatedly focused on whether MCP responses matched the actual command semantics:
+
+- idempotent event tools returning the wrong event
+- tool results reflecting the latest timeline row rather than the specific command outcome
+- event payloads such as emergency-stop reasons being invisible to MCP clients
+
+That was valuable because these issues matter to clients even when the internal session state is otherwise mostly correct.
+
+### 3. Concurrency and snapshot boundaries
+
+The later review rounds improved the implementation quality materially:
+
+- session snapshots addressable after rollover
+- atomic mutation-plus-snapshot behavior for tool responses
+- bounded session history
+- lighter-weight read snapshots
+
+These are the kinds of issues that often do not appear in a first working slice but become important immediately after the MCP surface is exercised more realistically.
+
+### 4. Test realism
+
+The final test comment about export manifest paths was good signal.
+
+The test was passing, but it was checking existence relative to the test process rather than the server subprocess `cwd`. That is the kind of false-confidence bug that is easy to ship unless someone looks at the environment boundary carefully.
+
+## Where The Review Added Churn
+
+The main cost was incremental review layering.
+
+Instead of one compact set of findings, the PR accumulated several rounds:
+
+1. basic lifecycle correctness
+2. event response correctness
+3. fault-terminal and snapshot lookup behavior
+4. payload visibility and session history
+5. bounded retention, atomic snapshots, and test-process path correctness
+
+This made the story feel longer than the initial acceptance criteria suggested. The review was still useful, but future stories may benefit from front-loading more of these invariants in the first implementation pass.
+
+## Final Runtime Improvements Caused By Review
+
+By the end of PR `#73`, Copilot review materially improved the runtime in these areas:
+
+- roast completion and fault termination semantics
+- manual-override config enforcement
+- fail-closed heat behavior after faults
+- deterministic MCP event results for idempotent commands
+- session-id readability after later session rollover
+- payload visibility in session and event snapshots
+- bounded retained session history
+- atomic mutation-and-response semantics
+- lighter-weight read snapshots
+- more realistic export-manifest tests
+
+That is a substantial quality delta compared with the first version of the story.
+
+## Token And Compaction Note
+
+This PR review cycle happened inside a long-running chat that had already covered `E2-S1` through `E2-S4`.
+
+Most important token snapshot preserved here:
+
+- Context window: `52% left (130K used / 258K)`
+
+Why this matters:
+
+- The session stayed productive because the repo already had durable state files and summary docs.
+- The review churn would have been much harder to manage without compaction and prior handoff summaries.
+- The practical lesson is that review-heavy MCP/runtime stories should keep adding durable summaries as token pressure rises.
+
+## Suggested Guidance For Future Stories
+
+Before starting `E2-S5` or later Epic 2 runtime stories, assume Copilot will be especially valuable for:
+
+- terminal lifecycle behavior
+- idempotent command semantics
+- response shape versus mutation timing
+- session rollover behavior
+- tests that cross process or filesystem boundaries
+
+The best way to reduce future churn is to implement with those review themes in mind from the start, rather than waiting for the PR to surface them one round at a time.

--- a/docs/session-summaries/2026-05-04-e2-s4-pr73-copilot-review-assessment.md
+++ b/docs/session-summaries/2026-05-04-e2-s4-pr73-copilot-review-assessment.md
@@ -27,6 +27,8 @@ The signal quality was high enough to catch several real MCP runtime problems th
 - concurrency gaps between mutation and response snapshotting
 - read-surface assumptions that were correct for one active session but broke after later session rollover
 - a test bug that checked the wrong filesystem location
+- export-path ambiguity for MCP clients consuming relative manifest paths
+- helper signatures that still reflected earlier implementation structure rather than the final contract
 
 The review also created some churn, because the issues arrived across many rounds and increasingly focused on deeper invariants rather than the initial functional slice. That meant the story expanded from “core tools work” into “core tools have durable MCP semantics under repeated calls and later session rollover”.
 
@@ -83,6 +85,7 @@ Instead of one compact set of findings, the PR accumulated several rounds:
 3. fault-terminal and snapshot lookup behavior
 4. payload visibility and session history
 5. bounded retention, atomic snapshots, and test-process path correctness
+6. absolute export-path clarity and final helper-contract cleanup
 
 This made the story feel longer than the initial acceptance criteria suggested. The review was still useful, but future stories may benefit from front-loading more of these invariants in the first implementation pass.
 
@@ -100,6 +103,8 @@ By the end of PR `#73`, Copilot review materially improved the runtime in these 
 - atomic mutation-and-response semantics
 - lighter-weight read snapshots
 - more realistic export-manifest tests
+- absolute export-path responses for MCP clients
+- cleaner helper signatures around session-state serialization
 
 That is a substantial quality delta compared with the first version of the story.
 
@@ -110,6 +115,10 @@ This PR review cycle happened inside a long-running chat that had already covere
 Most important token snapshot preserved here:
 
 - Context window: `52% left (130K used / 258K)`
+
+Later note:
+
+- A later status block was shared after more PR `#73` fixes, but the pasted portion did not include a fresh context-window line, so this remains the latest fully preserved token figure in repo docs.
 
 Why this matters:
 

--- a/docs/session-summaries/2026-05-04-e2-s4-pr73-final-runtime-and-review-cycle.md
+++ b/docs/session-summaries/2026-05-04-e2-s4-pr73-final-runtime-and-review-cycle.md
@@ -1,0 +1,140 @@
+# Session Summary: E2-S4 PR 73 Final Runtime And Review Cycle
+
+Date: 2026-05-04
+
+Repository: `syamaner/coffee-roaster-mcp`
+
+Branch at summary time: `feature/19-implement-core-mcp-tools`
+
+## Purpose
+
+This summary captures the final PR `#73` implementation and review-fix cycle after the earlier `E2-S3` and initial `E2-S4` summaries.
+
+The main outcomes were:
+
+- complete the remaining `E2-S4` review-fix rounds on PR `#73`
+- harden MCP event responses, session history access, and atomic snapshot behavior
+- tighten the export-manifest tests and lightweight read-snapshot path
+- preserve the latest non-PII Codex usage snapshot with emphasis on context-window usage
+
+This file is intended to be the shortest durable handoff for the end of the `E2-S4` review cycle.
+
+## Non-PII Codex Status Snapshot
+
+Latest snapshot received from the active Codex UI near the end of the PR `#73` review cycle:
+
+- Model: `gpt-5.4`
+- Reasoning: `medium`
+- Summaries: `auto`
+- Directory: `~/git/coffee-roaster-mcp`
+- Permissions: `Workspace (on-request)`
+- `AGENTS.md` loaded in this session: `AGENTS.md`
+- Thread name: `coffee roaster mcp`
+- Collaboration mode: `Default`
+- Context window: `52% left (130K used / 258K)`
+- 5h limit: `97% left` (reset shown as `06:43`)
+- Weekly limit: `98% left` (reset shown as `20:43 on 10 May`)
+- GPT-5.3-Codex-Spark 5h limit: `100% left` (reset shown as `07:42`)
+- GPT-5.3-Codex-Spark weekly limit: `100% left` (reset shown as `02:42 on 11 May`)
+- Warning: limits may be stale; run `/status` again shortly
+
+Fields intentionally excluded:
+
+- Account identity
+- Session ID
+
+Most important token note:
+
+- Earlier in the same long chat, the context window had dropped to `23% left (203K used / 258K)` during the `E2-S1` and `E2-S2` work.
+- By this later summary point it had recovered to `52% left (130K used / 258K)`, which means compaction and durable summaries materially reduced context pressure while the story stream continued.
+
+## Final PR 73 Outcome
+
+Story:
+
+- `E2-S4`
+- issue `#19`
+
+PR:
+
+- `#73`
+- `Add core MCP tools`
+
+Branch:
+
+- `feature/19-implement-core-mcp-tools`
+
+State at this summary point:
+
+- PR review rounds completed locally and pushed
+- durable state on the branch already points to `E2-S5` next
+
+## What Changed In The Final Review Rounds
+
+### MCP event and response correctness
+
+- event-command tools now serialize the exact `RoastEvent` returned by the store mutation instead of the last event in the timeline
+- idempotent commands such as repeated `mark_beans_added`, `mark_first_crack`, and `drop_beans` now return stable event results
+- `EventSnapshot` now includes `payload`, so fault reasons and future event metadata are visible through the MCP API
+
+### Session lookup and history behavior
+
+- completed sessions remain addressable by `session_id` after a later roast starts
+- session history is now bounded instead of growing forever
+- the retained-history design stays deliberately small and in-process for this story
+
+### Concurrency and snapshot behavior
+
+- store mutation methods now have atomic mutation-plus-snapshot helpers for the MCP layer
+- tool responses now reflect the command that just happened rather than any later interleaving mutation
+- read snapshots are lighter-weight and intentionally omit telemetry buffer copies
+
+### Export and path behavior
+
+- export remains a manifest-only read surface
+- tests now resolve relative paths against the server process `cwd`, so the no-side-effects assertion checks the right filesystem location
+
+## Final Review-Driven Commit Timeline For PR 73
+
+1. `e19f867` - `fix: harden mock tool lifecycle`
+2. `cb4f23a` - `fix: return stable mcp event results`
+3. `cba13c4` - `fix: harden mcp snapshot semantics`
+4. `d53b70b` - `fix: expose event payloads and session history`
+5. `2fb63b2` - `fix: bound session history and atomic snapshots`
+6. `e0e52e0` - `test: tighten snapshot and export coverage`
+
+## Final Validation State
+
+Validation after the last pushed review fixes:
+
+- `./.venv/bin/python -m pytest`: 47 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+
+## Durable State At Summary Time
+
+Current local durable state says:
+
+- `E2-S1` complete
+- `E2-S2` complete
+- `E2-S3` complete
+- `E2-S4` complete
+- `E2-S5` next
+
+Primary state files:
+
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+## Resume Guidance
+
+If this summary is used after compaction, the restart order should be:
+
+1. read this file
+2. read `docs/session-summaries/2026-05-04-e2-s3-e2-s4-code-review-summary.md`
+3. read `docs/state/registry.md`
+4. read `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+5. check whether PR `#73` has merged
+6. if merged, sync `main` and start `E2-S5`
+7. if not merged, continue from PR `#73`

--- a/docs/session-summaries/2026-05-04-e2-s4-pr73-final-runtime-and-review-cycle.md
+++ b/docs/session-summaries/2026-05-04-e2-s4-pr73-final-runtime-and-review-cycle.md
@@ -47,6 +47,7 @@ Most important token note:
 
 - Earlier in the same long chat, the context window had dropped to `23% left (203K used / 258K)` during the `E2-S1` and `E2-S2` work.
 - By this later summary point it had recovered to `52% left (130K used / 258K)`, which means compaction and durable summaries materially reduced context pressure while the story stream continued.
+- A later status excerpt was provided after more PR `#73` review fixes, but it did not include a fresh context-window line in the pasted portion, so `52% left (130K used / 258K)` remains the latest fully preserved token snapshot in repo docs.
 
 ## Final PR 73 Outcome
 
@@ -67,6 +68,7 @@ Branch:
 State at this summary point:
 
 - PR review rounds completed locally and pushed
+- latest review fixes now include absolute export-path responses and serializer-signature cleanup
 - durable state on the branch already points to `E2-S5` next
 
 ## What Changed In The Final Review Rounds
@@ -93,6 +95,12 @@ State at this summary point:
 
 - export remains a manifest-only read surface
 - tests now resolve relative paths against the server process `cwd`, so the no-side-effects assertion checks the right filesystem location
+- export manifest paths are now returned as absolute server-resolved paths so MCP clients do not have to infer server `cwd`
+
+### Helper and contract cleanup
+
+- `_serialize_session_state()` no longer accepts an unused `server_context` parameter
+- the final helper signatures now better match the actual MCP response contract
 
 ## Final Review-Driven Commit Timeline For PR 73
 
@@ -102,6 +110,7 @@ State at this summary point:
 4. `d53b70b` - `fix: expose event payloads and session history`
 5. `2fb63b2` - `fix: bound session history and atomic snapshots`
 6. `e0e52e0` - `test: tighten snapshot and export coverage`
+7. `e3b8379` - `fix: clarify export path responses`
 
 ## Final Validation State
 

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E2-S4`
-- Current target: Implement the first roast-session MCP tools on top of the authoritative session core
+- Active story: `E2-S5`
+- Current target: Make roast-session phase transitions deterministic across the new MCP tool flow
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -34,6 +34,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E2-S1` keeps the initial MCP tool surface bootstrap-safe with `get_server_info` and `get_runtime_config`. Roast-session lifecycle and roast-control tools remain later Epic 2 work.
 - `E2-S2` uses one in-process `RoastSessionStore` with at most one active `RoastSession` at a time. Session state now owns monotonic timing, phase, event timeline storage, telemetry retention, and log-writer references before tool wiring lands.
 - `E2-S3` keeps event writes behind `RoastSessionStore.record_event(...)`. The session timeline now records deterministic append order, authoritative UTC plus monotonic timestamps for core roast events, and idempotent singleton handling for beans added, first crack, bean drop, and cooling transitions.
+- `E2-S4` now exposes the first roast-session MCP tools on top of the mock path. `export_roast_log` currently returns the planned manifest only, while the real JSONL, CSV, and summary writers stay in Epic 5.
 - ONNX INT8 is the default real model backend.
 - ONNX FP32 is supported by config.
 - The `coffee-first-crack-detection` repo remains the source of truth for training, ONNX export, Hugging Face sync, model cards, and dataset cards.
@@ -112,7 +113,7 @@ Goal: implement one authoritative roast session runtime and MCP tool surface.
 - [x] `E2-S3` Implement core event timeline.
   - Done when `beans_added`, `first_crack_detected`, `beans_dropped`, `cooling_started`, `cooling_stopped`, and `fault` can be recorded with timestamps.
 
-- [ ] `E2-S4` Implement core MCP tools.
+- [x] `E2-S4` Implement core MCP tools.
   - Done when `start_roast_session`, `get_roast_state`, `set_heat`, `set_fan`, `mark_beans_added`, `mark_first_crack`, `drop_beans`, `start_cooling`, `stop_cooling`, `export_roast_log`, and `emergency_stop` exist.
 
 - [ ] `E2-S5` Implement phase transitions.
@@ -363,6 +364,7 @@ After completing a story:
 - E2-S1 added the first local stdio FastMCP entrypoint, `coffee-roaster-mcp serve`, and a bootstrap-safe runtime tool surface with `get_server_info` and `get_runtime_config`. It keeps roast-session lifecycle and roast-control tools out of the entrypoint story.
 - E2-S2 added `session.py` with an authoritative `RoastSession` model and `RoastSessionStore`. Session lifecycle now has stable ids, monotonic start/stop timing, explicit phase, event-timeline storage, telemetry-buffer retention, log-writer references, and clean single-owner start/stop behavior.
 - E2-S3 extended `session.py` with store-owned event recording. The authoritative session now records `beans_added`, `first_crack_detected`, `beans_dropped`, `cooling_started`, `cooling_stopped`, and `fault` in deterministic timeline order while also keeping authoritative UTC and monotonic timestamps for core roast milestones.
+- E2-S4 extended the FastMCP runtime with the first real roast-session tool surface. The mock path now supports starting a session, reading state, setting in-memory heat and fan values, recording core events, starting and stopping cooling, returning a planned export manifest, and recording emergency-stop faults through one authoritative session owner.
 - Validation run for E1-S8:
   - Reviewed issue #15 acceptance criteria against `AGENTS.md`, the active epic, and the overall plan.
   - Added `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, and `.claude/skills/release-registry` using the existing repo-local skill format.
@@ -432,6 +434,15 @@ After completing a story:
   - Kept singleton event writes idempotent for `beans_added`, `first_crack_detected`, `beans_dropped`, `cooling_started`, and `cooling_stopped` while allowing `fault` timeline rows.
   - Added `tests/test_session.py` coverage for deterministic event ordering, authoritative timestamp updates, singleton idempotency, and rejecting stopped-session event writes.
   - Ran `./.venv/bin/python -m pytest`: 32 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E2-S4:
+  - Extended `src/coffee_roaster_mcp/mcp_server.py` with the first roast-session MCP tools on top of the authoritative session core.
+  - Extended `src/coffee_roaster_mcp/session.py` with in-memory mock control state for heat, fan, and cooling plus store-owned mutation helpers used by the MCP tools.
+  - Added `tests/test_package.py` coverage for tool registration and a basic end-to-end mock tool flow over stdio MCP, including session start, control updates, event recording, state reads, export-manifest response, and emergency-stop fault recording.
+  - Updated `README.md` and `.claude/skills/mock-roast/SKILL.md` so they no longer describe the MCP runtime as introspection-only.
+  - Ran `./.venv/bin/python -m pytest`: 35 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,9 +22,9 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E2-S3 is complete. RoastPilot now records the core roast event timeline inside the authoritative in-process RoastSession with deterministic ordering, authoritative per-event timestamps, and store-owned idempotent singleton event handling.
+E2-S4 is complete. RoastPilot now exposes the first roast-session MCP tool surface on the mock path, including session start, state reads, in-memory control updates, core event recording, export-manifest stubs, and emergency-stop fault recording.
 
-The next story is E2-S4: implement the core MCP tools.
+The next story is E2-S5: implement phase transitions.
 
 The first implementation milestone remains a thin mock vertical slice: install the package, start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -298,7 +298,7 @@ def create_mcp_server(
         """Start one new authoritative roast session."""
         server_context = ctx.request_context.lifespan_context
         session = server_context.session_store.start_session_snapshot()
-        return StartRoastSessionResult(session=_serialize_session_state(session, server_context))
+        return StartRoastSessionResult(session=_serialize_session_state(session))
 
     @mcp.tool()
     def get_roast_state(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -308,7 +308,7 @@ def create_mcp_server(
         """Return the current authoritative roast session state."""
         server_context = ctx.request_context.lifespan_context
         session = _resolve_session(server_context, session_id=session_id)
-        return _serialize_session_state(session, server_context)
+        return _serialize_session_state(session)
 
     @mcp.tool()
     def set_heat(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -399,7 +399,7 @@ def create_mcp_server(
         """
         server_context = ctx.request_context.lifespan_context
         session = _resolve_session(server_context, session_id=session_id)
-        log_dir = _require_log_dir(session)
+        log_dir = _require_log_dir(session).resolve()
         return ExportRoastLogResult(
             session_id=session.id,
             log_dir=str(log_dir),
@@ -493,7 +493,6 @@ def _snapshot_session(
 
 def _serialize_session_state(
     session: RoastSession,
-    server_context: ServerContext,
 ) -> RoastSessionState:
     """Convert one in-memory session into an MCP-safe snapshot."""
     return RoastSessionState(
@@ -513,7 +512,9 @@ def _serialize_session_state(
         cooling_stopped_at_utc=_iso_or_none(session.cooling_stopped_at_utc),
         faulted_at_utc=_iso_or_none(session.faulted_at_utc),
         events=tuple(_serialize_event(event) for event in session.event_timeline),
-        log_dir=str(session.log_writer.log_dir) if session.log_writer is not None else None,
+        log_dir=str(session.log_writer.log_dir.resolve())
+        if session.log_writer is not None
+        else None,
     )
 
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -1,24 +1,21 @@
-"""FastMCP stdio server entrypoint for RoastPilot.
-
-This module implements the first local MCP server runtime for RoastPilot.
-The `E2-S1` scope is intentionally narrow: start cleanly over stdio, load the
-existing typed configuration, and expose a minimal bootstrap-safe tool list.
-"""
+"""FastMCP stdio server entrypoint for RoastPilot."""
 
 from __future__ import annotations
 
+import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Literal
 
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 
 from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.config import AppConfig, load_config
-from coffee_roaster_mcp.session import RoastSessionStore
+from coffee_roaster_mcp.session import RoastEvent, RoastPhase, RoastSession, RoastSessionStore
 
 
 @dataclass(frozen=True)
@@ -102,6 +99,79 @@ class RuntimeConfigSnapshot:
     auto_t0_detection_enabled: bool
 
 
+@dataclass(frozen=True)
+class EventSnapshot:
+    """Serializable roast event snapshot for MCP tool responses."""
+
+    kind: str
+    recorded_at_utc: str
+    monotonic_seconds: float
+
+
+@dataclass(frozen=True)
+class RoastSessionState:
+    """Serializable roast session state returned by MCP tools."""
+
+    session_id: str
+    active: bool
+    phase: RoastPhase
+    created_at_utc: str
+    stopped_at_utc: str | None
+    elapsed_monotonic_seconds: float
+    heat_level_percent: int
+    fan_level_percent: int
+    cooling_on: bool
+    beans_added_at_utc: str | None
+    first_crack_at_utc: str | None
+    beans_dropped_at_utc: str | None
+    cooling_started_at_utc: str | None
+    cooling_stopped_at_utc: str | None
+    faulted_at_utc: str | None
+    events: tuple[EventSnapshot, ...]
+    log_dir: str | None
+
+
+@dataclass(frozen=True)
+class StartRoastSessionResult:
+    """Result for starting one new roast session."""
+
+    session: RoastSessionState
+
+
+@dataclass(frozen=True)
+class ControlCommandResult:
+    """Result for one in-memory control update."""
+
+    session_id: str
+    phase: RoastPhase
+    heat_level_percent: int
+    fan_level_percent: int
+    cooling_on: bool
+
+
+@dataclass(frozen=True)
+class EventCommandResult:
+    """Result for one event-recording command."""
+
+    session_id: str
+    phase: RoastPhase
+    event: EventSnapshot
+    event_count: int
+
+
+@dataclass(frozen=True)
+class ExportRoastLogResult:
+    """Stub export manifest for the current pre-log-writer runtime."""
+
+    session_id: str
+    log_dir: str
+    jsonl_path: str
+    csv_path: str
+    summary_path: str
+    ready: bool
+    note: str
+
+
 def build_server_context(
     *,
     config_path: str | Path | None = None,
@@ -148,8 +218,9 @@ def create_mcp_server(
     mcp = FastMCP(
         name="RoastPilot",
         instructions=(
-            "Bootstrap-safe RoastPilot MCP server. "
-            "This E2-S1 tool surface exposes runtime introspection only."
+            "RoastPilot MCP server with a mock-safe session runtime. "
+            "This tool surface supports one in-process roast session and "
+            "basic mock-path controls before hardware drivers and log writers land."
         ),
         lifespan=server_lifespan,
     )
@@ -170,7 +241,21 @@ def create_mcp_server(
             roaster_driver=config.roaster.driver,
             first_crack_mode=config.first_crack.mode,
             bootstrap_safe=_is_bootstrap_safe(config),
-            available_bootstrap_tools=("get_server_info", "get_runtime_config"),
+            available_bootstrap_tools=(
+                "get_server_info",
+                "get_runtime_config",
+                "start_roast_session",
+                "get_roast_state",
+                "set_heat",
+                "set_fan",
+                "mark_beans_added",
+                "mark_first_crack",
+                "drop_beans",
+                "start_cooling",
+                "stop_cooling",
+                "export_roast_log",
+                "emergency_stop",
+            ),
             started_at_utc=server_context.started_at_utc.isoformat(),
         )
 
@@ -196,6 +281,140 @@ def create_mcp_server(
             sample_interval_seconds=config.logging.sample_interval_seconds,
             auto_t0_detection_enabled=config.session.auto_t0_detection_enabled,
         )
+
+    @mcp.tool()
+    def start_roast_session(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
+        ctx: Context[ServerSession, ServerContext],
+    ) -> StartRoastSessionResult:
+        """Start one new authoritative roast session."""
+        server_context = ctx.request_context.lifespan_context
+        session = server_context.session_store.start_session()
+        return StartRoastSessionResult(session=_serialize_session_state(session, server_context))
+
+    @mcp.tool()
+    def get_roast_state(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
+        ctx: Context[ServerSession, ServerContext],
+        session_id: str | None = None,
+    ) -> RoastSessionState:
+        """Return the current authoritative roast session state."""
+        server_context = ctx.request_context.lifespan_context
+        session = _resolve_session(server_context, session_id=session_id)
+        return _serialize_session_state(session, server_context)
+
+    @mcp.tool()
+    def set_heat(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
+        ctx: Context[ServerSession, ServerContext],
+        heat_level_percent: int,
+    ) -> ControlCommandResult:
+        """Set in-memory heat for the active mock session."""
+        server_context = ctx.request_context.lifespan_context
+        session = _require_active_session(server_context)
+        server_context.session_store.set_heat(session, heat_level_percent=heat_level_percent)
+        return _serialize_control_result(session)
+
+    @mcp.tool()
+    def set_fan(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
+        ctx: Context[ServerSession, ServerContext],
+        fan_level_percent: int,
+    ) -> ControlCommandResult:
+        """Set in-memory fan for the active mock session."""
+        server_context = ctx.request_context.lifespan_context
+        session = _require_active_session(server_context)
+        server_context.session_store.set_fan(session, fan_level_percent=fan_level_percent)
+        return _serialize_control_result(session)
+
+    @mcp.tool()
+    def mark_beans_added(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
+        ctx: Context[ServerSession, ServerContext],
+    ) -> EventCommandResult:
+        """Record the authoritative beans-added event."""
+        return _record_session_event(ctx, "beans_added")
+
+    @mcp.tool()
+    def mark_first_crack(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
+        ctx: Context[ServerSession, ServerContext],
+    ) -> EventCommandResult:
+        """Record the authoritative first-crack event."""
+        server_context = ctx.request_context.lifespan_context
+        if not server_context.config.first_crack.allow_manual_override:
+            raise ValueError("Manual first-crack override is disabled by configuration.")
+        return _record_session_event(ctx, "first_crack_detected")
+
+    @mcp.tool()
+    def drop_beans(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
+        ctx: Context[ServerSession, ServerContext],
+    ) -> EventCommandResult:
+        """Record bean drop and force heat off in the mock session state."""
+        server_context = ctx.request_context.lifespan_context
+        session = _require_active_session(server_context)
+        server_context.session_store.set_heat(session, heat_level_percent=0)
+        event = server_context.session_store.record_event(session, "beans_dropped")
+        return _serialize_event_result(session, event)
+
+    @mcp.tool()
+    def start_cooling(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
+        ctx: Context[ServerSession, ServerContext],
+    ) -> EventCommandResult:
+        """Start cooling in the mock session state and record the event."""
+        server_context = ctx.request_context.lifespan_context
+        session = _require_active_session(server_context)
+        event = server_context.session_store.start_cooling(session)
+        return _serialize_event_result(session, event)
+
+    @mcp.tool()
+    def stop_cooling(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
+        ctx: Context[ServerSession, ServerContext],
+    ) -> EventCommandResult:
+        """Stop cooling in the mock session state and record the event."""
+        server_context = ctx.request_context.lifespan_context
+        session = _require_active_session(server_context)
+        event = server_context.session_store.stop_cooling(session)
+        return _serialize_event_result(session, event)
+
+    @mcp.tool()
+    def export_roast_log(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
+        ctx: Context[ServerSession, ServerContext],
+        session_id: str | None = None,
+    ) -> ExportRoastLogResult:
+        """Return the planned export targets for one roast session.
+
+        Log writing itself lands in Epic 5. This tool only exposes the expected
+        output paths so the MCP surface can stabilize before the writers exist.
+        """
+        server_context = ctx.request_context.lifespan_context
+        session = _resolve_session(server_context, session_id=session_id)
+        log_dir = _require_log_dir(session)
+        log_dir.mkdir(parents=True, exist_ok=True)
+        return ExportRoastLogResult(
+            session_id=session.id,
+            log_dir=str(log_dir),
+            jsonl_path=str(log_dir / "roast.jsonl"),
+            csv_path=str(log_dir / "roast.csv"),
+            summary_path=str(log_dir / "summary.json"),
+            ready=False,
+            note=(
+                "Export writers land in Epic 5. "
+                "This tool currently returns the planned manifest only."
+            ),
+        )
+
+    @mcp.tool()
+    def emergency_stop(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
+        ctx: Context[ServerSession, ServerContext],
+        reason: str = "manual emergency stop",
+    ) -> EventCommandResult:
+        """Apply mock-safe emergency-stop state and record a fault event."""
+        server_context = ctx.request_context.lifespan_context
+        session = _require_active_session(server_context)
+        server_context.session_store.set_heat(session, heat_level_percent=0)
+        server_context.session_store.set_fan(session, fan_level_percent=100)
+        session.cooling_on = True
+        event = server_context.session_store.record_event(
+            session,
+            "fault",
+            payload={"reason": reason},
+        )
+        return _serialize_event_result(session, event)
 
     return mcp
 
@@ -223,3 +442,100 @@ def _is_bootstrap_safe(config: AppConfig) -> bool:
         "disabled",
         "manual",
     }
+
+
+def _require_active_session(server_context: ServerContext) -> RoastSession:
+    """Return the active session or fail clearly when none exists."""
+    session = server_context.session_store.get_active_session()
+    if session is None:
+        raise ValueError("No active roast session exists.")
+    return session
+
+
+def _resolve_session(server_context: ServerContext, *, session_id: str | None) -> RoastSession:
+    """Resolve one session for read or export operations."""
+    session = server_context.session_store.get_latest_session()
+    if session is None:
+        raise ValueError("No roast session exists.")
+    if session_id is not None and session.id != session_id:
+        raise ValueError(f"Unknown session_id: {session_id}")
+    return session
+
+
+def _record_session_event(
+    ctx: Context[ServerSession, ServerContext],
+    kind: Literal["beans_added", "first_crack_detected"],
+) -> EventCommandResult:
+    """Record one core event against the active session."""
+    server_context = ctx.request_context.lifespan_context
+    session = _require_active_session(server_context)
+    event = server_context.session_store.record_event(session, kind)
+    return _serialize_event_result(session, event)
+
+
+def _serialize_session_state(
+    session: RoastSession,
+    server_context: ServerContext,
+) -> RoastSessionState:
+    """Convert one in-memory session into an MCP-safe snapshot."""
+    return RoastSessionState(
+        session_id=session.id,
+        active=session.active,
+        phase=session.phase,
+        created_at_utc=session.created_at_utc.isoformat(),
+        stopped_at_utc=_iso_or_none(session.stopped_at_utc),
+        elapsed_monotonic_seconds=round(session.elapsed_monotonic_seconds(time.monotonic), 3),
+        heat_level_percent=session.heat_level_percent,
+        fan_level_percent=session.fan_level_percent,
+        cooling_on=session.cooling_on,
+        beans_added_at_utc=_iso_or_none(session.beans_added_at_utc),
+        first_crack_at_utc=_iso_or_none(session.first_crack_at_utc),
+        beans_dropped_at_utc=_iso_or_none(session.beans_dropped_at_utc),
+        cooling_started_at_utc=_iso_or_none(session.cooling_started_at_utc),
+        cooling_stopped_at_utc=_iso_or_none(session.cooling_stopped_at_utc),
+        faulted_at_utc=_iso_or_none(session.faulted_at_utc),
+        events=tuple(_serialize_event(event) for event in session.event_timeline),
+        log_dir=str(session.log_writer.log_dir) if session.log_writer is not None else None,
+    )
+
+
+def _serialize_control_result(session: RoastSession) -> ControlCommandResult:
+    """Convert one control mutation into a stable tool response."""
+    return ControlCommandResult(
+        session_id=session.id,
+        phase=session.phase,
+        heat_level_percent=session.heat_level_percent,
+        fan_level_percent=session.fan_level_percent,
+        cooling_on=session.cooling_on,
+    )
+
+
+def _serialize_event_result(session: RoastSession, event: RoastEvent) -> EventCommandResult:
+    """Convert one event mutation into a stable tool response."""
+    return EventCommandResult(
+        session_id=session.id,
+        phase=session.phase,
+        event=_serialize_event(event),
+        event_count=len(session.event_timeline),
+    )
+
+
+def _serialize_event(event: RoastEvent) -> EventSnapshot:
+    """Convert one roast event into a serializable snapshot."""
+    return EventSnapshot(
+        kind=event.kind,
+        recorded_at_utc=event.recorded_at_utc.isoformat(),
+        monotonic_seconds=event.monotonic_seconds,
+    )
+
+
+def _iso_or_none(value: datetime | None) -> str | None:
+    """Return one ISO8601 string when a datetime exists."""
+    return value.isoformat() if value is not None else None
+
+
+def _require_log_dir(session: RoastSession) -> Path:
+    """Return the session log directory when configured."""
+    if session.log_writer is None:
+        raise ValueError("Session log target is unavailable.")
+    return session.log_writer.log_dir

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -16,6 +16,7 @@ from mcp.server.session import ServerSession
 from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.config import AppConfig, load_config
 from coffee_roaster_mcp.session import (
+    EventPayloadValue,
     RoastEvent,
     RoastPhase,
     RoastSession,
@@ -113,6 +114,7 @@ class EventSnapshot:
     kind: str
     recorded_at_utc: str
     monotonic_seconds: float
+    payload: dict[str, EventPayloadValue]
 
 
 @dataclass(frozen=True)
@@ -356,10 +358,9 @@ def create_mcp_server(
     def drop_beans(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
         ctx: Context[ServerSession, ServerContext],
     ) -> EventCommandResult:
-        """Record bean drop and force heat off in the mock session state."""
+        """Record bean drop and let the event timeline force heat off."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        server_context.session_store.set_heat(session, heat_level_percent=0)
         event = server_context.session_store.record_event(session, "beans_dropped")
         return _serialize_event_result_for_command(
             server_context,
@@ -568,6 +569,7 @@ def _serialize_event(event: RoastEvent) -> EventSnapshot:
         kind=event.kind,
         recorded_at_utc=event.recorded_at_utc.isoformat(),
         monotonic_seconds=event.monotonic_seconds,
+        payload=dict(event.payload),
     )
 
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -289,7 +289,12 @@ def create_mcp_server(
         """Start one new authoritative roast session."""
         server_context = ctx.request_context.lifespan_context
         session = server_context.session_store.start_session()
-        return StartRoastSessionResult(session=_serialize_session_state(session, server_context))
+        return StartRoastSessionResult(
+            session=_serialize_session_state(
+                _snapshot_session(server_context, session_id=session.id),
+                server_context,
+            )
+        )
 
     @mcp.tool()
     def get_roast_state(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -310,7 +315,7 @@ def create_mcp_server(
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
         server_context.session_store.set_heat(session, heat_level_percent=heat_level_percent)
-        return _serialize_control_result(session)
+        return _serialize_control_result(_snapshot_session(server_context, session_id=session.id))
 
     @mcp.tool()
     def set_fan(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -321,7 +326,7 @@ def create_mcp_server(
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
         server_context.session_store.set_fan(session, fan_level_percent=fan_level_percent)
-        return _serialize_control_result(session)
+        return _serialize_control_result(_snapshot_session(server_context, session_id=session.id))
 
     @mcp.tool()
     def mark_beans_added(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -348,8 +353,8 @@ def create_mcp_server(
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
         server_context.session_store.set_heat(session, heat_level_percent=0)
-        event = server_context.session_store.record_event(session, "beans_dropped")
-        return _serialize_event_result(session, event)
+        server_context.session_store.record_event(session, "beans_dropped")
+        return _serialize_latest_event_result(server_context, session_id=session.id)
 
     @mcp.tool()
     def start_cooling(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -358,8 +363,8 @@ def create_mcp_server(
         """Start cooling in the mock session state and record the event."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        event = server_context.session_store.start_cooling(session)
-        return _serialize_event_result(session, event)
+        server_context.session_store.start_cooling(session)
+        return _serialize_latest_event_result(server_context, session_id=session.id)
 
     @mcp.tool()
     def stop_cooling(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -368,8 +373,8 @@ def create_mcp_server(
         """Stop cooling in the mock session state and record the event."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        event = server_context.session_store.stop_cooling(session)
-        return _serialize_event_result(session, event)
+        server_context.session_store.stop_cooling(session)
+        return _serialize_latest_event_result(server_context, session_id=session.id)
 
     @mcp.tool()
     def export_roast_log(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -384,7 +389,6 @@ def create_mcp_server(
         server_context = ctx.request_context.lifespan_context
         session = _resolve_session(server_context, session_id=session_id)
         log_dir = _require_log_dir(session)
-        log_dir.mkdir(parents=True, exist_ok=True)
         return ExportRoastLogResult(
             session_id=session.id,
             log_dir=str(log_dir),
@@ -406,15 +410,8 @@ def create_mcp_server(
         """Apply mock-safe emergency-stop state and record a fault event."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        server_context.session_store.set_heat(session, heat_level_percent=0)
-        server_context.session_store.set_fan(session, fan_level_percent=100)
-        session.cooling_on = True
-        event = server_context.session_store.record_event(
-            session,
-            "fault",
-            payload={"reason": reason},
-        )
-        return _serialize_event_result(session, event)
+        server_context.session_store.emergency_stop(session, reason=reason)
+        return _serialize_latest_event_result(server_context, session_id=session.id)
 
     return mcp
 
@@ -454,12 +451,7 @@ def _require_active_session(server_context: ServerContext) -> RoastSession:
 
 def _resolve_session(server_context: ServerContext, *, session_id: str | None) -> RoastSession:
     """Resolve one session for read or export operations."""
-    session = server_context.session_store.get_latest_session()
-    if session is None:
-        raise ValueError("No roast session exists.")
-    if session_id is not None and session.id != session_id:
-        raise ValueError(f"Unknown session_id: {session_id}")
-    return session
+    return _snapshot_session(server_context, session_id=session_id)
 
 
 def _record_session_event(
@@ -469,8 +461,20 @@ def _record_session_event(
     """Record one core event against the active session."""
     server_context = ctx.request_context.lifespan_context
     session = _require_active_session(server_context)
-    event = server_context.session_store.record_event(session, kind)
-    return _serialize_event_result(session, event)
+    server_context.session_store.record_event(session, kind)
+    return _serialize_latest_event_result(server_context, session_id=session.id)
+
+
+def _snapshot_session(
+    server_context: ServerContext,
+    *,
+    session_id: str | None = None,
+) -> RoastSession:
+    """Return a locked deep-copied session snapshot."""
+    try:
+        return server_context.session_store.get_session_snapshot(session_id=session_id)
+    except Exception as exc:
+        raise ValueError(str(exc)) from exc
 
 
 def _serialize_session_state(
@@ -518,6 +522,18 @@ def _serialize_event_result(session: RoastSession, event: RoastEvent) -> EventCo
         event=_serialize_event(event),
         event_count=len(session.event_timeline),
     )
+
+
+def _serialize_latest_event_result(
+    server_context: ServerContext,
+    *,
+    session_id: str,
+) -> EventCommandResult:
+    """Serialize the latest event from a locked session snapshot."""
+    snapshot = _snapshot_session(server_context, session_id=session_id)
+    if not snapshot.event_timeline:
+        raise ValueError("No roast events exist for this session.")
+    return _serialize_event_result(snapshot, snapshot.event_timeline[-1])
 
 
 def _serialize_event(event: RoastEvent) -> EventSnapshot:

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -15,7 +15,13 @@ from mcp.server.session import ServerSession
 
 from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.config import AppConfig, load_config
-from coffee_roaster_mcp.session import RoastEvent, RoastPhase, RoastSession, RoastSessionStore
+from coffee_roaster_mcp.session import (
+    RoastEvent,
+    RoastPhase,
+    RoastSession,
+    RoastSessionStore,
+    SessionLifecycleError,
+)
 
 
 @dataclass(frozen=True)
@@ -48,7 +54,8 @@ class ServerInfo:
         roaster_driver: Configured roaster driver.
         first_crack_mode: Configured first-crack mode.
         bootstrap_safe: Whether the current defaults stay hardware-free.
-        available_bootstrap_tools: Minimal tool surface exposed in `E2-S1`.
+        available_bootstrap_tools: Tools available while RoastPilot stays on the
+            bootstrap-safe mock path.
         started_at_utc: UTC timestamp when this server process started.
     """
 
@@ -291,7 +298,7 @@ def create_mcp_server(
         session = server_context.session_store.start_session()
         return StartRoastSessionResult(
             session=_serialize_session_state(
-                _snapshot_session(server_context, session_id=session.id),
+                _snapshot_known_session(server_context, session),
                 server_context,
             )
         )
@@ -315,7 +322,7 @@ def create_mcp_server(
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
         server_context.session_store.set_heat(session, heat_level_percent=heat_level_percent)
-        return _serialize_control_result(_snapshot_session(server_context, session_id=session.id))
+        return _serialize_control_result(_snapshot_known_session(server_context, session))
 
     @mcp.tool()
     def set_fan(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -326,7 +333,7 @@ def create_mcp_server(
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
         server_context.session_store.set_fan(session, fan_level_percent=fan_level_percent)
-        return _serialize_control_result(_snapshot_session(server_context, session_id=session.id))
+        return _serialize_control_result(_snapshot_known_session(server_context, session))
 
     @mcp.tool()
     def mark_beans_added(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -356,7 +363,7 @@ def create_mcp_server(
         event = server_context.session_store.record_event(session, "beans_dropped")
         return _serialize_event_result_for_command(
             server_context,
-            session_id=session.id,
+            session=session,
             event=event,
         )
 
@@ -370,7 +377,7 @@ def create_mcp_server(
         event = server_context.session_store.start_cooling(session)
         return _serialize_event_result_for_command(
             server_context,
-            session_id=session.id,
+            session=session,
             event=event,
         )
 
@@ -384,7 +391,7 @@ def create_mcp_server(
         event = server_context.session_store.stop_cooling(session)
         return _serialize_event_result_for_command(
             server_context,
-            session_id=session.id,
+            session=session,
             event=event,
         )
 
@@ -425,7 +432,7 @@ def create_mcp_server(
         event = server_context.session_store.emergency_stop(session, reason=reason)
         return _serialize_event_result_for_command(
             server_context,
-            session_id=session.id,
+            session=session,
             event=event,
         )
 
@@ -480,7 +487,7 @@ def _record_session_event(
     event = server_context.session_store.record_event(session, kind)
     return _serialize_event_result_for_command(
         server_context,
-        session_id=session.id,
+        session=session,
         event=event,
     )
 
@@ -493,8 +500,13 @@ def _snapshot_session(
     """Return a locked deep-copied session snapshot."""
     try:
         return server_context.session_store.get_session_snapshot(session_id=session_id)
-    except Exception as exc:
+    except SessionLifecycleError as exc:
         raise ValueError(str(exc)) from exc
+
+
+def _snapshot_known_session(server_context: ServerContext, session: RoastSession) -> RoastSession:
+    """Return a deep-copied snapshot for one known session object."""
+    return server_context.session_store.copy_session(session)
 
 
 def _serialize_session_state(
@@ -537,11 +549,11 @@ def _serialize_control_result(session: RoastSession) -> ControlCommandResult:
 def _serialize_event_result_for_command(
     server_context: ServerContext,
     *,
-    session_id: str,
+    session: RoastSession,
     event: RoastEvent,
 ) -> EventCommandResult:
     """Serialize the specific event produced or resolved for one command."""
-    snapshot = _snapshot_session(server_context, session_id=session_id)
+    snapshot = _snapshot_known_session(server_context, session)
     return EventCommandResult(
         session_id=snapshot.id,
         phase=snapshot.phase,

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -353,8 +353,12 @@ def create_mcp_server(
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
         server_context.session_store.set_heat(session, heat_level_percent=0)
-        server_context.session_store.record_event(session, "beans_dropped")
-        return _serialize_latest_event_result(server_context, session_id=session.id)
+        event = server_context.session_store.record_event(session, "beans_dropped")
+        return _serialize_event_result_for_command(
+            server_context,
+            session_id=session.id,
+            event=event,
+        )
 
     @mcp.tool()
     def start_cooling(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -363,8 +367,12 @@ def create_mcp_server(
         """Start cooling in the mock session state and record the event."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        server_context.session_store.start_cooling(session)
-        return _serialize_latest_event_result(server_context, session_id=session.id)
+        event = server_context.session_store.start_cooling(session)
+        return _serialize_event_result_for_command(
+            server_context,
+            session_id=session.id,
+            event=event,
+        )
 
     @mcp.tool()
     def stop_cooling(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -373,8 +381,12 @@ def create_mcp_server(
         """Stop cooling in the mock session state and record the event."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        server_context.session_store.stop_cooling(session)
-        return _serialize_latest_event_result(server_context, session_id=session.id)
+        event = server_context.session_store.stop_cooling(session)
+        return _serialize_event_result_for_command(
+            server_context,
+            session_id=session.id,
+            event=event,
+        )
 
     @mcp.tool()
     def export_roast_log(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -410,8 +422,12 @@ def create_mcp_server(
         """Apply mock-safe emergency-stop state and record a fault event."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        server_context.session_store.emergency_stop(session, reason=reason)
-        return _serialize_latest_event_result(server_context, session_id=session.id)
+        event = server_context.session_store.emergency_stop(session, reason=reason)
+        return _serialize_event_result_for_command(
+            server_context,
+            session_id=session.id,
+            event=event,
+        )
 
     return mcp
 
@@ -461,8 +477,12 @@ def _record_session_event(
     """Record one core event against the active session."""
     server_context = ctx.request_context.lifespan_context
     session = _require_active_session(server_context)
-    server_context.session_store.record_event(session, kind)
-    return _serialize_latest_event_result(server_context, session_id=session.id)
+    event = server_context.session_store.record_event(session, kind)
+    return _serialize_event_result_for_command(
+        server_context,
+        session_id=session.id,
+        event=event,
+    )
 
 
 def _snapshot_session(
@@ -514,26 +534,20 @@ def _serialize_control_result(session: RoastSession) -> ControlCommandResult:
     )
 
 
-def _serialize_event_result(session: RoastSession, event: RoastEvent) -> EventCommandResult:
-    """Convert one event mutation into a stable tool response."""
-    return EventCommandResult(
-        session_id=session.id,
-        phase=session.phase,
-        event=_serialize_event(event),
-        event_count=len(session.event_timeline),
-    )
-
-
-def _serialize_latest_event_result(
+def _serialize_event_result_for_command(
     server_context: ServerContext,
     *,
     session_id: str,
+    event: RoastEvent,
 ) -> EventCommandResult:
-    """Serialize the latest event from a locked session snapshot."""
+    """Serialize the specific event produced or resolved for one command."""
     snapshot = _snapshot_session(server_context, session_id=session_id)
-    if not snapshot.event_timeline:
-        raise ValueError("No roast events exist for this session.")
-    return _serialize_event_result(snapshot, snapshot.event_timeline[-1])
+    return EventCommandResult(
+        session_id=snapshot.id,
+        phase=snapshot.phase,
+        event=_serialize_event(event),
+        event_count=len(snapshot.event_timeline),
+    )
 
 
 def _serialize_event(event: RoastEvent) -> EventSnapshot:

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -297,13 +297,8 @@ def create_mcp_server(
     ) -> StartRoastSessionResult:
         """Start one new authoritative roast session."""
         server_context = ctx.request_context.lifespan_context
-        session = server_context.session_store.start_session()
-        return StartRoastSessionResult(
-            session=_serialize_session_state(
-                _snapshot_known_session(server_context, session),
-                server_context,
-            )
-        )
+        session = server_context.session_store.start_session_snapshot()
+        return StartRoastSessionResult(session=_serialize_session_state(session, server_context))
 
     @mcp.tool()
     def get_roast_state(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -323,8 +318,11 @@ def create_mcp_server(
         """Set in-memory heat for the active mock session."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        server_context.session_store.set_heat(session, heat_level_percent=heat_level_percent)
-        return _serialize_control_result(_snapshot_known_session(server_context, session))
+        snapshot = server_context.session_store.set_heat_snapshot(
+            session,
+            heat_level_percent=heat_level_percent,
+        )
+        return _serialize_control_result(snapshot)
 
     @mcp.tool()
     def set_fan(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -334,8 +332,11 @@ def create_mcp_server(
         """Set in-memory fan for the active mock session."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        server_context.session_store.set_fan(session, fan_level_percent=fan_level_percent)
-        return _serialize_control_result(_snapshot_known_session(server_context, session))
+        snapshot = server_context.session_store.set_fan_snapshot(
+            session,
+            fan_level_percent=fan_level_percent,
+        )
+        return _serialize_control_result(snapshot)
 
     @mcp.tool()
     def mark_beans_added(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -361,12 +362,10 @@ def create_mcp_server(
         """Record bean drop and let the event timeline force heat off."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        event = server_context.session_store.record_event(session, "beans_dropped")
-        return _serialize_event_result_for_command(
-            server_context,
-            session=session,
-            event=event,
+        event, snapshot = server_context.session_store.record_event_snapshot(
+            session, "beans_dropped"
         )
+        return _serialize_event_result(snapshot=snapshot, event=event)
 
     @mcp.tool()
     def start_cooling(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -375,12 +374,8 @@ def create_mcp_server(
         """Start cooling in the mock session state and record the event."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        event = server_context.session_store.start_cooling(session)
-        return _serialize_event_result_for_command(
-            server_context,
-            session=session,
-            event=event,
-        )
+        event, snapshot = server_context.session_store.start_cooling_snapshot(session)
+        return _serialize_event_result(snapshot=snapshot, event=event)
 
     @mcp.tool()
     def stop_cooling(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -389,12 +384,8 @@ def create_mcp_server(
         """Stop cooling in the mock session state and record the event."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        event = server_context.session_store.stop_cooling(session)
-        return _serialize_event_result_for_command(
-            server_context,
-            session=session,
-            event=event,
-        )
+        event, snapshot = server_context.session_store.stop_cooling_snapshot(session)
+        return _serialize_event_result(snapshot=snapshot, event=event)
 
     @mcp.tool()
     def export_roast_log(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -430,12 +421,11 @@ def create_mcp_server(
         """Apply mock-safe emergency-stop state and record a fault event."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        event = server_context.session_store.emergency_stop(session, reason=reason)
-        return _serialize_event_result_for_command(
-            server_context,
-            session=session,
-            event=event,
+        event, snapshot = server_context.session_store.emergency_stop_snapshot(
+            session,
+            reason=reason,
         )
+        return _serialize_event_result(snapshot=snapshot, event=event)
 
     return mcp
 
@@ -485,12 +475,8 @@ def _record_session_event(
     """Record one core event against the active session."""
     server_context = ctx.request_context.lifespan_context
     session = _require_active_session(server_context)
-    event = server_context.session_store.record_event(session, kind)
-    return _serialize_event_result_for_command(
-        server_context,
-        session=session,
-        event=event,
-    )
+    event, snapshot = server_context.session_store.record_event_snapshot(session, kind)
+    return _serialize_event_result(snapshot=snapshot, event=event)
 
 
 def _snapshot_session(
@@ -503,11 +489,6 @@ def _snapshot_session(
         return server_context.session_store.get_session_snapshot(session_id=session_id)
     except SessionLifecycleError as exc:
         raise ValueError(str(exc)) from exc
-
-
-def _snapshot_known_session(server_context: ServerContext, session: RoastSession) -> RoastSession:
-    """Return a deep-copied snapshot for one known session object."""
-    return server_context.session_store.copy_session(session)
 
 
 def _serialize_session_state(
@@ -547,14 +528,12 @@ def _serialize_control_result(session: RoastSession) -> ControlCommandResult:
     )
 
 
-def _serialize_event_result_for_command(
-    server_context: ServerContext,
+def _serialize_event_result(
     *,
-    session: RoastSession,
+    snapshot: RoastSession,
     event: RoastEvent,
 ) -> EventCommandResult:
     """Serialize the specific event produced or resolved for one command."""
-    snapshot = _snapshot_known_session(server_context, session)
     return EventCommandResult(
         session_id=snapshot.id,
         phase=snapshot.phase,

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import deque
 from collections.abc import Callable
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -348,10 +349,13 @@ class RoastSessionStore:
         """Set the latest in-memory heat value for one active session."""
         with self._lock:
             self._assert_latest_active_session(session)
-            session.heat_level_percent = _validate_control_percent(
+            validated_heat = _validate_control_percent(
                 heat_level_percent,
                 label="heat_level_percent",
             )
+            if session.phase == "fault" and validated_heat > 0:
+                raise SessionLifecycleError("Heat cannot be increased after a fault.")
+            session.heat_level_percent = validated_heat
             return session
 
     def set_fan(
@@ -419,6 +423,8 @@ class RoastSessionStore:
         """
         with self._lock:
             self._assert_latest_active_session(session)
+            if session.phase == "fault" and kind != "fault":
+                raise SessionLifecycleError("No non-fault events can be recorded after a fault.")
 
             existing_event = self._get_existing_singleton_event(session, kind)
             if existing_event is not None:
@@ -436,6 +442,26 @@ class RoastSessionStore:
             _apply_event_timestamp(session, event)
             return event
 
+    def emergency_stop(
+        self,
+        session: RoastSession,
+        *,
+        reason: str,
+    ) -> RoastEvent:
+        """Apply mock-safe emergency-stop state and finalize the session."""
+        with self._lock:
+            self._assert_latest_active_session(session)
+            session.heat_level_percent = 0
+            session.fan_level_percent = 100
+            session.cooling_on = True
+            event = self.record_event(session, "fault", payload={"reason": reason})
+            session.stop(
+                utc_now=self._utc_now,
+                monotonic_now=self._monotonic_now,
+                phase="fault",
+            )
+            return event
+
     def get_active_session(self) -> RoastSession | None:
         """Return the current active session when present."""
         with self._lock:
@@ -447,6 +473,22 @@ class RoastSessionStore:
         """Return the latest session whether active or stopped."""
         with self._lock:
             return self._latest_session
+
+    def get_session_snapshot(
+        self,
+        *,
+        session_id: str | None = None,
+        active_only: bool = False,
+    ) -> RoastSession:
+        """Return a deep-copied session snapshot under store-owned locking."""
+        with self._lock:
+            if self._latest_session is None:
+                raise SessionLifecycleError("No roast session exists.")
+            if session_id is not None and self._latest_session.id != session_id:
+                raise SessionLifecycleError(f"Unknown session_id: {session_id}")
+            if active_only and not self._latest_session.active:
+                raise SessionLifecycleError("No active roast session exists.")
+            return deepcopy(self._latest_session)
 
     @property
     def telemetry_buffer_limit(self) -> int:
@@ -515,8 +557,10 @@ def _generate_session_id() -> str:
     return uuid4().hex
 
 
-def _validate_control_percent(value: int, *, label: str) -> int:
+def _validate_control_percent(value: object, *, label: str) -> int:
     """Validate one percentage-like control input."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{label} must be an integer between 0 and 100.")
     if not 0 <= value <= 100:
         raise ValueError(f"{label} must be between 0 and 100.")
     return value

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -272,6 +272,7 @@ class RoastSessionStore:
         self._default_log_dir = default_log_dir
         self._lock = RLock()
         self._latest_session: RoastSession | None = None
+        self._sessions_by_id: dict[str, RoastSession] = {}
 
     def start_session(self) -> RoastSession:
         """Start one new active session.
@@ -297,6 +298,7 @@ class RoastSessionStore:
                 ),
             )
             self._latest_session = session
+            self._sessions_by_id[session_id] = session
             return session
 
     def stop_session(self, *, phase: RoastPhase = "complete") -> RoastSession | None:
@@ -482,11 +484,14 @@ class RoastSessionStore:
         with self._lock:
             if self._latest_session is None:
                 raise SessionLifecycleError("No roast session exists.")
-            if session_id is not None and self._latest_session.id != session_id:
-                raise SessionLifecycleError(f"Unknown session_id: {session_id}")
-            if active_only and not self._latest_session.active:
+            session = self._latest_session
+            if session_id is not None:
+                session = self._sessions_by_id.get(session_id)
+                if session is None:
+                    raise SessionLifecycleError(f"Unknown session_id: {session_id}")
+            if active_only and not session.active:
                 raise SessionLifecycleError("No active roast session exists.")
-            return deepcopy(self._latest_session)
+            return deepcopy(session)
 
     def copy_session(self, session: RoastSession) -> RoastSession:
         """Return a deep-copied snapshot of one known session object under the store lock."""

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -246,6 +246,7 @@ class RoastSessionStore:
         self,
         *,
         telemetry_buffer_limit: int = 300,
+        session_history_limit: int = 8,
         utc_now: Callable[[], datetime] | None = None,
         monotonic_now: Callable[[], float] | None = None,
         session_id_factory: Callable[[], str] | None = None,
@@ -255,6 +256,7 @@ class RoastSessionStore:
 
         Args:
             telemetry_buffer_limit: Maximum retained telemetry samples per session.
+            session_history_limit: Maximum retained sessions addressable by id.
             utc_now: Optional UTC timestamp supplier.
             monotonic_now: Optional monotonic clock supplier.
             session_id_factory: Optional session id supplier.
@@ -264,8 +266,11 @@ class RoastSessionStore:
 
         if telemetry_buffer_limit < 0:
             raise ValueError("telemetry_buffer_limit must be >= 0.")
+        if session_history_limit < 1:
+            raise ValueError("session_history_limit must be >= 1.")
 
         self._telemetry_buffer_limit = telemetry_buffer_limit
+        self._session_history_limit = session_history_limit
         self._utc_now = utc_now or (lambda: datetime.now(UTC))
         self._monotonic_now = monotonic_now or time.monotonic
         self._session_id_factory = session_id_factory or _generate_session_id
@@ -273,6 +278,7 @@ class RoastSessionStore:
         self._lock = RLock()
         self._latest_session: RoastSession | None = None
         self._sessions_by_id: dict[str, RoastSession] = {}
+        self._session_id_order: deque[str] = deque()
 
     def start_session(self) -> RoastSession:
         """Start one new active session.
@@ -299,7 +305,15 @@ class RoastSessionStore:
             )
             self._latest_session = session
             self._sessions_by_id[session_id] = session
+            self._session_id_order.append(session_id)
+            self._prune_session_history_locked()
             return session
+
+    def start_session_snapshot(self) -> RoastSession:
+        """Start one new session and return an atomic lightweight snapshot."""
+        with self._lock:
+            session = self.start_session()
+            return _copy_session_for_read(session)
 
     def stop_session(self, *, phase: RoastPhase = "complete") -> RoastSession | None:
         """Stop the active session if one exists.
@@ -360,6 +374,17 @@ class RoastSessionStore:
             session.heat_level_percent = validated_heat
             return session
 
+    def set_heat_snapshot(
+        self,
+        session: RoastSession,
+        *,
+        heat_level_percent: int,
+    ) -> RoastSession:
+        """Apply heat and return an atomic lightweight snapshot."""
+        with self._lock:
+            self.set_heat(session, heat_level_percent=heat_level_percent)
+            return _copy_session_for_read(session)
+
     def set_fan(
         self,
         session: RoastSession,
@@ -375,6 +400,17 @@ class RoastSessionStore:
             )
             return session
 
+    def set_fan_snapshot(
+        self,
+        session: RoastSession,
+        *,
+        fan_level_percent: int,
+    ) -> RoastSession:
+        """Apply fan and return an atomic lightweight snapshot."""
+        with self._lock:
+            self.set_fan(session, fan_level_percent=fan_level_percent)
+            return _copy_session_for_read(session)
+
     def start_cooling(self, session: RoastSession) -> RoastEvent:
         """Start cooling for one active session."""
         with self._lock:
@@ -382,6 +418,12 @@ class RoastSessionStore:
             if session.beans_dropped_at_utc is None:
                 raise SessionLifecycleError("Cooling can only start after beans are dropped.")
             return self.record_event(session, "cooling_started")
+
+    def start_cooling_snapshot(self, session: RoastSession) -> tuple[RoastEvent, RoastSession]:
+        """Start cooling and return the event plus an atomic lightweight snapshot."""
+        with self._lock:
+            event = self.start_cooling(session)
+            return event, _copy_session_for_read(session)
 
     def stop_cooling(self, session: RoastSession) -> RoastEvent:
         """Stop cooling for one active session."""
@@ -398,6 +440,12 @@ class RoastSessionStore:
                 phase="complete",
             )
             return event
+
+    def stop_cooling_snapshot(self, session: RoastSession) -> tuple[RoastEvent, RoastSession]:
+        """Stop cooling and return the event plus an atomic lightweight snapshot."""
+        with self._lock:
+            event = self.stop_cooling(session)
+            return event, _copy_session_for_read(session)
 
     def record_event(
         self,
@@ -442,6 +490,18 @@ class RoastSessionStore:
             _apply_event_timestamp(session, event)
             return event
 
+    def record_event_snapshot(
+        self,
+        session: RoastSession,
+        kind: RoastEventKind,
+        *,
+        payload: dict[str, EventPayloadValue] | None = None,
+    ) -> tuple[RoastEvent, RoastSession]:
+        """Record one event and return the event plus an atomic lightweight snapshot."""
+        with self._lock:
+            event = self.record_event(session, kind, payload=payload)
+            return event, _copy_session_for_read(session)
+
     def emergency_stop(
         self,
         session: RoastSession,
@@ -461,6 +521,17 @@ class RoastSessionStore:
                 phase="fault",
             )
             return event
+
+    def emergency_stop_snapshot(
+        self,
+        session: RoastSession,
+        *,
+        reason: str,
+    ) -> tuple[RoastEvent, RoastSession]:
+        """Apply emergency stop and return the event plus an atomic lightweight snapshot."""
+        with self._lock:
+            event = self.emergency_stop(session, reason=reason)
+            return event, _copy_session_for_read(session)
 
     def get_active_session(self) -> RoastSession | None:
         """Return the current active session when present."""
@@ -491,12 +562,12 @@ class RoastSessionStore:
                     raise SessionLifecycleError(f"Unknown session_id: {session_id}")
             if active_only and not session.active:
                 raise SessionLifecycleError("No active roast session exists.")
-            return deepcopy(session)
+            return _copy_session_for_read(session)
 
     def copy_session(self, session: RoastSession) -> RoastSession:
         """Return a deep-copied snapshot of one known session object under the store lock."""
         with self._lock:
-            return deepcopy(session)
+            return _copy_session_for_read(session)
 
     @property
     def telemetry_buffer_limit(self) -> int:
@@ -522,6 +593,17 @@ class RoastSessionStore:
             if event.kind == kind:
                 return event
         return None
+
+    def _prune_session_history_locked(self) -> None:
+        """Evict oldest completed sessions once retained history exceeds the limit."""
+        while len(self._session_id_order) > self._session_history_limit:
+            oldest_session_id = self._session_id_order[0]
+            oldest_session = self._sessions_by_id.get(oldest_session_id)
+            if oldest_session is not None and oldest_session.active:
+                break
+            self._session_id_order.popleft()
+            if oldest_session is not None:
+                del self._sessions_by_id[oldest_session_id]
 
 
 def _apply_event_timestamp(session: RoastSession, event: RoastEvent) -> None:
@@ -563,6 +645,13 @@ def _apply_event_timestamp(session: RoastSession, event: RoastEvent) -> None:
 def _generate_session_id() -> str:
     """Return a stable opaque session identifier."""
     return uuid4().hex
+
+
+def _copy_session_for_read(session: RoastSession) -> RoastSession:
+    """Return a lightweight read snapshot without telemetry buffer retention."""
+    snapshot = deepcopy(session)
+    snapshot.telemetry_buffer = deque()
+    return snapshot
 
 
 def _validate_control_percent(value: object, *, label: str) -> int:

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -649,9 +649,32 @@ def _generate_session_id() -> str:
 
 def _copy_session_for_read(session: RoastSession) -> RoastSession:
     """Return a lightweight read snapshot without telemetry buffer retention."""
-    snapshot = deepcopy(session)
-    snapshot.telemetry_buffer = deque()
-    return snapshot
+    return RoastSession(
+        id=session.id,
+        created_at_utc=session.created_at_utc,
+        monotonic_start=session.monotonic_start,
+        phase=session.phase,
+        beans_added_at_utc=session.beans_added_at_utc,
+        beans_added_monotonic_seconds=session.beans_added_monotonic_seconds,
+        first_crack_at_utc=session.first_crack_at_utc,
+        first_crack_monotonic_seconds=session.first_crack_monotonic_seconds,
+        beans_dropped_at_utc=session.beans_dropped_at_utc,
+        beans_dropped_monotonic_seconds=session.beans_dropped_monotonic_seconds,
+        cooling_started_at_utc=session.cooling_started_at_utc,
+        cooling_started_monotonic_seconds=session.cooling_started_monotonic_seconds,
+        cooling_stopped_at_utc=session.cooling_stopped_at_utc,
+        cooling_stopped_monotonic_seconds=session.cooling_stopped_monotonic_seconds,
+        faulted_at_utc=session.faulted_at_utc,
+        faulted_monotonic_seconds=session.faulted_monotonic_seconds,
+        heat_level_percent=session.heat_level_percent,
+        fan_level_percent=session.fan_level_percent,
+        cooling_on=session.cooling_on,
+        event_timeline=deepcopy(session.event_timeline),
+        telemetry_buffer=deque(),
+        log_writer=session.log_writer,
+        stopped_at_utc=session.stopped_at_utc,
+        monotonic_stop=session.monotonic_stop,
+    )
 
 
 def _validate_control_percent(value: object, *, label: str) -> int:

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -353,7 +353,7 @@ class RoastSessionStore:
                 heat_level_percent,
                 label="heat_level_percent",
             )
-            if session.phase == "fault" and validated_heat > 0:
+            if session.faulted_at_utc is not None and validated_heat > 0:
                 raise SessionLifecycleError("Heat cannot be increased after a fault.")
             session.heat_level_percent = validated_heat
             return session
@@ -379,8 +379,6 @@ class RoastSessionStore:
             self._assert_latest_active_session(session)
             if session.beans_dropped_at_utc is None:
                 raise SessionLifecycleError("Cooling can only start after beans are dropped.")
-            session.cooling_on = True
-            session.phase = "cooling"
             return self.record_event(session, "cooling_started")
 
     def stop_cooling(self, session: RoastSession) -> RoastEvent:
@@ -423,7 +421,7 @@ class RoastSessionStore:
         """
         with self._lock:
             self._assert_latest_active_session(session)
-            if session.phase == "fault" and kind != "fault":
+            if session.faulted_at_utc is not None and kind != "fault":
                 raise SessionLifecycleError("No non-fault events can be recorded after a fault.")
 
             existing_event = self._get_existing_singleton_event(session, kind)
@@ -489,6 +487,11 @@ class RoastSessionStore:
             if active_only and not self._latest_session.active:
                 raise SessionLifecycleError("No active roast session exists.")
             return deepcopy(self._latest_session)
+
+    def copy_session(self, session: RoastSession) -> RoastSession:
+        """Return a deep-copied snapshot of one known session object under the store lock."""
+        with self._lock:
+            return deepcopy(session)
 
     @property
     def telemetry_buffer_limit(self) -> int:

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -149,6 +149,9 @@ class RoastSession:
         cooling_stopped_monotonic_seconds: Monotonic elapsed seconds for cooling stop.
         faulted_at_utc: Wall-clock UTC timestamp for the first recorded fault.
         faulted_monotonic_seconds: Monotonic elapsed seconds for the first fault.
+        heat_level_percent: Latest in-memory heat setting for the active mock path.
+        fan_level_percent: Latest in-memory fan setting for the active mock path.
+        cooling_on: Whether cooling is currently active in the session state.
         event_timeline: Shared ordered event timeline for future runtime stories.
         telemetry_buffer: Rolling telemetry sample buffer.
         log_writer: Append-only log writer reference when available.
@@ -172,6 +175,9 @@ class RoastSession:
     cooling_stopped_monotonic_seconds: float | None = None
     faulted_at_utc: datetime | None = None
     faulted_monotonic_seconds: float | None = None
+    heat_level_percent: int = 0
+    fan_level_percent: int = 0
+    cooling_on: bool = False
     event_timeline: list[RoastEvent] = field(default_factory=_event_timeline_default)
     telemetry_buffer: deque[TelemetrySample] = field(default_factory=_telemetry_buffer_default)
     log_writer: LogWriterReference | None = None
@@ -333,6 +339,62 @@ class RoastSessionStore:
                 max_samples=self._telemetry_buffer_limit,
             )
 
+    def set_heat(
+        self,
+        session: RoastSession,
+        *,
+        heat_level_percent: int,
+    ) -> RoastSession:
+        """Set the latest in-memory heat value for one active session."""
+        with self._lock:
+            self._assert_latest_active_session(session)
+            session.heat_level_percent = _validate_control_percent(
+                heat_level_percent,
+                label="heat_level_percent",
+            )
+            return session
+
+    def set_fan(
+        self,
+        session: RoastSession,
+        *,
+        fan_level_percent: int,
+    ) -> RoastSession:
+        """Set the latest in-memory fan value for one active session."""
+        with self._lock:
+            self._assert_latest_active_session(session)
+            session.fan_level_percent = _validate_control_percent(
+                fan_level_percent,
+                label="fan_level_percent",
+            )
+            return session
+
+    def start_cooling(self, session: RoastSession) -> RoastEvent:
+        """Start cooling for one active session."""
+        with self._lock:
+            self._assert_latest_active_session(session)
+            if session.beans_dropped_at_utc is None:
+                raise SessionLifecycleError("Cooling can only start after beans are dropped.")
+            session.cooling_on = True
+            session.phase = "cooling"
+            return self.record_event(session, "cooling_started")
+
+    def stop_cooling(self, session: RoastSession) -> RoastEvent:
+        """Stop cooling for one active session."""
+        with self._lock:
+            self._assert_latest_active_session(session)
+            if session.beans_dropped_at_utc is None:
+                raise SessionLifecycleError("Cooling cannot stop before beans are dropped.")
+            if session.cooling_started_at_utc is None or not session.cooling_on:
+                raise SessionLifecycleError("Cooling must be started before it can be stopped.")
+            event = self.record_event(session, "cooling_stopped")
+            session.stop(
+                utc_now=self._utc_now,
+                monotonic_now=self._monotonic_now,
+                phase="complete",
+            )
+            return event
+
     def record_event(
         self,
         session: RoastSession,
@@ -415,26 +477,35 @@ class RoastSessionStore:
 def _apply_event_timestamp(session: RoastSession, event: RoastEvent) -> None:
     """Update authoritative event timestamp fields from one timeline event."""
     if event.kind == "beans_added":
+        session.phase = "roasting"
         session.beans_added_at_utc = event.recorded_at_utc
         session.beans_added_monotonic_seconds = event.monotonic_seconds
         return
     if event.kind == "first_crack_detected":
+        session.phase = "development"
         session.first_crack_at_utc = event.recorded_at_utc
         session.first_crack_monotonic_seconds = event.monotonic_seconds
         return
     if event.kind == "beans_dropped":
+        session.phase = "dropped"
+        session.heat_level_percent = 0
         session.beans_dropped_at_utc = event.recorded_at_utc
         session.beans_dropped_monotonic_seconds = event.monotonic_seconds
         return
     if event.kind == "cooling_started":
+        session.phase = "cooling"
+        session.cooling_on = True
         session.cooling_started_at_utc = event.recorded_at_utc
         session.cooling_started_monotonic_seconds = event.monotonic_seconds
         return
     if event.kind == "cooling_stopped":
+        session.cooling_on = False
+        session.phase = "complete" if session.beans_dropped_at_utc is not None else "pre_roast"
         session.cooling_stopped_at_utc = event.recorded_at_utc
         session.cooling_stopped_monotonic_seconds = event.monotonic_seconds
         return
     if event.kind == "fault" and session.faulted_at_utc is None:
+        session.phase = "fault"
         session.faulted_at_utc = event.recorded_at_utc
         session.faulted_monotonic_seconds = event.monotonic_seconds
 
@@ -442,3 +513,10 @@ def _apply_event_timestamp(session: RoastSession, event: RoastEvent) -> None:
 def _generate_session_id() -> str:
     """Return a stable opaque session identifier."""
     return uuid4().hex
+
+
+def _validate_control_percent(value: int, *, label: str) -> int:
+    """Validate one percentage-like control input."""
+    if not 0 <= value <= 100:
+        raise ValueError(f"{label} must be between 0 and 100.")
+    return value

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -216,11 +216,10 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         assert export_result.structuredContent["ready"] is False
         export_log_dir = Path(export_result.structuredContent["log_dir"])
         export_jsonl_path = Path(export_result.structuredContent["jsonl_path"])
-        resolved_export_log_dir = (
-            export_log_dir if export_log_dir.is_absolute() else tmp_path / export_log_dir
-        )
+        assert export_log_dir.is_absolute()
+        assert export_jsonl_path.is_absolute()
         assert export_jsonl_path.name == "roast.jsonl"
-        assert not resolved_export_log_dir.exists()
+        assert not export_log_dir.exists()
 
         second_start_result = cast(
             Any,

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -204,6 +204,7 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
             "cooling_started",
             "cooling_stopped",
         ]
+        assert state_result.structuredContent["events"][2]["payload"] == {}
 
         export_result = cast(
             Any,
@@ -230,6 +231,9 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         assert emergency_stop_result.structuredContent["session_id"] == second_session_id
         assert emergency_stop_result.structuredContent["event"]["kind"] == "fault"
         assert emergency_stop_result.structuredContent["phase"] == "fault"
+        assert emergency_stop_result.structuredContent["event"]["payload"] == {
+            "reason": "test-path"
+        }
 
         faulted_state_result = cast(
             Any,
@@ -239,12 +243,24 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         )
         assert faulted_state_result.structuredContent["active"] is False
         assert faulted_state_result.structuredContent["phase"] == "fault"
+        assert faulted_state_result.structuredContent["events"][-1]["payload"] == {
+            "reason": "test-path"
+        }
 
         third_start_result = cast(
             Any,
             await _call_with_timeout(session.call_tool("start_roast_session", {})),
         )
         assert third_start_result.structuredContent["session"]["session_id"] != second_session_id
+
+        old_session_state_after_rollover = cast(
+            Any,
+            await _call_with_timeout(
+                session.call_tool("get_roast_state", {"session_id": session_id})
+            ),
+        )
+        assert old_session_state_after_rollover.structuredContent["session_id"] == session_id
+        assert old_session_state_after_rollover.structuredContent["active"] is False
 
 
 def test_stdio_server_rejects_manual_first_crack_override_when_disabled(tmp_path: Path) -> None:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -214,8 +214,13 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         )
         assert export_result.structuredContent["session_id"] == session_id
         assert export_result.structuredContent["ready"] is False
-        assert export_result.structuredContent["jsonl_path"].endswith("/roast.jsonl")
-        assert not Path(export_result.structuredContent["log_dir"]).exists()
+        export_log_dir = Path(export_result.structuredContent["log_dir"])
+        export_jsonl_path = Path(export_result.structuredContent["jsonl_path"])
+        resolved_export_log_dir = (
+            export_log_dir if export_log_dir.is_absolute() else tmp_path / export_log_dir
+        )
+        assert export_jsonl_path.name == "roast.jsonl"
+        assert not resolved_export_log_dir.exists()
 
         second_start_result = cast(
             Any,

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -200,6 +200,7 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         assert export_result.structuredContent["session_id"] == session_id
         assert export_result.structuredContent["ready"] is False
         assert export_result.structuredContent["jsonl_path"].endswith("/roast.jsonl")
+        assert not Path(export_result.structuredContent["log_dir"]).exists()
 
         second_start_result = cast(
             Any,
@@ -215,6 +216,21 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         assert emergency_stop_result.structuredContent["session_id"] == second_session_id
         assert emergency_stop_result.structuredContent["event"]["kind"] == "fault"
         assert emergency_stop_result.structuredContent["phase"] == "fault"
+
+        faulted_state_result = cast(
+            Any,
+            await _call_with_timeout(
+                session.call_tool("get_roast_state", {"session_id": second_session_id})
+            ),
+        )
+        assert faulted_state_result.structuredContent["active"] is False
+        assert faulted_state_result.structuredContent["phase"] == "fault"
+
+        third_start_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("start_roast_session", {})),
+        )
+        assert third_start_result.structuredContent["session"]["session_id"] != second_session_id
 
 
 def test_stdio_server_rejects_manual_first_crack_override_when_disabled(tmp_path: Path) -> None:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -151,12 +151,26 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         assert first_crack_result.structuredContent["event"]["kind"] == "first_crack_detected"
         assert first_crack_result.structuredContent["phase"] == "development"
 
+        repeated_beans_added_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("mark_beans_added", {})),
+        )
+        assert repeated_beans_added_result.structuredContent["event"]["kind"] == "beans_added"
+        assert repeated_beans_added_result.structuredContent["event_count"] == 2
+
         drop_result = cast(
             Any,
             await _call_with_timeout(session.call_tool("drop_beans", {})),
         )
         assert drop_result.structuredContent["event"]["kind"] == "beans_dropped"
         assert drop_result.structuredContent["phase"] == "dropped"
+
+        repeated_drop_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("drop_beans", {})),
+        )
+        assert repeated_drop_result.structuredContent["event"]["kind"] == "beans_dropped"
+        assert repeated_drop_result.structuredContent["event_count"] == 3
 
         cooling_result = cast(
             Any,

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -71,7 +71,21 @@ async def _assert_stdio_server_tools(tmp_path: Path) -> None:
 
         tools = cast(Any, await _call_with_timeout(session.list_tools()))
         tool_names = {tool.name for tool in tools.tools}
-        assert tool_names == {"get_server_info", "get_runtime_config"}
+        assert tool_names == {
+            "drop_beans",
+            "emergency_stop",
+            "export_roast_log",
+            "get_roast_state",
+            "get_runtime_config",
+            "get_server_info",
+            "mark_beans_added",
+            "mark_first_crack",
+            "set_fan",
+            "set_heat",
+            "start_cooling",
+            "start_roast_session",
+            "stop_cooling",
+        }
 
         server_info = cast(Any, await _call_with_timeout(session.call_tool("get_server_info", {})))
         assert server_info.structuredContent is not None
@@ -85,6 +99,152 @@ async def _assert_stdio_server_tools(tmp_path: Path) -> None:
         assert runtime_config.structuredContent is not None
         assert runtime_config.structuredContent["roaster_driver"] == "mock"
         assert runtime_config.structuredContent["first_crack_mode"] == "disabled"
+
+
+def test_stdio_server_supports_basic_mock_roast_tool_flow(tmp_path: Path) -> None:
+    asyncio.run(_assert_basic_mock_roast_flow(tmp_path))
+
+
+async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "coffee_roaster_mcp.cli", "serve"],
+        env=_build_clean_server_env(),
+        cwd=tmp_path,
+    )
+
+    async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
+        await _call_with_timeout(session.initialize())
+
+        start_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("start_roast_session", {})),
+        )
+        started_session = start_result.structuredContent["session"]
+        session_id = started_session["session_id"]
+        assert started_session["phase"] == "pre_roast"
+        assert started_session["active"] is True
+
+        heat_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("set_heat", {"heat_level_percent": 60})),
+        )
+        assert heat_result.structuredContent["heat_level_percent"] == 60
+
+        fan_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("set_fan", {"fan_level_percent": 35})),
+        )
+        assert fan_result.structuredContent["fan_level_percent"] == 35
+
+        beans_added_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("mark_beans_added", {})),
+        )
+        assert beans_added_result.structuredContent["event"]["kind"] == "beans_added"
+        assert beans_added_result.structuredContent["phase"] == "roasting"
+
+        first_crack_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("mark_first_crack", {})),
+        )
+        assert first_crack_result.structuredContent["event"]["kind"] == "first_crack_detected"
+        assert first_crack_result.structuredContent["phase"] == "development"
+
+        drop_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("drop_beans", {})),
+        )
+        assert drop_result.structuredContent["event"]["kind"] == "beans_dropped"
+        assert drop_result.structuredContent["phase"] == "dropped"
+
+        cooling_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("start_cooling", {})),
+        )
+        assert cooling_result.structuredContent["event"]["kind"] == "cooling_started"
+        assert cooling_result.structuredContent["phase"] == "cooling"
+
+        stopped_cooling_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("stop_cooling", {})),
+        )
+        assert stopped_cooling_result.structuredContent["event"]["kind"] == "cooling_stopped"
+        assert stopped_cooling_result.structuredContent["phase"] == "complete"
+
+        state_result = cast(
+            Any,
+            await _call_with_timeout(
+                session.call_tool("get_roast_state", {"session_id": session_id})
+            ),
+        )
+        assert state_result.structuredContent["session_id"] == session_id
+        assert state_result.structuredContent["active"] is False
+        assert state_result.structuredContent["heat_level_percent"] == 0
+        assert state_result.structuredContent["fan_level_percent"] == 35
+        assert state_result.structuredContent["cooling_on"] is False
+        assert [event["kind"] for event in state_result.structuredContent["events"]] == [
+            "beans_added",
+            "first_crack_detected",
+            "beans_dropped",
+            "cooling_started",
+            "cooling_stopped",
+        ]
+
+        export_result = cast(
+            Any,
+            await _call_with_timeout(
+                session.call_tool("export_roast_log", {"session_id": session_id})
+            ),
+        )
+        assert export_result.structuredContent["session_id"] == session_id
+        assert export_result.structuredContent["ready"] is False
+        assert export_result.structuredContent["jsonl_path"].endswith("/roast.jsonl")
+
+        second_start_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("start_roast_session", {})),
+        )
+        second_session_id = second_start_result.structuredContent["session"]["session_id"]
+        assert second_session_id != session_id
+
+        emergency_stop_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("emergency_stop", {"reason": "test-path"})),
+        )
+        assert emergency_stop_result.structuredContent["session_id"] == second_session_id
+        assert emergency_stop_result.structuredContent["event"]["kind"] == "fault"
+        assert emergency_stop_result.structuredContent["phase"] == "fault"
+
+
+def test_stdio_server_rejects_manual_first_crack_override_when_disabled(tmp_path: Path) -> None:
+    asyncio.run(_assert_manual_override_disabled(tmp_path))
+
+
+async def _assert_manual_override_disabled(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "first_crack:\n  allow_manual_override: false\n",
+        encoding="utf-8",
+    )
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "coffee_roaster_mcp.cli", "serve"],
+        env=_build_clean_server_env(),
+        cwd=tmp_path,
+    )
+
+    async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
+        await _call_with_timeout(session.initialize())
+        await _call_with_timeout(session.call_tool("start_roast_session", {}))
+
+        result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("mark_first_crack", {})),
+        )
+        assert result.isError is True
+        assert result.content is not None
+        assert "Manual first-crack override is disabled" in result.content[0].text
 
 
 def test_stdio_server_reports_manual_mode_as_bootstrap_safe(tmp_path: Path) -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -165,6 +165,63 @@ def test_start_session_allows_new_session_after_previous_stop() -> None:
     assert store.get_latest_session() is second_session
 
 
+def test_start_cooling_rejects_session_before_bean_drop() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    with pytest.raises(SessionLifecycleError, match="after beans are dropped"):
+        store.start_cooling(session)
+
+
+def test_stop_cooling_marks_session_complete_and_stopped() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_dropped")
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 2, tzinfo=UTC)
+    clock.monotonic_value = 110.0
+    store.start_cooling(session)
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 3, tzinfo=UTC)
+    clock.monotonic_value = 120.0
+    event = store.stop_cooling(session)
+
+    assert event.kind == "cooling_stopped"
+    assert session.phase == "complete"
+    assert session.active is False
+    assert session.cooling_on is False
+    assert session.stopped_at_utc == datetime(2026, 5, 4, 12, 3, tzinfo=UTC)
+    assert session.monotonic_stop == 120.0
+    assert store.get_active_session() is None
+
+
+def test_stop_cooling_rejects_session_when_cooling_not_started() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_dropped")
+
+    with pytest.raises(SessionLifecycleError, match="must be started"):
+        store.stop_cooling(session)
+
+
 def test_store_append_telemetry_rejects_non_latest_session() -> None:
     clock = ClockHarness()
     issued_ids = iter(["session-001", "session-002"])

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -254,6 +254,23 @@ def test_record_event_rejects_non_fault_events_after_fault() -> None:
         store.record_event(session, "beans_dropped")
 
 
+def test_start_cooling_rejects_session_that_has_faulted() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_dropped")
+    store.record_event(session, "fault", payload={"reason": "test"})
+
+    with pytest.raises(SessionLifecycleError, match="No non-fault events"):
+        store.start_cooling(session)
+
+
 def test_stop_cooling_rejects_session_when_cooling_not_started() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -206,6 +206,54 @@ def test_stop_cooling_marks_session_complete_and_stopped() -> None:
     assert store.get_active_session() is None
 
 
+def test_emergency_stop_faults_and_stops_session() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 4, tzinfo=UTC)
+    clock.monotonic_value = 130.0
+    event = store.emergency_stop(session, reason="test-fault")
+
+    assert event.kind == "fault"
+    assert session.phase == "fault"
+    assert session.active is False
+    assert session.heat_level_percent == 0
+    assert session.fan_level_percent == 100
+    assert session.cooling_on is True
+    assert session.stopped_at_utc == datetime(2026, 5, 4, 12, 4, tzinfo=UTC)
+    assert session.monotonic_stop == 130.0
+
+
+def test_set_heat_rejects_faulted_session() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+    store.emergency_stop(session, reason="test-fault")
+
+    with pytest.raises(SessionLifecycleError, match="Stopped sessions"):
+        store.set_heat(session, heat_level_percent=50)
+
+
+def test_record_event_rejects_non_fault_events_after_fault() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+    store.emergency_stop(session, reason="test-fault")
+
+    with pytest.raises(SessionLifecycleError, match="Stopped sessions"):
+        store.record_event(session, "beans_dropped")
+
+
 def test_stop_cooling_rejects_session_when_cooling_not_started() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(
@@ -220,6 +268,17 @@ def test_stop_cooling_rejects_session_when_cooling_not_started() -> None:
 
     with pytest.raises(SessionLifecycleError, match="must be started"):
         store.stop_cooling(session)
+
+
+def test_set_heat_rejects_non_integer_values() -> None:
+    store = RoastSessionStore()
+    session = store.start_session()
+
+    with pytest.raises(TypeError, match="integer"):
+        store.set_heat(session, heat_level_percent=True)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="integer"):
+        store.set_heat(session, heat_level_percent=12.5)  # type: ignore[arg-type]
 
 
 def test_store_append_telemetry_rejects_non_latest_session() -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -165,6 +165,33 @@ def test_start_session_allows_new_session_after_previous_stop() -> None:
     assert store.get_latest_session() is second_session
 
 
+def test_get_session_snapshot_supports_completed_session_after_rollover() -> None:
+    clock = ClockHarness()
+    issued_ids = iter(["session-001", "session-002"])
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        session_id_factory=lambda: next(issued_ids),
+    )
+
+    first_session = store.start_session()
+    clock.utc_value = datetime(2026, 5, 4, 12, 5, tzinfo=UTC)
+    clock.monotonic_value = 120.0
+    store.stop_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 6, tzinfo=UTC)
+    clock.monotonic_value = 121.0
+    second_session = store.start_session()
+
+    first_snapshot = store.get_session_snapshot(session_id=first_session.id)
+    second_snapshot = store.get_session_snapshot(session_id=second_session.id)
+
+    assert first_snapshot.id == first_session.id
+    assert first_snapshot.active is False
+    assert second_snapshot.id == second_session.id
+    assert second_snapshot.active is True
+
+
 def test_start_cooling_rejects_session_before_bean_drop() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -100,6 +100,11 @@ def test_negative_telemetry_buffer_limit_is_rejected() -> None:
         RoastSessionStore(telemetry_buffer_limit=-1)
 
 
+def test_session_history_limit_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="session_history_limit"):
+        RoastSessionStore(session_history_limit=0)
+
+
 def test_stop_session_returns_none_after_session_already_stopped() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(
@@ -190,6 +195,35 @@ def test_get_session_snapshot_supports_completed_session_after_rollover() -> Non
     assert first_snapshot.active is False
     assert second_snapshot.id == second_session.id
     assert second_snapshot.active is True
+
+
+def test_oldest_completed_session_is_evicted_when_history_limit_is_exceeded() -> None:
+    clock = ClockHarness()
+    issued_ids = iter(["session-001", "session-002", "session-003"])
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        session_id_factory=lambda: next(issued_ids),
+        session_history_limit=2,
+    )
+
+    first_session = store.start_session()
+    store.stop_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    clock.monotonic_value = 101.0
+    second_session = store.start_session()
+    store.stop_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 2, tzinfo=UTC)
+    clock.monotonic_value = 102.0
+    third_session = store.start_session()
+
+    with pytest.raises(SessionLifecycleError, match=first_session.id):
+        store.get_session_snapshot(session_id=first_session.id)
+
+    assert store.get_session_snapshot(session_id=second_session.id).id == second_session.id
+    assert store.get_session_snapshot(session_id=third_session.id).id == third_session.id
 
 
 def test_start_cooling_rejects_session_before_bean_drop() -> None:


### PR DESCRIPTION
## Summary
- add the first roast-session MCP tool surface on top of the authoritative session core
- enforce correct cooling lifecycle completion and manual first-crack override rules
- update docs and durable state to mark E2-S4 complete and move active context to E2-S5

## Why
Story #19 requires the first real mock-path MCP control surface before later phase, safety, and logging stories can build on stable session behavior. This change keeps all mutations behind the single in-process session owner and tightens the lifecycle semantics found during review.

## Validation
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`

## Story
- closes #19