### PR TITLE
E2-S8: Add GitHub Actions coverage reporting

### DIFF
--- a/.github/scripts/write_coverage_summary.py
+++ b/.github/scripts/write_coverage_summary.py
@@ -1,0 +1,169 @@
+"""Write a concise GitHub Actions coverage summary from coverage.py JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class FileCoverage:
+    """Coverage metrics for one measured source file."""
+
+    path: str
+    percent_covered: float
+    covered_lines: int
+    missing_lines: int
+
+
+def main() -> int:
+    """Run the coverage summary writer."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("coverage_json", type=Path, help="Path to coverage.py JSON output.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Summary output path. Defaults to stdout when omitted.",
+    )
+    args = parser.parse_args()
+
+    payload = _load_coverage_payload(args.coverage_json)
+    summary = _build_summary(payload)
+    if args.output is None:
+        print(summary)
+    else:
+        args.output.write_text(summary + "\n", encoding="utf-8")
+    return 0
+
+
+def _load_coverage_payload(path: Path) -> dict[str, Any]:
+    """Load coverage.py JSON output."""
+    with path.open(encoding="utf-8") as input_file:
+        loaded = json.load(input_file)
+    if not isinstance(loaded, dict):
+        raise ValueError("Coverage JSON root must be an object.")
+    return loaded
+
+
+def _build_summary(payload: dict[str, Any]) -> str:
+    """Build a Markdown coverage summary for GitHub Actions."""
+    totals = _as_mapping(payload.get("totals"))
+    files = _file_coverages(_as_mapping(payload.get("files")))
+    total_percent = _as_float(totals.get("percent_covered_display"))
+    if total_percent is None:
+        total_percent = _as_float(totals.get("percent_covered")) or 0.0
+    covered_lines = _as_int(totals.get("covered_lines"))
+    missing_lines = _as_int(totals.get("missing_lines"))
+    branch_percent = _as_float(totals.get("percent_covered")) or total_percent
+
+    lines = [
+        "## Test Coverage",
+        "",
+        "| Metric | Value |",
+        "| --- | ---: |",
+        f"| Total coverage | **{total_percent:.2f}%** |",
+        f"| Lines covered | {covered_lines} |",
+        f"| Lines missing | {missing_lines} |",
+        f"| Branch-aware coverage | {branch_percent:.2f}% |",
+        "",
+        _coverage_bar(total_percent),
+        "",
+        "### Lowest Covered Source Files",
+        "",
+    ]
+    if not files:
+        lines.append("No measured source files were reported.")
+    else:
+        lines.extend(
+            [
+                "| File | Coverage | Missing lines |",
+                "| --- | ---: | ---: |",
+            ]
+        )
+        for file_coverage in sorted(files, key=lambda item: item.percent_covered)[:5]:
+            lines.append(
+                "| "
+                f"`{file_coverage.path}` | "
+                f"{file_coverage.percent_covered:.2f}% | "
+                f"{file_coverage.missing_lines} |"
+            )
+
+    lines.extend(
+        [
+            "",
+            "### Artifact",
+            "",
+            "Download `html-coverage-report` from this workflow run for a drill-down HTML report.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _file_coverages(files_payload: dict[str, Any]) -> list[FileCoverage]:
+    """Return measured source file coverage rows from coverage.py JSON."""
+    rows: list[FileCoverage] = []
+    for path, value in files_payload.items():
+        if not path.startswith("src/coffee_roaster_mcp/"):
+            continue
+        summary = _as_mapping(_as_mapping(value).get("summary"))
+        percent_covered = _as_float(summary.get("percent_covered_display"))
+        if percent_covered is None:
+            percent_covered = _as_float(summary.get("percent_covered")) or 0.0
+        rows.append(
+            FileCoverage(
+                path=path,
+                percent_covered=percent_covered,
+                covered_lines=_as_int(summary.get("covered_lines")),
+                missing_lines=_as_int(summary.get("missing_lines")),
+            )
+        )
+    return rows
+
+
+def _coverage_bar(percent: float) -> str:
+    """Return a simple HTML coverage bar for GitHub-flavored Markdown."""
+    bounded_percent = max(0.0, min(100.0, percent))
+    return (
+        "<p>"
+        f"<strong>{bounded_percent:.2f}%</strong><br>"
+        f'<progress max="100" value="{bounded_percent:.2f}"></progress>'
+        "</p>"
+    )
+
+
+def _as_mapping(value: object) -> dict[str, Any]:
+    """Return a dictionary when the value has the expected JSON shape."""
+    return value if isinstance(value, dict) else {}
+
+
+def _as_float(value: object) -> float | None:
+    """Return a float when the value is numeric or numeric text."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _as_int(value: object) -> int:
+    """Return an int when the value is numeric, otherwise zero."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,34 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e . --group dev
 
-      - name: Run tests
-        run: python -m pytest
+      - name: Run tests with coverage
+        run: |
+          python -m pytest \
+            --cov=coffee_roaster_mcp \
+            --cov-report=term-missing:skip-covered \
+            --cov-report=json:coverage.json \
+            --cov-report=html:htmlcov
+
+      - name: Write coverage summary
+        if: always()
+        run: |
+          if [ -f coverage.json ]; then
+            python .github/scripts/write_coverage_summary.py coverage.json --output "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Test Coverage"
+              echo
+              echo "Coverage output was not generated because the test step failed before writing coverage.json."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload HTML coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-coverage-report
+          path: htmlcov/
+          if-no-files-found: ignore
 
       - name: Run lint
         run: python -m ruff check .

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ htmlcov/
 .coverage.*
 .cache
 nosetests.xml
+coverage.json
 coverage.xml
 *.cover
 *.py.cover

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The v0.1 direction is one local stdio MCP server that will own:
 - derived roast metrics
 - roast log export
 
-The current repo state is still bootstrap. The package scaffold, config loading, local development commands, pull-request CI, and the first stdio MCP entrypoint are in place. The full roast-session runtime and control surface continue through Epic 2.
+The current repo state is still bootstrap. The package scaffold, config loading, local development commands, pull-request CI, stdio MCP entrypoint, mock roast-session tool surface, and one-process mock vertical slice are in place.
 
 ## Install
 
@@ -46,6 +46,15 @@ Use the commands in the [Install](#install) section, then continue with the chec
 ```bash
 python -m pytest
 ```
+
+### Coverage
+
+```bash
+python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=html:htmlcov --cov-report=json:coverage.json
+python .github/scripts/write_coverage_summary.py coverage.json
+```
+
+Pull-request CI publishes a Markdown coverage summary in the `Checks` job summary and uploads `html-coverage-report` as a workflow artifact for file-by-file drill-down.
 
 ### Lint
 
@@ -106,7 +115,7 @@ The current MCP tool surface includes:
 - `export_roast_log`
 - `emergency_stop`
 
-`export_roast_log` currently returns the planned export manifest only. The real JSONL, CSV, and summary writers land in Epic 5.
+`export_roast_log` writes snapshot `roast.jsonl`, `roast.csv`, and `summary.json` files for the current in-process session. Append-only telemetry writers and final log schemas land in Epic 5.
 
 ### Mock-Safe Bootstrap Smoke
 

--- a/docs/session-summaries/2026-05-04-e2-s7-e2-s8-pr76-pr78-coverage-and-review-cycle.md
+++ b/docs/session-summaries/2026-05-04-e2-s7-e2-s8-pr76-pr78-coverage-and-review-cycle.md
@@ -1,0 +1,273 @@
+# Session Summary: E2-S7 And E2-S8 PR 76/78 Coverage And Review Cycle
+
+Date: 2026-05-04
+
+Repository: `syamaner/coffee-roaster-mcp`
+
+Branch at summary time: `feature/77-gh-actions-code-coverage`
+
+Stories:
+
+- `#22` - `E2-S7: Complete thin vertical slice spike`
+- `#77` - `E2-S8: Add GitHub Actions code coverage reporting`
+
+Pull requests:
+
+- `#76` - `E2-S7: Complete mock roast vertical slice`
+- `#78` - `E2-S8: Add GitHub Actions coverage reporting`
+
+## Purpose
+
+This summary captures the post-compaction work for the final Epic 2 stories:
+
+- complete the one-process mock roast vertical slice
+- add GitHub Actions code coverage reporting with readable visual output
+- capture the value of the Copilot review loop on PR `#76`
+- preserve a non-account context snapshot for the next compaction/resume point
+
+## Non-PII Codex Status Snapshot
+
+Snapshot provided near the end of this E2-S7/E2-S8 cycle:
+
+- Context window: `36% left (169K used / 258K)`
+
+Fields intentionally excluded:
+
+- account identity
+- durable session identifier
+
+Context usage notes:
+
+- This chat resumed from a compacted state and covered two stories end to end.
+- Context was spent on state-file reconciliation, GitHub issue/PR reads, repeated PR review-thread fetches, implementation diffs, local validation output, GitHub CI checks, and user-facing explanations.
+- The highest-context part of the cycle was the PR `#76` review loop because each review required fetching thread-aware GitHub state, applying targeted fixes, rerunning checks, pushing, and rechecking CI.
+- E2-S8 used less review context but included workflow design, local dependency refresh with network escalation, coverage output validation, and PR creation.
+
+## Story Outcome: E2-S7
+
+Issue `#22` acceptance criteria:
+
+- a mock roast can start
+- beans added can be marked
+- first crack can be injected
+- beans can be dropped
+- state can be returned
+- logs can be exported
+
+Outcome:
+
+- PR `#76` was opened, reviewed, fixed through several Copilot rounds, then squashed and merged.
+- The PR body included `Closes #22`, so issue `#22` should close automatically after merge.
+- The merged squash on `main` was `882ecf3 E2-S7: Complete mock roast vertical slice (#76)`.
+
+Implementation details:
+
+- Added `src/coffee_roaster_mcp/exports.py`.
+- `export_roast_log` now writes snapshot `roast.jsonl`, `roast.csv`, and `summary.json`.
+- Added minimal timestamp-derived metrics:
+  - `roast_elapsed_seconds`
+  - `development_time_seconds`
+  - `development_percent`
+- Extended stdio MCP smoke coverage to prove start -> beans added -> first crack -> drop -> state -> export in one process.
+- Kept append-only telemetry writers and final export schemas scoped to Epic 5.
+- Added E2-S8 issue `#77` and inserted it as the final Epic 2 hardening story before E3-S1.
+
+Validation:
+
+- `./.venv/bin/python -m pytest tests/test_session.py tests/test_package.py`: 50 passed before later review hardening.
+- `./.venv/bin/python -m pytest`: 64 passed before later review hardening.
+- `./.venv/bin/python -m ruff check .`: passed.
+- `./.venv/bin/python -m ruff format --check .`: passed after applying `ruff format`.
+- `./.venv/bin/python -m pyright`: 0 errors.
+- GitHub CI on PR `#76`: `Checks` passed and `Build Package` passed.
+
+## PR 76 Review Feedback Classification
+
+### Copilot Review: Export result docstring stale
+
+Finding:
+
+- `ExportRoastLogResult` still said it was a "Stub export manifest" even though `export_roast_log` now writes files and returns `ready: true`.
+
+Classification:
+
+- Severity: low
+- Type: MCP schema/documentation accuracy
+- Importance: worth fixing because dataclass docstrings influence tool-schema clarity
+
+Response:
+
+- Updated the docstring to `Result for one snapshot roast-log export.`
+
+Value:
+
+- Medium for user-facing schema clarity. Small change, but it prevents stale MCP tool documentation from spreading.
+
+### Copilot Review: Epic decision note contradiction
+
+Finding:
+
+- The new E2-S7 decision note said exports are written, while the older E2-S4 note still said `export_roast_log` returns a planned manifest only.
+
+Classification:
+
+- Severity: low to medium
+- Type: durable state consistency
+- Importance: important for spec-driven resume accuracy
+
+Response:
+
+- Rewrote the E2-S4 note to describe the historical placeholder behavior and clarify that E2-S7 replaced it with snapshot exports.
+
+Value:
+
+- High for this workflow. The state files are used as the next-turn source of truth, so internal contradictions are expensive later.
+
+### Copilot Review: Active-session metrics branch untested
+
+Finding:
+
+- `compute_roast_metrics()` had an active-session branch that used the current monotonic clock when no drop/stop timestamp exists, but tests only covered completed-after-drop and no-beans-added paths.
+
+Classification:
+
+- Severity: medium
+- Type: test coverage gap
+- Importance: valuable because active-session state is visible through MCP
+
+Response:
+
+- Added coverage where beans are added and first crack is recorded while the session remains active.
+- Asserted metrics advance from the supplied monotonic clock.
+
+Value:
+
+- High. This directly validated behavior users will observe during an in-progress roast.
+
+### Copilot Review: `_elapsed_since` docstring imprecise
+
+Finding:
+
+- The helper docstring said elapsed seconds go "to stop or now", but the implementation prefers drop, then stop, then now.
+
+Classification:
+
+- Severity: low
+- Type: helper documentation precision
+- Importance: useful because metric semantics depend on end-time precedence
+
+Response:
+
+- Updated the docstring to `Return elapsed seconds from one event to drop, stop, or now.`
+
+Value:
+
+- Medium. It made the metric semantics explicit and avoided future confusion.
+
+### Copilot Review: PR body next-story mismatch
+
+Finding:
+
+- The PR description said the next story was E3-S1, but durable state had been updated to add E2-S8 first.
+
+Classification:
+
+- Severity: low
+- Type: PR metadata/state consistency
+- Importance: important for reviewer trust and issue workflow accuracy
+
+Response:
+
+- Updated the PR `#76` body to say E2-S8 coverage reporting is the next story.
+
+Value:
+
+- Medium. It did not require code changes, but it kept public PR metadata aligned with durable state.
+
+## Story Outcome: E2-S8
+
+Issue `#77` acceptance criteria:
+
+- CI runs tests with coverage enabled.
+- Coverage includes the `coffee_roaster_mcp` package source.
+- Coverage output is visible in GitHub Actions in a readable summary.
+- A visually clear report is available as a workflow artifact or step summary.
+- Coverage workflow remains compatible with existing checks.
+- Project docs or state notes mention how to read the coverage output.
+
+Outcome at summary time:
+
+- PR `#78` is open and pushed.
+- PR `#78` includes `Closes #77`.
+- GitHub CI passed:
+  - `Checks`
+  - `Build Package`
+- Local branch is clean and tracks `origin/feature/77-gh-actions-code-coverage`.
+
+Implementation details:
+
+- Added `pytest-cov>=5.0` to dev dependencies.
+- Added branch-aware coverage config for `coffee_roaster_mcp` in `pyproject.toml`.
+- Updated `.github/workflows/ci.yml` so the `Checks` job runs:
+  - terminal coverage report
+  - JSON coverage output
+  - HTML coverage output
+- Added `.github/scripts/write_coverage_summary.py`.
+- The summary script writes a GitHub Actions Markdown summary with:
+  - total coverage
+  - covered lines
+  - missing lines
+  - branch-aware coverage
+  - visual progress bar
+  - lowest-covered source files
+  - artifact guidance
+- CI uploads `html-coverage-report` as an artifact.
+- Added `coverage.json` to `.gitignore`.
+- Updated `README.md` with local coverage commands and GitHub Actions report/artifact guidance.
+- Updated durable state:
+  - `E2-S8` marked complete
+  - active story moved to `E3-S1`
+  - registry says Epic 2 is complete enough to move into driver contract work
+
+Validation:
+
+- `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`: 65 passed, total coverage 77%.
+- `./.venv/bin/python .github/scripts/write_coverage_summary.py coverage.json`: passed and produced the expected Markdown summary.
+- `./.venv/bin/python -m pytest`: 65 passed.
+- `./.venv/bin/python -m ruff check .`: passed.
+- `./.venv/bin/python -m ruff format --check .`: passed after applying `ruff format`.
+- `./.venv/bin/python -m pyright`: 0 errors.
+- GitHub CI on PR `#78`: `Checks` passed and `Build Package` passed.
+
+## E2-S8 Review Status
+
+At summary time:
+
+- No Copilot review fixes had been requested yet for PR `#78`.
+- GitHub CI passed on the first pushed commit.
+- The main potential review surface is the custom summary script and whether GitHub renders the HTML `<progress>` element as expected in the job summary.
+
+Expected next review response pattern if comments arrive:
+
+- For workflow or artifact naming feedback, prefer small CI/doc edits.
+- For summary formatting feedback, update `.github/scripts/write_coverage_summary.py` and rerun the local JSON-summary command.
+- For coverage threshold feedback, make an explicit product decision before adding a failing threshold, because E2-S8 acceptance requires visibility, not enforcement.
+
+## Current Durable State
+
+`docs/state/registry.md` now says:
+
+- E2-S8 is complete.
+- The next story is E3-S1.
+- Epic 2 is complete enough to move into Epic 3 driver contract work.
+- Coverage output is visible through a Markdown job summary and an `html-coverage-report` artifact.
+
+`docs/state/epics/coffee-roaster-mcp-v0.1.md` now says:
+
+- Active story: `E3-S1`
+- Current target: define the broader roaster driver interface and capabilities model
+- E2-S1 through E2-S8 are complete
+
+## Next Suggested Resume Prompt
+
+Resume in `/Users/sertanyamaner/git/coffee-roaster-mcp`: PR `#78` for E2-S8 is open with CI passing and includes `Closes #77`; the E2-S8 durable summary is at `docs/session-summaries/2026-05-04-e2-s7-e2-s8-pr76-pr78-coverage-and-review-cycle.md`. If PR `#78` has review comments, address those first. If it has been squashed and merged, check out `main`, pull `origin main`, confirm issue `#77` closed, then begin E3-S1 from updated `main`. E3-S1 should define the broader roaster driver interface and capabilities model while preserving the E2 one-session store boundary, MCP semantics, mock-safe defaults, and existing emergency-stop/fault behavior.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E2-S8`
-- Current target: Add GitHub Actions code coverage reporting with readable visual output
+- Active story: `E3-S1`
+- Current target: Define the broader roaster driver interface and capabilities model
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -38,7 +38,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E2-S5` now enforces phase-ordered roast events inside `RoastSessionStore`. New events must start with `pre_roast -> roasting`, may move through `development` when first crack is recorded, may drop directly from `roasting` when first crack is not recorded, and then continue through `dropped -> cooling -> complete`; repeated singleton calls keep their original event rows and fault rows remain appendable without resetting the first-fault timestamp.
 - `E2-S6` keeps `RoastSessionStore` as the one-session mutation boundary but moves emergency-stop safety behavior behind the configured driver boundary. The current mock driver fail-closes heat to `0`, fan to `100`, and cooling to `on`; the store records the resulting fault event and stops the session, and MCP responses expose the fault payload plus final session state.
 - `E2-S7` completes the first one-process mock vertical slice. `export_roast_log` now writes snapshot JSONL, CSV, and summary files from the current session state, and `get_roast_state` exposes minimal timestamp-derived roast and development metrics. Append-only telemetry writers and final export schemas remain Epic 5 work.
-- `E2-S8` is the final Epic 2 hardening story before moving into the broader driver contract work. It should add GitHub Actions coverage reporting with an easy-to-read job summary and an HTML artifact, without introducing an external hosted coverage service by default.
+- `E2-S8` completed the final Epic 2 hardening story before broader driver contract work. Pull-request CI now runs tests with coverage for `coffee_roaster_mcp`, writes an easy-to-read GitHub Actions Markdown summary, and uploads an `html-coverage-report` artifact without adding an external hosted coverage service.
 - ONNX INT8 is the default real model backend.
 - ONNX FP32 is supported by config.
 - The `coffee-first-crack-detection` repo remains the source of truth for training, ONNX export, Hugging Face sync, model cards, and dataset cards.
@@ -129,7 +129,7 @@ Goal: implement one authoritative roast session runtime and MCP tool surface.
 - [x] `E2-S7` Complete thin vertical slice spike.
   - Done when a mock roast can start, mark beans added, inject first crack, drop beans, return state, and export logs in one process.
 
-- [ ] `E2-S8` Add GitHub Actions code coverage reporting.
+- [x] `E2-S8` Add GitHub Actions code coverage reporting.
   - Done when CI runs tests with coverage for `coffee_roaster_mcp`, publishes a readable GitHub Actions summary, uploads a visually useful HTML coverage artifact, and documents how to read the output.
 
 ### Epic Acceptance Criteria
@@ -479,6 +479,18 @@ After completing a story:
   - Updated the stdio MCP smoke flow to prove one process can start a mock roast, mark beans added, inject first crack, drop beans, return state, and export readable files without hardware or model download.
   - Ran `./.venv/bin/python -m pytest tests/test_session.py tests/test_package.py`: 50 passed.
   - Ran `./.venv/bin/python -m pytest`: 64 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed after applying `ruff format`.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E2-S8:
+  - Added `pytest-cov` as a declared dev dependency and configured branch-aware coverage for `coffee_roaster_mcp`.
+  - Updated pull-request CI so the `Checks` job runs pytest with terminal, JSON, and HTML coverage outputs.
+  - Added `.github/scripts/write_coverage_summary.py` to convert `coverage.json` into a readable GitHub Actions Markdown summary with total coverage, line counts, a progress bar, lowest-covered source files, and artifact guidance.
+  - CI uploads `html-coverage-report` for file-by-file drill-down without adding an external hosted coverage service.
+  - Updated `README.md` with local coverage commands and how to read the GitHub Actions summary and artifact.
+  - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`: 65 passed, total coverage 77%.
+  - Ran `./.venv/bin/python .github/scripts/write_coverage_summary.py coverage.json`: passed and produced the expected Markdown summary.
+  - Ran `./.venv/bin/python -m pytest`: 65 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed after applying `ruff format`.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,12 +22,12 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E2-S7 is complete. RoastPilot now has a one-process mock vertical slice that starts a session, records beans added, records manual first crack, drops beans, returns state with timestamp-derived metrics, and writes snapshot JSONL, CSV, and summary exports from the MCP tool surface.
+E2-S8 is complete. RoastPilot pull-request CI now runs tests with coverage for `coffee_roaster_mcp`, writes a readable Markdown coverage summary in GitHub Actions, and uploads an HTML coverage artifact for file-by-file drill-down.
 
-The next story is E2-S8: add GitHub Actions code coverage reporting with readable visual output.
+The next story is E3-S1: define the broader roaster driver interface and capabilities model.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 
-Before moving into Epic 3 driver contract work, E2-S8 should make test coverage visible in GitHub Actions through a concise Markdown job summary and an HTML artifact for drill-down review.
+Epic 2 is complete enough to move into Epic 3 driver contract work. Coverage output is visible in GitHub Actions through a concise Markdown job summary and an `html-coverage-report` artifact.
 
 For Epic 2 implementation, the old `coffee-roasting` repository is a behavioral reference only. Reuse proven roast-session and stdio MCP patterns, but do not recreate the old two-server, Auth0, SSE, or `n8n` architecture.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ coffee-roaster-mcp = "coffee_roaster_mcp.cli:main"
 dev = [
   "build>=1.2",
   "pytest>=8.0",
+  "pytest-cov>=5.0",
   "ruff>=0.8",
   "pyright>=1.1",
   "types-PyYAML>=6.0"
@@ -59,6 +60,17 @@ path = "src/coffee_roaster_mcp/__init__.py"
 testpaths = ["tests"]
 addopts = "-q"
 pythonpath = ["src"]
+
+[tool.coverage.run]
+branch = true
+source = ["coffee_roaster_mcp"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+
+[tool.coverage.html]
+directory = "htmlcov"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary

Completes E2-S8 by making coverage visible in pull-request CI without adding an external hosted coverage service.

- Adds `pytest-cov` as a declared dev dependency and configures branch-aware coverage for `coffee_roaster_mcp`.
- Updates the `Checks` workflow to run pytest with terminal, JSON, and HTML coverage outputs.
- Adds `.github/scripts/write_coverage_summary.py` to turn `coverage.json` into a readable GitHub Actions Markdown summary with total coverage, line counts, a progress bar, lowest-covered source files, and artifact guidance.
- Uploads `html-coverage-report` as a workflow artifact for visual file-by-file drill-down.
- Documents local coverage commands and where to find coverage output in GitHub Actions.
- Updates durable registry and epic state for E2-S8 completion and E3-S1 as the next story.

Closes #77

## Validation

- `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`: 65 passed, total coverage 77%
- `./.venv/bin/python .github/scripts/write_coverage_summary.py coverage.json`: passed
- `./.venv/bin/python -m pytest`: 65 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: passed after applying `ruff format`
- `./.venv/bin/python -m pyright`: 0 errors
