### PR TITLE
E2-S6: Add driver-owned emergency stop safety

### DIFF
--- a/docs/session-summaries/2026-05-04-e2-s6-pr75-emergency-stop-review-cycle.md
+++ b/docs/session-summaries/2026-05-04-e2-s6-pr75-emergency-stop-review-cycle.md
@@ -1,0 +1,353 @@
+# Session Summary: E2-S6 PR 75 Emergency Stop And Review Cycle
+
+Date: 2026-05-04
+
+Repository: `syamaner/coffee-roaster-mcp`
+
+Branch at summary time: `feature/21-emergency-stop-fault-recording`
+
+PR: `#75` - `E2-S6: Add driver-owned emergency stop safety`
+
+Story: `#21` - `E2-S6: Implement emergency stop and fault recording`
+
+## Purpose
+
+This summary captures the E2-S6 implementation and review cycle.
+
+The main outcomes were:
+
+- extend emergency-stop behavior into a driver-owned mock safety boundary
+- preserve the E2-S4/E2-S5 one-session store boundary and MCP semantics
+- keep fault recording and stopped-session state authoritative in `RoastSessionStore`
+- respond to multiple Codex and Copilot review rounds around safety atomicity, driver failure handling, concurrency, and payload semantics
+- preserve a non-account context snapshot for compaction and resume
+
+## Non-PII Codex Status Snapshot
+
+Snapshot provided near the end of the PR `#75` review cycle:
+
+- Session ID: intentionally not retained in durable state
+- Context window: `28% left (189K used / 258K)`
+- 5h limit: `96% left` (reset shown as `22:14`)
+- Weekly limit: `97% left` (reset shown as `20:43 on 10 May`)
+- GPT-5.3-Codex-Spark 5h limit: `100% left` (reset shown as `01:06 on 5 May`)
+- GPT-5.3-Codex-Spark weekly limit: `100% left` (reset shown as `20:06 on 11 May`)
+- Warning: limits may be stale; run `/status` again shortly
+
+Context-window progression during this story:
+
+- E2-S5 summary snapshot: `39% left (162K used / 258K)`.
+- E2-S6 summary snapshot: `28% left (189K used / 258K)`.
+- E2-S6 consumed roughly `27K` additional context tokens.
+- The increase was driven mostly by PR review loops, repeated GitHub thread inspection, patch iteration, validation output, and review-thread resolution tracking.
+
+Fields intentionally excluded:
+
+- account identity
+- durable session identifier
+
+## Story Outcome
+
+Issue `#21` acceptance criteria:
+
+- emergency stop records an event
+- emergency stop calls the active driver safety method
+- fault state is visible in `get_roast_state`
+- emergency stop unit test with mock driver
+
+PR `#75` includes `Closes #21` in the PR body, so the story should close automatically when merged.
+
+Current PR state at summary time:
+
+- PR is open and pushed
+- branch is clean
+- GitHub CI has passed after the latest commit
+- all review threads are resolved
+
+## What Changed
+
+### Driver-owned emergency stop
+
+- Added `src/coffee_roaster_mcp/drivers.py`.
+- Added `RoasterSafetyDriver` protocol for the minimal E2-S6 safety boundary.
+- Added `MockRoasterDriver.emergency_stop(...)`.
+- Added `EmergencyStopResult.as_event_payload()`.
+- Added `create_roaster_safety_driver(...)`.
+
+This was intentionally not the full E3 driver architecture. It is the smallest E2-S6 boundary needed to prove emergency stop goes through configured driver-owned safety behavior while keeping the current in-process session model intact.
+
+### MCP integration
+
+- `ServerContext` now owns a configured `roaster_driver`.
+- `build_server_context(...)` creates the driver from config.
+- Unknown driver setup is wrapped as `ConfigError` instead of leaking a raw `ValueError`.
+- MCP `emergency_stop` calls the configured driver safety method and passes the safety payload into the session store.
+- Driver-call failures return a fail-closed payload with heat `0`, fan `100`, cooling `on`, `driver_safety_method_called: false`, and a `driver_error`.
+
+### Session-store semantics
+
+- `RoastSessionStore` remains the authoritative mutation and snapshot boundary.
+- `emergency_stop(...)` applies safety payload state, records a `fault`, and stops or faults the latest session.
+- The store preserves the core `reason` field even if driver payload contains a colliding `reason`.
+- The fail-closed payload/state helper is centralized as `default_emergency_safety_payload(...)`.
+- `emergency_stop_snapshot(..., allow_stopped_latest=True)` can append a fault to the same latest session if the driver already ran and another tool stopped the session in the race window.
+
+### Tests
+
+Added or updated coverage for:
+
+- mock driver factory and emergency-stop payload
+- MCP emergency-stop payload visibility through `get_roast_state`
+- driver failure fail-closed payload
+- unknown driver config error wrapping
+- fallback semantics where no driver call occurred
+- payload collision preserving core `reason`
+- stopped-latest race after driver side effect still recording a fault
+
+## Review Feedback Classification
+
+### Codex Review: Driver exception must fail closed
+
+Finding:
+
+- If the driver safety callback raised, the original implementation exited before fault recording and before session stop.
+- That left the session active and unfaulted after an emergency-stop request.
+
+Classification:
+
+- Severity: high
+- Type: safety atomicity
+- Importance: critical to fix before merge
+
+Response:
+
+- Wrapped driver emergency-stop execution.
+- On driver failure, returned a fail-closed payload.
+- Store still records a `fault` and stops the session.
+- Added tests for driver failure behavior.
+
+Value:
+
+- Very high. This found the most important safety bug in the first E2-S6 implementation.
+
+### Copilot Review: Driver call under store lock
+
+Finding:
+
+- Calling driver safety behavior inside the store lock could block unrelated MCP tool calls when future non-mock drivers perform I/O.
+
+Classification:
+
+- Severity: medium-high
+- Type: concurrency and architecture boundary
+- Importance: important to fix now to avoid encoding the wrong driver/store boundary
+
+Response:
+
+- Moved driver execution out of the store lock.
+- Store now receives a completed safety payload.
+- Store remains authoritative for event and phase mutation.
+
+Value:
+
+- High. It forced a cleaner separation between driver-owned I/O and store-owned state mutation.
+
+### Copilot Review: Payload collision on `reason`
+
+Finding:
+
+- `event_payload.update(safety_payload)` allowed driver payload to overwrite core fields such as `reason`.
+
+Classification:
+
+- Severity: medium
+- Type: MCP response contract and diagnostics stability
+- Importance: worthwhile to fix
+
+Response:
+
+- Built emergency fault payloads so core `reason` is assigned after driver payload merge.
+- Added a regression test for a colliding driver `reason`.
+
+Value:
+
+- Medium-high. It protected a user-visible MCP field from accidental driver overwrite.
+
+### Copilot Review: stale MCP docstring
+
+Finding:
+
+- The MCP `emergency_stop` docstring still described mock-safe state mutation even after behavior moved through the configured driver safety method.
+
+Classification:
+
+- Severity: low
+- Type: documentation accuracy
+- Importance: easy cleanup
+
+Response:
+
+- Updated docstring to describe driver safety method plus fault recording.
+
+Value:
+
+- Low to medium. It avoids misleading MCP tool documentation.
+
+### Copilot Review: fallback says driver method called
+
+Finding:
+
+- Store fallback payload represented unavailable driver behavior but set `driver_safety_method_called: true`.
+
+Classification:
+
+- Severity: medium
+- Type: diagnostic accuracy
+- Importance: important because payloads may be used for safety diagnosis
+
+Response:
+
+- Changed fallback payload to `driver_safety_method_called: false`.
+- Updated tests for store default emergency stop behavior.
+
+Value:
+
+- Medium. It corrected safety telemetry semantics.
+
+### Copilot Review: unknown driver should be `ConfigError`
+
+Finding:
+
+- `create_roaster_safety_driver(...)` raised `ValueError`, which could leak as an inconsistent config failure from `build_server_context(...)`.
+
+Classification:
+
+- Severity: medium-low
+- Type: configuration error handling
+- Importance: useful hardening
+
+Response:
+
+- Caught `ValueError` in `build_server_context(...)`.
+- Re-raised as `ConfigError`.
+- Added a test for unknown driver config.
+
+Value:
+
+- Medium. It improved startup diagnostics and preserved the existing config-error contract.
+
+### Copilot Review: duplicate transition validation
+
+Finding:
+
+- `emergency_stop(...)` validated `fault` transition before calling `record_event(...)`, which already validates transitions.
+
+Classification:
+
+- Severity: low
+- Type: code maintainability
+- Importance: cleanup
+
+Response:
+
+- Removed the duplicate validation.
+
+Value:
+
+- Low to medium. It kept lifecycle validation centralized.
+
+### Copilot Review: race after driver call before store fault
+
+Finding:
+
+- After moving driver execution outside the store lock, another tool could stop the same session between `_require_active_session()` and `emergency_stop_snapshot(...)`.
+- In that case, the driver side effect could happen without a recorded fault.
+
+Classification:
+
+- Severity: high
+- Type: concurrency and safety atomicity
+- Importance: critical to fix before merge
+
+Response:
+
+- Added `allow_stopped_latest=True` for the MCP emergency-stop path.
+- Added store support to append a fault to the same latest session after it has stopped, specifically for the driver-already-ran race.
+- Preserved the original stop timestamp while setting final phase to `fault`.
+- Added regression coverage.
+
+Value:
+
+- Very high. It caught the main correctness hole introduced by the prior lock-boundary fix.
+
+### Copilot Review: duplicated fail-closed defaults
+
+Finding:
+
+- `run_driver_emergency_stop(...)` duplicated heat `0`, fan `100`, cooling `on` defaults that also existed in the store fallback.
+
+Classification:
+
+- Severity: medium
+- Type: safety default drift risk
+- Importance: important because duplicated safety constants can diverge
+
+Response:
+
+- Centralized the fail-closed payload in `default_emergency_safety_payload(...)`.
+- Reused it from MCP driver-failure handling.
+
+Value:
+
+- Medium-high. It reduced drift risk in safety-critical defaults.
+
+## Commit Timeline For PR 75
+
+1. `cb4c229` - `feat: add driver-owned emergency stop safety`
+2. `d7cb970` - `fix: harden driver emergency stop faults`
+3. `a60fc17` - `fix: align emergency stop fallback semantics`
+4. `f52c755` - `fix: guarantee fault after driver stop`
+
+## Validation State
+
+Latest local validation after the last review-fix commit:
+
+- `./.venv/bin/python -m pytest`: 62 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+
+Latest GitHub validation after the last push:
+
+- `Checks`: passed
+- `Build Package`: passed
+
+## Durable State At Summary Time
+
+Primary state files:
+
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+Current durable state says:
+
+- `E2-S6` is complete
+- next story is `E2-S7`
+- E2-S7 target is the thin vertical slice spike for one-process mock roast flow and export readiness
+
+## Resume Guidance
+
+If this summary is used after compaction:
+
+1. read this file
+2. read `docs/state/registry.md`
+3. read `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+4. check whether PR `#75` has merged
+5. if PR `#75` has not merged, inspect unresolved PR review threads before making more changes
+6. if PR `#75` has merged, sync `main` and start E2-S7 from updated main
+
+Implementation boundary to preserve:
+
+- Do not expand E2-S6 into the full E3 roaster driver contract.
+- Keep model sync and first-crack training outside this repo.
+- Keep the old `coffee-roasting` repo as behavioral reference only.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E2-S6`
-- Current target: Extend fault handling from the mock MCP path into driver-owned emergency-stop behavior
+- Active story: `E2-S7`
+- Current target: Complete the thin vertical slice spike for one-process mock roast flow and export readiness
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -36,6 +36,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E2-S3` keeps event writes behind `RoastSessionStore.record_event(...)`. The session timeline now records deterministic append order, authoritative UTC plus monotonic timestamps for core roast events, and idempotent singleton handling for beans added, first crack, bean drop, and cooling transitions.
 - `E2-S4` now exposes the first roast-session MCP tools on top of the mock path. `export_roast_log` currently returns the planned manifest only, while the real JSONL, CSV, and summary writers stay in Epic 5.
 - `E2-S5` now enforces phase-ordered roast events inside `RoastSessionStore`. New events must start with `pre_roast -> roasting`, may move through `development` when first crack is recorded, may drop directly from `roasting` when first crack is not recorded, and then continue through `dropped -> cooling -> complete`; repeated singleton calls keep their original event rows and fault rows remain appendable without resetting the first-fault timestamp.
+- `E2-S6` keeps `RoastSessionStore` as the one-session mutation boundary but moves emergency-stop safety behavior behind the configured driver boundary. The current mock driver fail-closes heat to `0`, fan to `100`, and cooling to `on`; the store records the resulting fault event and stops the session, and MCP responses expose the fault payload plus final session state.
 - ONNX INT8 is the default real model backend.
 - ONNX FP32 is supported by config.
 - The `coffee-first-crack-detection` repo remains the source of truth for training, ONNX export, Hugging Face sync, model cards, and dataset cards.
@@ -120,7 +121,7 @@ Goal: implement one authoritative roast session runtime and MCP tool surface.
 - [x] `E2-S5` Implement phase transitions.
   - Done when session phase changes are deterministic for pre-roast, roasting, development, dropped, cooling, complete, and fault states.
 
-- [ ] `E2-S6` Implement emergency stop and fault recording.
+- [x] `E2-S6` Implement emergency stop and fault recording.
   - Done when emergency stop records an event and calls the active driver safety method.
 
 - [ ] `E2-S7` Complete thin vertical slice spike.
@@ -453,6 +454,14 @@ After completing a story:
   - Added `tests/test_package.py` coverage that invalid MCP tool calls surface phase-transition errors over stdio before a valid roast sequence starts.
   - Used the old `coffee-roasting` repo only as a behavioral reference for roast ordering and development/drop/cooling semantics, not as an architecture template.
   - Ran `./.venv/bin/python -m pytest`: 53 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E2-S6:
+  - Added `src/coffee_roaster_mcp/drivers.py` with a minimal `RoasterSafetyDriver` protocol and `MockRoasterDriver` emergency-stop safety method.
+  - Routed the MCP `emergency_stop` tool through the configured mock driver safety method while keeping `RoastSessionStore` responsible for fault recording, session stop semantics, and snapshots.
+  - Added unit coverage for the mock driver emergency-stop behavior, store-supplied driver safety callbacks, and MCP fault payload visibility through `get_roast_state`.
+  - Ran `./.venv/bin/python -m pytest`: 58 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -460,8 +460,9 @@ After completing a story:
 - Validation run for E2-S6:
   - Added `src/coffee_roaster_mcp/drivers.py` with a minimal `RoasterSafetyDriver` protocol and `MockRoasterDriver` emergency-stop safety method.
   - Routed the MCP `emergency_stop` tool through the configured mock driver safety method while keeping `RoastSessionStore` responsible for fault recording, session stop semantics, and snapshots.
-  - Added unit coverage for the mock driver emergency-stop behavior, store-supplied driver safety callbacks, and MCP fault payload visibility through `get_roast_state`.
-  - Ran `./.venv/bin/python -m pytest`: 58 passed.
+  - Added unit coverage for the mock driver emergency-stop behavior, store-owned safety payload application, driver failure fail-closed fallback, payload collision handling, and MCP fault payload visibility through `get_roast_state`.
+  - Review hardening moved driver emergency-stop execution outside the store lock, falls back to safe controls when the driver call raises, and preserves core fault payload fields such as `reason`.
+  - Ran `./.venv/bin/python -m pytest`: 60 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -460,9 +460,9 @@ After completing a story:
 - Validation run for E2-S6:
   - Added `src/coffee_roaster_mcp/drivers.py` with a minimal `RoasterSafetyDriver` protocol and `MockRoasterDriver` emergency-stop safety method.
   - Routed the MCP `emergency_stop` tool through the configured mock driver safety method while keeping `RoastSessionStore` responsible for fault recording, session stop semantics, and snapshots.
-  - Added unit coverage for the mock driver emergency-stop behavior, store-owned safety payload application, driver failure fail-closed fallback, payload collision handling, and MCP fault payload visibility through `get_roast_state`.
-  - Review hardening moved driver emergency-stop execution outside the store lock, falls back to safe controls when the driver call raises, and preserves core fault payload fields such as `reason`.
-  - Ran `./.venv/bin/python -m pytest`: 60 passed.
+  - Added unit coverage for the mock driver emergency-stop behavior, store-owned safety payload application, driver failure fail-closed fallback, payload collision handling, stopped-latest fault recording after a driver-side emergency stop, and MCP fault payload visibility through `get_roast_state`.
+  - Review hardening moved driver emergency-stop execution outside the store lock, falls back to centralized safe controls when the driver call raises, preserves core fault payload fields such as `reason`, wraps unknown driver startup as `ConfigError`, and still records a fault if the same latest session stops after the driver safety method has already run.
+  - Ran `./.venv/bin/python -m pytest`: 62 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,9 +22,9 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E2-S5 is complete. RoastPilot now enforces deterministic roast-session phase transitions on the mock MCP path, rejecting impossible event ordering while keeping the current one-session store boundary and E2-S4 MCP response semantics intact.
+E2-S6 is complete. RoastPilot emergency stop now routes through a driver-owned mock safety method, records a fault event with driver-call evidence, and keeps fault state visible through the existing MCP session state response.
 
-The next story is E2-S6: extend emergency-stop and fault handling into driver-owned safety behavior.
+The next story is E2-S7: complete the thin vertical slice spike for one-process mock roast flow and export readiness.
 
 The first implementation milestone remains a thin mock vertical slice: install the package, start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -1,0 +1,85 @@
+"""Roaster driver safety boundary for the current mock runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from coffee_roaster_mcp.session import EventPayloadValue, RoastSession
+
+
+@dataclass(frozen=True)
+class EmergencyStopResult:
+    """Result returned by a driver-owned emergency stop action.
+
+    Attributes:
+        driver: Driver identifier that handled the safety action.
+        safety_method: Driver method that was called.
+        heat_level_percent: Heat level after the safety action.
+        fan_level_percent: Fan level after the safety action.
+        cooling_on: Cooling state after the safety action.
+    """
+
+    driver: str
+    safety_method: str
+    heat_level_percent: int
+    fan_level_percent: int
+    cooling_on: bool
+
+    def as_event_payload(self) -> dict[str, EventPayloadValue]:
+        """Return event payload fields that prove the driver safety call ran."""
+        return {
+            "driver": self.driver,
+            "driver_safety_method": self.safety_method,
+            "driver_safety_method_called": True,
+            "heat_level_percent": self.heat_level_percent,
+            "fan_level_percent": self.fan_level_percent,
+            "cooling_on": self.cooling_on,
+        }
+
+
+class RoasterSafetyDriver(Protocol):
+    """Minimal driver protocol needed before the full E3 driver contract lands."""
+
+    def emergency_stop(self, session: RoastSession, *, reason: str) -> EmergencyStopResult:
+        """Apply the safest available stop behavior for one active session."""
+        ...
+
+
+class MockRoasterDriver:
+    """Mock roaster driver with deterministic fail-closed emergency stop behavior."""
+
+    name = "mock"
+
+    def emergency_stop(self, session: RoastSession, *, reason: str) -> EmergencyStopResult:
+        """Apply mock-safe emergency stop controls to one session."""
+        _ = reason
+        session.heat_level_percent = 0
+        session.fan_level_percent = 100
+        session.cooling_on = True
+        return EmergencyStopResult(
+            driver=self.name,
+            safety_method="emergency_stop",
+            heat_level_percent=session.heat_level_percent,
+            fan_level_percent=session.fan_level_percent,
+            cooling_on=session.cooling_on,
+        )
+
+
+def create_roaster_safety_driver(driver_name: str) -> RoasterSafetyDriver:
+    """Create the configured roaster safety driver.
+
+    Args:
+        driver_name: Roaster driver name from configuration.
+
+    Returns:
+        Driver safety adapter for the configured driver.
+
+    Raises:
+        ValueError: If the driver is not implemented in the current runtime.
+    """
+    if driver_name == "mock":
+        return MockRoasterDriver()
+    raise ValueError(
+        f"Roaster driver {driver_name!r} is not implemented in this bootstrap runtime."
+    )

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Protocol
 
-from coffee_roaster_mcp.session import EventPayloadValue, RoastSession
+from coffee_roaster_mcp.session import EventPayloadValue
 
 
 @dataclass(frozen=True)
@@ -41,8 +41,8 @@ class EmergencyStopResult:
 class RoasterSafetyDriver(Protocol):
     """Minimal driver protocol needed before the full E3 driver contract lands."""
 
-    def emergency_stop(self, session: RoastSession, *, reason: str) -> EmergencyStopResult:
-        """Apply the safest available stop behavior for one active session."""
+    def emergency_stop(self, *, reason: str) -> EmergencyStopResult:
+        """Apply the safest available driver-owned stop behavior."""
         ...
 
 
@@ -51,18 +51,15 @@ class MockRoasterDriver:
 
     name = "mock"
 
-    def emergency_stop(self, session: RoastSession, *, reason: str) -> EmergencyStopResult:
-        """Apply mock-safe emergency stop controls to one session."""
+    def emergency_stop(self, *, reason: str) -> EmergencyStopResult:
+        """Return deterministic mock-safe emergency stop controls."""
         _ = reason
-        session.heat_level_percent = 0
-        session.fan_level_percent = 100
-        session.cooling_on = True
         return EmergencyStopResult(
             driver=self.name,
             safety_method="emergency_stop",
-            heat_level_percent=session.heat_level_percent,
-            fan_level_percent=session.fan_level_percent,
-            cooling_on=session.cooling_on,
+            heat_level_percent=0,
+            fan_level_percent=100,
+            cooling_on=True,
         )
 
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -14,7 +14,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 
 from coffee_roaster_mcp import __version__
-from coffee_roaster_mcp.config import AppConfig, load_config
+from coffee_roaster_mcp.config import AppConfig, ConfigError, load_config
 from coffee_roaster_mcp.drivers import RoasterSafetyDriver, create_roaster_safety_driver
 from coffee_roaster_mcp.session import (
     EventPayloadValue,
@@ -199,11 +199,15 @@ def build_server_context(
         The initialized server context used by the MCP lifespan.
     """
     config = load_config(path=config_path)
+    try:
+        roaster_driver = create_roaster_safety_driver(config.roaster.driver)
+    except ValueError as exc:
+        raise ConfigError(str(exc)) from exc
     return ServerContext(
         config=config,
         transport=transport,
         session_store=RoastSessionStore(default_log_dir=config.logging.log_dir / "roasts"),
-        roaster_driver=create_roaster_safety_driver(config.roaster.driver),
+        roaster_driver=roaster_driver,
         started_at_utc=datetime.now(UTC),
     )
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -15,6 +15,7 @@ from mcp.server.session import ServerSession
 
 from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.config import AppConfig, load_config
+from coffee_roaster_mcp.drivers import RoasterSafetyDriver, create_roaster_safety_driver
 from coffee_roaster_mcp.session import (
     EventPayloadValue,
     RoastEvent,
@@ -33,12 +34,14 @@ class ServerContext:
         config: Loaded RoastPilot configuration.
         transport: Actual MCP transport used by this server process.
         session_store: Authoritative in-process roast session owner.
+        roaster_driver: Configured driver safety boundary.
         started_at_utc: UTC time when the MCP process initialized.
     """
 
     config: AppConfig
     transport: str
     session_store: RoastSessionStore
+    roaster_driver: RoasterSafetyDriver
     started_at_utc: datetime
 
 
@@ -200,6 +203,7 @@ def build_server_context(
         config=config,
         transport=transport,
         session_store=RoastSessionStore(default_log_dir=config.logging.log_dir / "roasts"),
+        roaster_driver=create_roaster_safety_driver(config.roaster.driver),
         started_at_utc=datetime.now(UTC),
     )
 
@@ -424,6 +428,10 @@ def create_mcp_server(
         event, snapshot = server_context.session_store.emergency_stop_snapshot(
             session,
             reason=reason,
+            safety_action=lambda active_session: server_context.roaster_driver.emergency_stop(
+                active_session,
+                reason=reason,
+            ).as_event_payload(),
         )
         return _serialize_event_result(snapshot=snapshot, event=event)
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -422,16 +422,14 @@ def create_mcp_server(
         ctx: Context[ServerSession, ServerContext],
         reason: str = "manual emergency stop",
     ) -> EventCommandResult:
-        """Apply mock-safe emergency-stop state and record a fault event."""
+        """Call the configured driver safety method and record a fault event."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
+        safety_payload = run_driver_emergency_stop(server_context, reason=reason)
         event, snapshot = server_context.session_store.emergency_stop_snapshot(
             session,
             reason=reason,
-            safety_action=lambda active_session: server_context.roaster_driver.emergency_stop(
-                active_session,
-                reason=reason,
-            ).as_event_payload(),
+            safety_payload=safety_payload,
         )
         return _serialize_event_result(snapshot=snapshot, event=event)
 
@@ -485,6 +483,26 @@ def _record_session_event(
     session = _require_active_session(server_context)
     event, snapshot = server_context.session_store.record_event_snapshot(session, kind)
     return _serialize_event_result(snapshot=snapshot, event=event)
+
+
+def run_driver_emergency_stop(
+    server_context: ServerContext,
+    *,
+    reason: str,
+) -> dict[str, EventPayloadValue]:
+    """Run driver-owned emergency stop before taking the session-store lock."""
+    try:
+        return server_context.roaster_driver.emergency_stop(reason=reason).as_event_payload()
+    except Exception as exc:
+        return {
+            "driver": server_context.config.roaster.driver,
+            "driver_safety_method": "emergency_stop",
+            "driver_safety_method_called": False,
+            "driver_error": f"{type(exc).__name__}: {exc}",
+            "heat_level_percent": 0,
+            "fan_level_percent": 100,
+            "cooling_on": True,
+        }
 
 
 def _snapshot_session(

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -23,6 +23,7 @@ from coffee_roaster_mcp.session import (
     RoastSession,
     RoastSessionStore,
     SessionLifecycleError,
+    default_emergency_safety_payload,
 )
 
 
@@ -434,6 +435,7 @@ def create_mcp_server(
             session,
             reason=reason,
             safety_payload=safety_payload,
+            allow_stopped_latest=True,
         )
         return _serialize_event_result(snapshot=snapshot, event=event)
 
@@ -498,15 +500,10 @@ def run_driver_emergency_stop(
     try:
         return server_context.roaster_driver.emergency_stop(reason=reason).as_event_payload()
     except Exception as exc:
-        return {
-            "driver": server_context.config.roaster.driver,
-            "driver_safety_method": "emergency_stop",
-            "driver_safety_method_called": False,
-            "driver_error": f"{type(exc).__name__}: {exc}",
-            "heat_level_percent": 0,
-            "fan_level_percent": 100,
-            "cooling_on": True,
-        }
+        return default_emergency_safety_payload(
+            driver=server_context.config.roaster.driver,
+            driver_error=f"{type(exc).__name__}: {exc}",
+        )
 
 
 def _snapshot_session(

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -537,19 +537,22 @@ class RoastSessionStore:
         session: RoastSession,
         *,
         reason: str,
-        safety_action: Callable[[RoastSession], Mapping[str, EventPayloadValue]] | None = None,
+        safety_payload: Mapping[str, EventPayloadValue] | None = None,
     ) -> RoastEvent:
         """Apply driver-owned emergency-stop behavior and finalize the session."""
         with self._lock:
             self._assert_latest_active_session(session)
             _validate_event_transition(session, "fault")
-            safety_payload = (
-                _default_emergency_safety_action(session)
-                if safety_action is None
-                else dict(safety_action(session))
+            normalized_safety_payload = (
+                _default_emergency_safety_payload()
+                if safety_payload is None
+                else dict(safety_payload)
             )
-            event_payload: dict[str, EventPayloadValue] = {"reason": reason}
-            event_payload.update(safety_payload)
+            _apply_emergency_safety_payload(session, normalized_safety_payload)
+            event_payload = _build_emergency_fault_payload(
+                reason=reason,
+                safety_payload=normalized_safety_payload,
+            )
             event = self.record_event(session, "fault", payload=event_payload)
             session.stop(
                 utc_now=self._utc_now,
@@ -563,14 +566,14 @@ class RoastSessionStore:
         session: RoastSession,
         *,
         reason: str,
-        safety_action: Callable[[RoastSession], Mapping[str, EventPayloadValue]] | None = None,
+        safety_payload: Mapping[str, EventPayloadValue] | None = None,
     ) -> tuple[RoastEvent, RoastSession]:
         """Apply emergency stop and return the event plus an atomic lightweight snapshot."""
         with self._lock:
             event = self.emergency_stop(
                 session,
                 reason=reason,
-                safety_action=safety_action,
+                safety_payload=safety_payload,
             )
             return event, _copy_session_for_read(session)
 
@@ -703,21 +706,73 @@ def _generate_session_id() -> str:
     return uuid4().hex
 
 
-def _default_emergency_safety_action(
-    session: RoastSession,
-) -> dict[str, EventPayloadValue]:
-    """Apply legacy mock-safe stop state when no driver callback is supplied."""
-    session.heat_level_percent = 0
-    session.fan_level_percent = 100
-    session.cooling_on = True
+def _default_emergency_safety_payload() -> dict[str, EventPayloadValue]:
+    """Return fail-closed safety state when driver safety behavior is unavailable."""
     return {
         "driver": "store-default",
         "driver_safety_method": "emergency_stop",
         "driver_safety_method_called": True,
-        "heat_level_percent": session.heat_level_percent,
-        "fan_level_percent": session.fan_level_percent,
-        "cooling_on": session.cooling_on,
+        "heat_level_percent": 0,
+        "fan_level_percent": 100,
+        "cooling_on": True,
     }
+
+
+def _apply_emergency_safety_payload(
+    session: RoastSession,
+    safety_payload: Mapping[str, EventPayloadValue],
+) -> None:
+    """Apply fail-closed emergency safety state from a driver payload."""
+    session.heat_level_percent = _payload_control_percent(
+        safety_payload,
+        key="heat_level_percent",
+        default=0,
+    )
+    session.fan_level_percent = _payload_control_percent(
+        safety_payload,
+        key="fan_level_percent",
+        default=100,
+    )
+    cooling_on = safety_payload.get("cooling_on", True)
+    session.cooling_on = cooling_on if isinstance(cooling_on, bool) else True
+
+
+def _build_emergency_fault_payload(
+    *,
+    reason: str,
+    safety_payload: Mapping[str, EventPayloadValue],
+) -> dict[str, EventPayloadValue]:
+    """Build a fault payload without allowing drivers to override core keys."""
+    event_payload = dict(safety_payload)
+    event_payload["reason"] = reason
+    event_payload["heat_level_percent"] = _payload_control_percent(
+        safety_payload,
+        key="heat_level_percent",
+        default=0,
+    )
+    event_payload["fan_level_percent"] = _payload_control_percent(
+        safety_payload,
+        key="fan_level_percent",
+        default=100,
+    )
+    cooling_on = safety_payload.get("cooling_on", True)
+    event_payload["cooling_on"] = cooling_on if isinstance(cooling_on, bool) else True
+    return event_payload
+
+
+def _payload_control_percent(
+    payload: Mapping[str, EventPayloadValue],
+    *,
+    key: str,
+    default: int,
+) -> int:
+    """Return a valid control percentage from driver payload or a safe default."""
+    value = payload.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return default
+    if not 0 <= value <= 100:
+        return default
+    return value
 
 
 def _copy_session_for_read(session: RoastSession) -> RoastSession:

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -538,12 +538,16 @@ class RoastSessionStore:
         *,
         reason: str,
         safety_payload: Mapping[str, EventPayloadValue] | None = None,
+        allow_stopped_latest: bool = False,
     ) -> RoastEvent:
         """Apply driver-owned emergency-stop behavior and finalize the session."""
         with self._lock:
-            self._assert_latest_active_session(session)
+            if allow_stopped_latest:
+                self._assert_latest_session(session)
+            else:
+                self._assert_latest_active_session(session)
             normalized_safety_payload = (
-                _default_emergency_safety_payload()
+                default_emergency_safety_payload()
                 if safety_payload is None
                 else dict(safety_payload)
             )
@@ -552,12 +556,19 @@ class RoastSessionStore:
                 reason=reason,
                 safety_payload=normalized_safety_payload,
             )
-            event = self.record_event(session, "fault", payload=event_payload)
-            session.stop(
-                utc_now=self._utc_now,
-                monotonic_now=self._monotonic_now,
-                phase="fault",
+            event = self._record_emergency_fault_locked(
+                session,
+                payload=event_payload,
+                allow_stopped_latest=allow_stopped_latest,
             )
+            if session.active:
+                session.stop(
+                    utc_now=self._utc_now,
+                    monotonic_now=self._monotonic_now,
+                    phase="fault",
+                )
+            else:
+                session.phase = "fault"
             return event
 
     def emergency_stop_snapshot(
@@ -566,6 +577,7 @@ class RoastSessionStore:
         *,
         reason: str,
         safety_payload: Mapping[str, EventPayloadValue] | None = None,
+        allow_stopped_latest: bool = False,
     ) -> tuple[RoastEvent, RoastSession]:
         """Apply emergency stop and return the event plus an atomic lightweight snapshot."""
         with self._lock:
@@ -573,6 +585,7 @@ class RoastSessionStore:
                 session,
                 reason=reason,
                 safety_payload=safety_payload,
+                allow_stopped_latest=allow_stopped_latest,
             )
             return event, _copy_session_for_read(session)
 
@@ -619,10 +632,14 @@ class RoastSessionStore:
 
     def _assert_latest_active_session(self, session: RoastSession) -> None:
         """Validate that one session is the current mutable active session."""
-        if self._latest_session is not session:
-            raise SessionLifecycleError("Only the latest session can be mutated.")
+        self._assert_latest_session(session)
         if not session.active:
             raise SessionLifecycleError("Stopped sessions cannot be mutated.")
+
+    def _assert_latest_session(self, session: RoastSession) -> None:
+        """Validate that one session is the latest known session."""
+        if self._latest_session is not session:
+            raise SessionLifecycleError("Only the latest session can be mutated.")
 
     def _get_existing_singleton_event(
         self,
@@ -647,6 +664,30 @@ class RoastSessionStore:
             self._session_id_order.popleft()
             if oldest_session is not None:
                 del self._sessions_by_id[oldest_session_id]
+
+    def _record_emergency_fault_locked(
+        self,
+        session: RoastSession,
+        *,
+        payload: dict[str, EventPayloadValue],
+        allow_stopped_latest: bool,
+    ) -> RoastEvent:
+        """Record an emergency fault, including a stopped latest-session race."""
+        if session.active:
+            return self.record_event(session, "fault", payload=payload)
+        if not allow_stopped_latest:
+            raise SessionLifecycleError("Stopped sessions cannot be mutated.")
+        if session.faulted_at_utc is None:
+            _validate_event_transition(session, "fault")
+        event = RoastEvent(
+            kind="fault",
+            recorded_at_utc=self._utc_now(),
+            monotonic_seconds=session.elapsed_monotonic_seconds(self._monotonic_now),
+            payload=dict(payload),
+        )
+        session.event_timeline.append(event)
+        _apply_event_timestamp(session, event)
+        return event
 
 
 def _apply_event_timestamp(session: RoastSession, event: RoastEvent) -> None:
@@ -705,16 +746,23 @@ def _generate_session_id() -> str:
     return uuid4().hex
 
 
-def _default_emergency_safety_payload() -> dict[str, EventPayloadValue]:
+def default_emergency_safety_payload(
+    *,
+    driver: str = "store-default",
+    driver_error: str | None = None,
+) -> dict[str, EventPayloadValue]:
     """Return fail-closed safety state when driver safety behavior is unavailable."""
-    return {
-        "driver": "store-default",
+    payload: dict[str, EventPayloadValue] = {
+        "driver": driver,
         "driver_safety_method": "emergency_stop",
         "driver_safety_method_called": False,
         "heat_level_percent": 0,
         "fan_level_percent": 100,
         "cooling_on": True,
     }
+    if driver_error is not None:
+        payload["driver_error"] = driver_error
+    return payload
 
 
 def _apply_emergency_safety_payload(

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -542,7 +542,6 @@ class RoastSessionStore:
         """Apply driver-owned emergency-stop behavior and finalize the session."""
         with self._lock:
             self._assert_latest_active_session(session)
-            _validate_event_transition(session, "fault")
             normalized_safety_payload = (
                 _default_emergency_safety_payload()
                 if safety_payload is None
@@ -711,7 +710,7 @@ def _default_emergency_safety_payload() -> dict[str, EventPayloadValue]:
     return {
         "driver": "store-default",
         "driver_safety_method": "emergency_stop",
-        "driver_safety_method_called": True,
+        "driver_safety_method_called": False,
         "heat_level_percent": 0,
         "fan_level_percent": 100,
         "cooling_on": True,

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -537,14 +537,20 @@ class RoastSessionStore:
         session: RoastSession,
         *,
         reason: str,
+        safety_action: Callable[[RoastSession], Mapping[str, EventPayloadValue]] | None = None,
     ) -> RoastEvent:
-        """Apply mock-safe emergency-stop state and finalize the session."""
+        """Apply driver-owned emergency-stop behavior and finalize the session."""
         with self._lock:
             self._assert_latest_active_session(session)
-            session.heat_level_percent = 0
-            session.fan_level_percent = 100
-            session.cooling_on = True
-            event = self.record_event(session, "fault", payload={"reason": reason})
+            _validate_event_transition(session, "fault")
+            safety_payload = (
+                _default_emergency_safety_action(session)
+                if safety_action is None
+                else dict(safety_action(session))
+            )
+            event_payload: dict[str, EventPayloadValue] = {"reason": reason}
+            event_payload.update(safety_payload)
+            event = self.record_event(session, "fault", payload=event_payload)
             session.stop(
                 utc_now=self._utc_now,
                 monotonic_now=self._monotonic_now,
@@ -557,10 +563,15 @@ class RoastSessionStore:
         session: RoastSession,
         *,
         reason: str,
+        safety_action: Callable[[RoastSession], Mapping[str, EventPayloadValue]] | None = None,
     ) -> tuple[RoastEvent, RoastSession]:
         """Apply emergency stop and return the event plus an atomic lightweight snapshot."""
         with self._lock:
-            event = self.emergency_stop(session, reason=reason)
+            event = self.emergency_stop(
+                session,
+                reason=reason,
+                safety_action=safety_action,
+            )
             return event, _copy_session_for_read(session)
 
     def get_active_session(self) -> RoastSession | None:
@@ -690,6 +701,23 @@ def _validate_event_transition(session: RoastSession, kind: RoastEventKind) -> N
 def _generate_session_id() -> str:
     """Return a stable opaque session identifier."""
     return uuid4().hex
+
+
+def _default_emergency_safety_action(
+    session: RoastSession,
+) -> dict[str, EventPayloadValue]:
+    """Apply legacy mock-safe stop state when no driver callback is supplied."""
+    session.heat_level_percent = 0
+    session.fan_level_percent = 100
+    session.cooling_on = True
+    return {
+        "driver": "store-default",
+        "driver_safety_method": "emergency_stop",
+        "driver_safety_method_called": True,
+        "heat_level_percent": session.heat_level_percent,
+        "fan_level_percent": session.fan_level_percent,
+        "cooling_on": session.cooling_on,
+    }
 
 
 def _copy_session_for_read(session: RoastSession) -> RoastSession:

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,9 +1,6 @@
 """Roaster driver safety behavior coverage."""
 
-from datetime import UTC, datetime
-
 from coffee_roaster_mcp.drivers import MockRoasterDriver, create_roaster_safety_driver
-from coffee_roaster_mcp.session import RoastSessionStore
 
 
 def test_create_roaster_safety_driver_returns_mock_driver() -> None:
@@ -12,22 +9,14 @@ def test_create_roaster_safety_driver_returns_mock_driver() -> None:
     assert isinstance(driver, MockRoasterDriver)
 
 
-def test_mock_driver_emergency_stop_applies_safe_session_state() -> None:
-    store = RoastSessionStore(
-        utc_now=lambda: datetime(2026, 5, 4, 12, 0, tzinfo=UTC),
-        monotonic_now=lambda: 100.0,
-    )
-    session = store.start_session()
-    session.heat_level_percent = 70
-    session.fan_level_percent = 20
-    session.cooling_on = False
+def test_mock_driver_emergency_stop_returns_safe_session_state() -> None:
     driver = MockRoasterDriver()
 
-    result = driver.emergency_stop(session, reason="unit-test")
+    result = driver.emergency_stop(reason="unit-test")
 
     assert result.driver == "mock"
     assert result.safety_method == "emergency_stop"
-    assert session.heat_level_percent == 0
-    assert session.fan_level_percent == 100
-    assert session.cooling_on is True
+    assert result.heat_level_percent == 0
+    assert result.fan_level_percent == 100
+    assert result.cooling_on is True
     assert result.as_event_payload()["driver_safety_method_called"] is True

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,0 +1,33 @@
+"""Roaster driver safety behavior coverage."""
+
+from datetime import UTC, datetime
+
+from coffee_roaster_mcp.drivers import MockRoasterDriver, create_roaster_safety_driver
+from coffee_roaster_mcp.session import RoastSessionStore
+
+
+def test_create_roaster_safety_driver_returns_mock_driver() -> None:
+    driver = create_roaster_safety_driver("mock")
+
+    assert isinstance(driver, MockRoasterDriver)
+
+
+def test_mock_driver_emergency_stop_applies_safe_session_state() -> None:
+    store = RoastSessionStore(
+        utc_now=lambda: datetime(2026, 5, 4, 12, 0, tzinfo=UTC),
+        monotonic_now=lambda: 100.0,
+    )
+    session = store.start_session()
+    session.heat_level_percent = 70
+    session.fan_level_percent = 20
+    session.cooling_on = False
+    driver = MockRoasterDriver()
+
+    result = driver.emergency_stop(session, reason="unit-test")
+
+    assert result.driver == "mock"
+    assert result.safety_method == "emergency_stop"
+    assert session.heat_level_percent == 0
+    assert session.fan_level_percent == 100
+    assert session.cooling_on is True
+    assert result.as_event_payload()["driver_safety_method_called"] is True

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -13,7 +13,7 @@ from mcp.client.stdio import stdio_client
 
 from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.cli import build_parser, main
-from coffee_roaster_mcp.mcp_server import build_server_context
+from coffee_roaster_mcp.mcp_server import build_server_context, run_driver_emergency_stop
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 _T = TypeVar("_T")
@@ -379,6 +379,30 @@ def test_stdio_server_uses_configured_log_root_for_session_store(tmp_path: Path)
 
     assert session.log_writer is not None
     assert session.log_writer.log_dir == Path("custom-logs/roasts") / session.id
+
+
+def test_driver_emergency_stop_failure_returns_fail_closed_payload() -> None:
+    server_context = build_server_context()
+    object.__setattr__(server_context, "roaster_driver", _FailingSafetyDriver())
+
+    payload = run_driver_emergency_stop(server_context, reason="unit-test")
+
+    assert payload["driver"] == "mock"
+    assert payload["driver_safety_method"] == "emergency_stop"
+    assert payload["driver_safety_method_called"] is False
+    assert payload["driver_error"] == "RuntimeError: driver offline"
+    assert payload["heat_level_percent"] == 0
+    assert payload["fan_level_percent"] == 100
+    assert payload["cooling_on"] is True
+
+
+class _FailingSafetyDriver:
+    """Test driver that simulates an emergency-stop I/O failure."""
+
+    def emergency_stop(self, *, reason: str) -> object:
+        """Raise a deterministic driver failure."""
+        _ = reason
+        raise RuntimeError("driver offline")
 
 
 def _build_clean_server_env(overrides: dict[str, str] | None = None) -> dict[str, str]:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -13,6 +13,7 @@ from mcp.client.stdio import stdio_client
 
 from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.cli import build_parser, main
+from coffee_roaster_mcp.config import ConfigError
 from coffee_roaster_mcp.mcp_server import build_server_context, run_driver_emergency_stop
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -379,6 +380,14 @@ def test_stdio_server_uses_configured_log_root_for_session_store(tmp_path: Path)
 
     assert session.log_writer is not None
     assert session.log_writer.log_dir == Path("custom-logs/roasts") / session.id
+
+
+def test_build_server_context_wraps_unknown_driver_as_config_error(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("roaster:\n  driver: missing-driver\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="missing-driver"):
+        build_server_context(config_path=config_path)
 
 
 def test_driver_emergency_stop_failure_returns_fail_closed_payload() -> None:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -235,9 +235,11 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         assert emergency_stop_result.structuredContent["session_id"] == second_session_id
         assert emergency_stop_result.structuredContent["event"]["kind"] == "fault"
         assert emergency_stop_result.structuredContent["phase"] == "fault"
-        assert emergency_stop_result.structuredContent["event"]["payload"] == {
-            "reason": "test-path"
-        }
+        emergency_payload = emergency_stop_result.structuredContent["event"]["payload"]
+        assert emergency_payload["reason"] == "test-path"
+        assert emergency_payload["driver"] == "mock"
+        assert emergency_payload["driver_safety_method"] == "emergency_stop"
+        assert emergency_payload["driver_safety_method_called"] is True
 
         faulted_state_result = cast(
             Any,
@@ -247,9 +249,10 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         )
         assert faulted_state_result.structuredContent["active"] is False
         assert faulted_state_result.structuredContent["phase"] == "fault"
-        assert faulted_state_result.structuredContent["events"][-1]["payload"] == {
-            "reason": "test-path"
-        }
+        faulted_payload = faulted_state_result.structuredContent["events"][-1]["payload"]
+        assert faulted_payload["reason"] == "test-path"
+        assert faulted_payload["driver"] == "mock"
+        assert faulted_payload["driver_safety_method_called"] is True
 
         third_start_result = cast(
             Any,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -7,7 +7,6 @@ from typing import cast
 import pytest
 
 from coffee_roaster_mcp.session import (
-    EventPayloadValue,
     RoastEventKind,
     RoastSessionStore,
     SessionLifecycleError,
@@ -371,33 +370,56 @@ def test_emergency_stop_calls_supplied_driver_safety_action() -> None:
         monotonic_now=clock.monotonic_now,
     )
     session = store.start_session()
-    calls: list[str] = []
-
-    def safety_action(active_session: object) -> dict[str, EventPayloadValue]:
-        assert active_session is session
-        calls.append("emergency_stop")
-        session.heat_level_percent = 0
-        session.fan_level_percent = 100
-        session.cooling_on = True
-        return {
-            "driver": "test-driver",
-            "driver_safety_method": "emergency_stop",
-            "driver_safety_method_called": True,
-        }
 
     event = store.emergency_stop(
         session,
         reason="driver-owned-safety",
-        safety_action=safety_action,
+        safety_payload={
+            "driver": "test-driver",
+            "driver_safety_method": "emergency_stop",
+            "driver_safety_method_called": True,
+            "heat_level_percent": 0,
+            "fan_level_percent": 100,
+            "cooling_on": True,
+        },
     )
 
-    assert calls == ["emergency_stop"]
     assert event.kind == "fault"
     assert event.payload["reason"] == "driver-owned-safety"
     assert event.payload["driver"] == "test-driver"
     assert event.payload["driver_safety_method_called"] is True
+    assert session.heat_level_percent == 0
+    assert session.fan_level_percent == 100
+    assert session.cooling_on is True
     assert session.phase == "fault"
     assert session.active is False
+
+
+def test_emergency_stop_preserves_core_reason_when_driver_payload_collides() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    event = store.emergency_stop(
+        session,
+        reason="core-reason",
+        safety_payload={
+            "reason": "driver-reason",
+            "driver": "test-driver",
+            "heat_level_percent": 25,
+            "fan_level_percent": 75,
+            "cooling_on": False,
+        },
+    )
+
+    assert event.payload["reason"] == "core-reason"
+    assert event.payload["driver"] == "test-driver"
+    assert session.heat_level_percent == 25
+    assert session.fan_level_percent == 75
+    assert session.cooling_on is False
 
 
 def test_emergency_stop_faults_active_complete_session() -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -7,6 +7,7 @@ from typing import cast
 import pytest
 
 from coffee_roaster_mcp.session import (
+    EventPayloadValue,
     RoastEventKind,
     RoastSessionStore,
     SessionLifecycleError,
@@ -358,8 +359,45 @@ def test_emergency_stop_faults_and_stops_session() -> None:
     assert session.heat_level_percent == 0
     assert session.fan_level_percent == 100
     assert session.cooling_on is True
+    assert event.payload["driver_safety_method_called"] is True
     assert session.stopped_at_utc == datetime(2026, 5, 4, 12, 4, tzinfo=UTC)
     assert session.monotonic_stop == 130.0
+
+
+def test_emergency_stop_calls_supplied_driver_safety_action() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+    calls: list[str] = []
+
+    def safety_action(active_session: object) -> dict[str, EventPayloadValue]:
+        assert active_session is session
+        calls.append("emergency_stop")
+        session.heat_level_percent = 0
+        session.fan_level_percent = 100
+        session.cooling_on = True
+        return {
+            "driver": "test-driver",
+            "driver_safety_method": "emergency_stop",
+            "driver_safety_method_called": True,
+        }
+
+    event = store.emergency_stop(
+        session,
+        reason="driver-owned-safety",
+        safety_action=safety_action,
+    )
+
+    assert calls == ["emergency_stop"]
+    assert event.kind == "fault"
+    assert event.payload["reason"] == "driver-owned-safety"
+    assert event.payload["driver"] == "test-driver"
+    assert event.payload["driver_safety_method_called"] is True
+    assert session.phase == "fault"
+    assert session.active is False
 
 
 def test_emergency_stop_faults_active_complete_session() -> None:
@@ -394,7 +432,8 @@ def test_emergency_stop_faults_active_complete_session() -> None:
     event = store.emergency_stop(session, reason="post-complete-fault")
 
     assert event.kind == "fault"
-    assert event.payload == {"reason": "post-complete-fault"}
+    assert event.payload["reason"] == "post-complete-fault"
+    assert event.payload["driver_safety_method_called"] is True
     assert session.phase == "fault"
     assert session.active is False
     assert session.heat_level_percent == 0

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -422,6 +422,45 @@ def test_emergency_stop_preserves_core_reason_when_driver_payload_collides() -> 
     assert session.cooling_on is False
 
 
+def test_emergency_stop_can_fault_latest_session_stopped_after_driver_call() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    clock.monotonic_value = 105.0
+    store.stop_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 2, tzinfo=UTC)
+    clock.monotonic_value = 115.0
+    event, snapshot = store.emergency_stop_snapshot(
+        session,
+        reason="driver-already-ran",
+        safety_payload={
+            "driver": "test-driver",
+            "driver_safety_method": "emergency_stop",
+            "driver_safety_method_called": True,
+            "heat_level_percent": 0,
+            "fan_level_percent": 100,
+            "cooling_on": True,
+        },
+        allow_stopped_latest=True,
+    )
+
+    assert event.kind == "fault"
+    assert event.payload["reason"] == "driver-already-ran"
+    assert event.payload["driver_safety_method_called"] is True
+    assert session.active is False
+    assert session.phase == "fault"
+    assert session.stopped_at_utc == datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    assert session.monotonic_stop == 105.0
+    assert snapshot.phase == "fault"
+    assert snapshot.event_timeline[-1].kind == "fault"
+
+
 def test_emergency_stop_faults_active_complete_session() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -358,7 +358,7 @@ def test_emergency_stop_faults_and_stops_session() -> None:
     assert session.heat_level_percent == 0
     assert session.fan_level_percent == 100
     assert session.cooling_on is True
-    assert event.payload["driver_safety_method_called"] is True
+    assert event.payload["driver_safety_method_called"] is False
     assert session.stopped_at_utc == datetime(2026, 5, 4, 12, 4, tzinfo=UTC)
     assert session.monotonic_stop == 130.0
 
@@ -455,7 +455,7 @@ def test_emergency_stop_faults_active_complete_session() -> None:
 
     assert event.kind == "fault"
     assert event.payload["reason"] == "post-complete-fault"
-    assert event.payload["driver_safety_method_called"] is True
+    assert event.payload["driver_safety_method_called"] is False
     assert session.phase == "fault"
     assert session.active is False
     assert session.heat_level_percent == 0


### PR DESCRIPTION
## Summary
- add a minimal driver safety boundary with a mock emergency-stop method
- route MCP emergency_stop through the configured driver safety method while preserving the one-session store boundary
- expose driver-call evidence in the fault event payload and faulted roast state
- update durable project state for E2-S6 completion and E2-S7 next

## Validation
- ./.venv/bin/python -m pytest
- ./.venv/bin/python -m ruff check .
- ./.venv/bin/python -m ruff format --check .
- ./.venv/bin/python -m pyright

Closes #21