### PR TITLE
E3-S1: Define roaster driver interface

### DIFF
--- a/docs/session-summaries/2026-05-09-e3-s1-pr79-driver-interface-review-cycle.md
+++ b/docs/session-summaries/2026-05-09-e3-s1-pr79-driver-interface-review-cycle.md
@@ -1,0 +1,268 @@
+# Session Summary: E3-S1 PR 79 Driver Interface Review Cycle
+
+Date: 2026-05-09
+
+Repository: `syamaner/coffee-roaster-mcp`
+
+Branch at summary time: `feature/23-roaster-driver-interface`
+
+Story:
+
+- `#23` - `E3-S1: Define RoasterDriver interface and capabilities model`
+
+Pull request:
+
+- `#79` - `E3-S1: Define roaster driver interface`
+
+## Purpose
+
+This summary captures the first Epic 3 story after Epic 2 closure:
+
+- define the broader `RoasterDriver` interface and capability model
+- preserve the Epic 2 one-session store boundary and MCP semantics
+- use the old `coffee-roasting` prototype only as a behavioral reference
+- capture the Copilot review loop and why each review item was worth fixing
+- preserve a non-account context snapshot for the next compaction/resume point
+
+## Non-PII Codex Status Snapshot
+
+Snapshot provided near the end of this E3-S1 cycle:
+
+- Context window: `53% left (128K used / 258K)`
+- 5h limit: `99% left (resets 03:37 on 10 May)`
+- Weekly limit: `100% left (resets 20:39 on 13 May)`
+- GPT-5.3-Codex-Spark 5h limit: `100% left (resets 03:48 on 10 May)`
+- GPT-5.3-Codex-Spark weekly limit: `100% left (resets 22:48 on 16 May)`
+- Warning: limits may be stale; run `/status` again shortly
+
+Fields intentionally excluded:
+
+- account identity
+- durable chat/session identifier
+
+Context usage notes:
+
+- This chat resumed from compacted state after Epic 2 completion and PR `#78` merge.
+- Context was spent on branch hygiene, reading `AGENTS.md`, durable state, issue `#23`, current driver/session code, the old prototype reference, local validation output, PR creation, and two Copilot review rounds.
+- The highest-context parts were the review cycles because each round required thread-aware review fetches, targeted fixes, full validation, commits, pushes, and rechecking PR thread/check state.
+- The prototype review was read-only and intentionally behavioral: it informed command streaming, temperature-unit normalization, compound drop/cooling behavior, and cleanup lifecycle concerns without copying the old architecture.
+
+## Story Outcome
+
+Issue `#23` acceptance criteria:
+
+- driver interface exposes connection lifecycle
+- driver interface exposes state reads
+- driver interface exposes heat and fan control
+- driver interface exposes drop, cooling, and emergency stop
+- capabilities describe ranges, supported actions, sensor units, and command-streaming requirements
+- interface contract tests or type checks exist
+
+Outcome:
+
+- PR `#79` is open and includes `Closes #23`.
+- Branch `feature/23-roaster-driver-interface` is pushed.
+- GitHub checks on the latest pushed commit are passing:
+  - `Checks`: pass
+  - `Build Package`: pass
+- The active durable state now points to `E3-S2`.
+
+Implementation details:
+
+- Added a broader `RoasterDriver` protocol in `src/coffee_roaster_mcp/drivers.py`.
+- Added capability and state models:
+  - `ControlRange`
+  - `SupportedActions`
+  - `SensorUnits`
+  - `CommandStreaming`
+  - `RoasterCapabilities`
+  - `RoasterState`
+- Extended `MockRoasterDriver` to implement the broader contract while preserving emergency-stop fail-closed behavior.
+- Updated MCP server wiring to use `create_roaster_driver()` and `RoasterDriver`.
+- Preserved current MCP tool behavior and the one-session store boundary. Normal `set_heat`, `set_fan`, drop, and cooling commands remain store-owned in this story.
+- Added shared control validation in `src/coffee_roaster_mcp/controls.py`.
+- Updated durable state in `docs/state/registry.md` and `docs/state/epics/coffee-roaster-mcp-v0.1.md`.
+
+## Prototype Reference
+
+The old prototype was checked at:
+
+- `/Users/sertanyamaner/git/coffee-roasting/src/mcp_servers/roaster_control/hardware.py`
+- `/Users/sertanyamaner/git/coffee-roasting/src/mcp_servers/roaster_control/HOTTOP_README.md`
+
+Behavioral findings from the prototype:
+
+- Hottop needs continuous command streaming around `0.3s`.
+- Hardware may require temperature-unit normalization before state leaves the driver.
+- Drop is compound behavior: heat off, drum/solenoid state changes, cooling on, and fan changes.
+- Driver lifecycle cleanup matters because Hottop/prototype code uses background command/control loops.
+- Drum control exists in the prototype, but remains internal to future Hottop driver work because issue `#23` did not require a public drum command.
+
+Decision:
+
+- Keep E3-S1 focused on the public roaster driver contract required by the issue.
+- Do not copy the prototype architecture, old split MCP servers, Auth0, SSE, or orchestration patterns.
+- Let future Hottop stories model vendor-specific internals through driver implementation and raw diagnostic data unless product scope requires public drum controls later.
+
+## Validation
+
+Initial implementation validation:
+
+- `./.venv/bin/python -m pytest tests/test_drivers.py`: 11 passed
+- `./.venv/bin/python -m pytest`: 74 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+
+After first review round:
+
+- `./.venv/bin/python -m pytest tests/test_drivers.py`: 11 passed
+- `./.venv/bin/python -m pytest`: 74 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+
+After second review round:
+
+- `./.venv/bin/python -m pytest tests/test_drivers.py tests/test_session.py`: 54 passed
+- `./.venv/bin/python -m pytest`: 79 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+
+GitHub PR checks:
+
+- PR `#79` latest run:
+  - `Checks`: pass
+  - `Build Package`: pass
+
+## PR 79 Review Feedback Classification
+
+### Copilot Review: Driver temperature-unit alias conflicts with config
+
+Finding:
+
+- `TemperatureUnit` existed in both `config.py` and `drivers.py`, but with different meanings.
+- Config allowed `celsius`, `fahrenheit`, and `auto`; driver state units represented normalized output.
+
+Classification:
+
+- Severity: low to medium
+- Type: type clarity and future import-risk reduction
+- Importance: worth fixing before Hottop implementation because temperature-unit semantics will matter in E3-S8
+
+Response:
+
+- Renamed the driver-side alias to `ReportedTemperatureUnit`.
+
+Value:
+
+- High for future maintainability. It prevents confusing configured hardware input units with normalized driver-state output units.
+
+### Copilot Review: `RoasterState` temperatures are Celsius, but capabilities allowed Fahrenheit
+
+Finding:
+
+- `RoasterState` fields are named `bean_temp_c` and `env_temp_c`, but `SensorUnits` allowed `fahrenheit`.
+
+Classification:
+
+- Severity: medium
+- Type: contract consistency
+- Importance: important because state normalization is a driver boundary invariant
+
+Response:
+
+- Constrained `ReportedTemperatureUnit` to `celsius` or `unknown`.
+- Clarified the `SensorUnits` docstring: raw hardware may report Fahrenheit, but `RoasterState` must normalize to Celsius before crossing the driver boundary.
+
+Value:
+
+- High. This made the contract explicit and protects later telemetry, metrics, and exports from mixed-unit bugs.
+
+### Copilot Review: Driver test module docstring was stale
+
+Finding:
+
+- `tests/test_drivers.py` still described only safety behavior, but now covers the broader driver contract and capabilities.
+
+Classification:
+
+- Severity: low
+- Type: test discoverability and documentation accuracy
+- Importance: worth fixing because tests are now the first contract reference for future driver work
+
+Response:
+
+- Updated the module docstring to `Roaster driver contract, capability, and safety behavior coverage.`
+
+Value:
+
+- Medium. Small change, but it keeps test intent clear as Epic 3 expands.
+
+### Copilot Review: `CommandStreaming` allowed inconsistent values
+
+Finding:
+
+- `CommandStreaming(required=True, interval_seconds=None)` was possible even though the docstring says an interval is required when streaming is required.
+
+Classification:
+
+- Severity: medium
+- Type: capability model invariant
+- Importance: important because Hottop command streaming is safety-relevant and later stories rely on this model
+
+Response:
+
+- Added `CommandStreaming.__post_init__`.
+- Enforced:
+  - required streaming must provide `interval_seconds`
+  - non-required streaming must not provide `interval_seconds`
+  - provided intervals must be greater than zero
+- Added tests for valid and invalid combinations.
+
+Value:
+
+- High. This prevents invalid driver capability declarations from reaching runtime or future Hottop implementation.
+
+### Copilot Review: Duplicate percent validation between driver and session
+
+Finding:
+
+- `_validate_control_percent` existed separately in `drivers.py` and `session.py` with the same behavior and messages.
+
+Classification:
+
+- Severity: low to medium
+- Type: duplication and drift risk
+- Importance: worth fixing because control validation affects safety-sensitive heat and fan commands
+
+Response:
+
+- Added `src/coffee_roaster_mcp/controls.py`.
+- Moved shared validation to `validate_control_percent(...)`.
+- Updated both session and driver code to use the shared helper.
+
+Value:
+
+- High. Centralized validation reduces drift between MCP/session behavior and driver behavior as E3 expands.
+
+## Current Branch And Commits
+
+Branch:
+
+- `feature/23-roaster-driver-interface`
+
+Commits on PR `#79`:
+
+- `eb7bbbd feat: define roaster driver contract`
+- `c526ab9 fix: clarify driver temperature units`
+- `dd35743 fix: harden driver capability validation`
+
+Local status at summary time:
+
+- Branch is clean and tracking `origin/feature/23-roaster-driver-interface`.
+
+## Next Resume Prompt
+
+Resume in `/Users/sertanyamaner/git/coffee-roaster-mcp`: PR `#79` for `E3-S1` is open on branch `feature/23-roaster-driver-interface`, includes `Closes #23`, and GitHub checks are passing. The E3-S1 summary is at `docs/session-summaries/2026-05-09-e3-s1-pr79-driver-interface-review-cycle.md`. Start by checking PR `#79` state and issue `#23`; if PR `#79` has been squashed and merged, check out `main`, pull `origin main`, verify issue closure and durable state, then begin `E3-S2` from updated `main` only. E3-S2 should implement deterministic mock-driver telemetry against the new `RoasterDriver` contract while preserving the one-session store boundary, MCP semantics, mock-safe defaults, snapshot export behavior, coverage workflow, and emergency-stop/fault safety behavior.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E3-S1`
-- Current target: Define the broader roaster driver interface and capabilities model
+- Active story: `E3-S2`
+- Current target: Implement the mock driver against the broader driver contract
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -39,6 +39,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E2-S6` keeps `RoastSessionStore` as the one-session mutation boundary but moves emergency-stop safety behavior behind the configured driver boundary. The current mock driver fail-closes heat to `0`, fan to `100`, and cooling to `on`; the store records the resulting fault event and stops the session, and MCP responses expose the fault payload plus final session state.
 - `E2-S7` completes the first one-process mock vertical slice. `export_roast_log` now writes snapshot JSONL, CSV, and summary files from the current session state, and `get_roast_state` exposes minimal timestamp-derived roast and development metrics. Append-only telemetry writers and final export schemas remain Epic 5 work.
 - `E2-S8` completed the final Epic 2 hardening story before broader driver contract work. Pull-request CI now runs tests with coverage for `coffee_roaster_mcp`, writes an easy-to-read GitHub Actions Markdown summary, and uploads an `html-coverage-report` artifact without adding an external hosted coverage service.
+- `E3-S1` defines the broader `RoasterDriver` contract without changing MCP tool semantics. Drivers now expose connection lifecycle, normalized state reads, heat and fan controls, drop, cooling, driver-owned emergency stop, and static capabilities for ranges, supported actions, sensor units, and command-streaming requirements. The current mock driver implements this contract while preserving E2 emergency-stop fail-closed behavior.
+- The old `coffee-roasting` prototype was checked as a behavioral reference for E3-S1. It confirmed the need to model Hottop command streaming, temperature-unit normalization, compound drop/cooling behavior, and cleanup through driver lifecycle methods. Drum control remains an internal driver concern for now because E3-S1 and issue #23 do not require a public drum command.
 - ONNX INT8 is the default real model backend.
 - ONNX FP32 is supported by config.
 - The `coffee-first-crack-detection` repo remains the source of truth for training, ONNX export, Hugging Face sync, model cards, and dataset cards.
@@ -146,7 +148,7 @@ Goal: support multiple roasters behind one driver contract while preserving curr
 
 ### Stories
 
-- [ ] `E3-S1` Define `RoasterDriver` interface and capabilities model.
+- [x] `E3-S1` Define `RoasterDriver` interface and capabilities model.
   - Done when drivers expose connection lifecycle, read state, heat/fan control, drop, cooling, emergency stop, and capabilities.
 
 - [ ] `E3-S2` Implement mock driver.
@@ -493,4 +495,15 @@ After completing a story:
   - Ran `./.venv/bin/python -m pytest`: 65 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed after applying `ruff format`.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E3-S1:
+  - Replaced the E2 safety-only driver shape with a typed `RoasterDriver` protocol covering connection lifecycle, state reads, heat and fan control, bean drop, cooling control, emergency stop, and capabilities.
+  - Added capability models for control ranges, supported actions, sensor units, and command-streaming requirements, plus a normalized `RoasterState` return type.
+  - Extended `MockRoasterDriver` to satisfy the full contract while preserving the existing emergency-stop event payload and fail-closed heat `0`, fan `100`, cooling `on` behavior.
+  - Kept normal MCP heat, fan, drop, and cooling semantics on the existing one-session store boundary; only the server's configured driver type and factory moved to the broader contract.
+  - Checked the old `coffee-roasting` prototype as a behavioral reference and kept drum motor behavior internal to future Hottop driver implementation rather than adding it to the public E3-S1 contract.
+  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 11 passed.
+  - Ran `./.venv/bin/python -m pytest`: 74 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,12 +22,12 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E2-S8 is complete. RoastPilot pull-request CI now runs tests with coverage for `coffee_roaster_mcp`, writes a readable Markdown coverage summary in GitHub Actions, and uploads an HTML coverage artifact for file-by-file drill-down.
+E3-S1 is complete. RoastPilot now has a typed `RoasterDriver` contract covering connection lifecycle, normalized state reads, heat and fan control, drop, cooling, driver-owned emergency stop, and static capabilities.
 
-The next story is E3-S1: define the broader roaster driver interface and capabilities model.
+The next story is E3-S2: implement the mock driver against the broader driver contract with deterministic telemetry and contract tests.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 
-Epic 2 is complete enough to move into Epic 3 driver contract work. Coverage output is visible in GitHub Actions through a concise Markdown job summary and an `html-coverage-report` artifact.
+Epic 2 is complete and Epic 3 driver contract work has started. Coverage output is visible in GitHub Actions through a concise Markdown job summary and an `html-coverage-report` artifact.
 
 For Epic 2 implementation, the old `coffee-roasting` repository is a behavioral reference only. Reuse proven roast-session and stdio MCP patterns, but do not recreate the old two-server, Auth0, SSE, or `n8n` architecture.

--- a/src/coffee_roaster_mcp/controls.py
+++ b/src/coffee_roaster_mcp/controls.py
@@ -1,0 +1,24 @@
+"""Shared control validation helpers for RoastPilot."""
+
+from __future__ import annotations
+
+
+def validate_control_percent(value: object, *, label: str) -> int:
+    """Validate one percentage-like control input.
+
+    Args:
+        value: Candidate control value.
+        label: Field label to include in validation errors.
+
+    Returns:
+        Validated integer percentage.
+
+    Raises:
+        TypeError: If the value is not an integer percentage.
+        ValueError: If the value is outside the inclusive 0 to 100 range.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{label} must be an integer between 0 and 100.")
+    if not 0 <= value <= 100:
+        raise ValueError(f"{label} must be between 0 and 100.")
+    return value

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -7,7 +7,7 @@ from typing import Literal, Protocol
 
 from coffee_roaster_mcp.session import EventPayloadValue
 
-TemperatureUnit = Literal["celsius", "fahrenheit", "unknown"]
+ReportedTemperatureUnit = Literal["celsius", "unknown"]
 
 
 def _raw_vendor_data_default() -> dict[str, EventPayloadValue]:
@@ -53,15 +53,19 @@ class SupportedActions:
 
 @dataclass(frozen=True)
 class SensorUnits:
-    """Temperature units reported by one roaster driver.
+    """Temperature units emitted by normalized driver state.
+
+    Raw hardware may report Celsius or Fahrenheit, but `RoasterState`
+    temperature fields are normalized to Celsius before crossing the driver
+    boundary. `unknown` is reserved for drivers that cannot provide a sensor.
 
     Attributes:
         bean_temperature: Unit for normalized bean temperature readings.
         environment_temperature: Unit for normalized environment temperature readings.
     """
 
-    bean_temperature: TemperatureUnit
-    environment_temperature: TemperatureUnit
+    bean_temperature: ReportedTemperatureUnit
+    environment_temperature: ReportedTemperatureUnit
 
 
 @dataclass(frozen=True)

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal, Protocol
 
+from coffee_roaster_mcp.controls import validate_control_percent
 from coffee_roaster_mcp.session import EventPayloadValue
 
 ReportedTemperatureUnit = Literal["celsius", "unknown"]
@@ -79,6 +80,17 @@ class CommandStreaming:
 
     required: bool
     interval_seconds: float | None = None
+
+    def __post_init__(self) -> None:
+        """Validate streaming settings are internally consistent."""
+        if self.required and self.interval_seconds is None:
+            raise ValueError("interval_seconds is required when command streaming is required.")
+        if not self.required and self.interval_seconds is not None:
+            raise ValueError(
+                "interval_seconds must be None when command streaming is not required."
+            )
+        if self.interval_seconds is not None and self.interval_seconds <= 0:
+            raise ValueError("interval_seconds must be greater than 0.")
 
 
 @dataclass(frozen=True)
@@ -264,7 +276,7 @@ class MockRoasterDriver:
 
     def set_heat(self, *, heat_level_percent: int) -> RoasterState:
         """Set mock heat and return normalized state."""
-        self._heat_level_percent = _validate_control_percent(
+        self._heat_level_percent = validate_control_percent(
             heat_level_percent,
             label="heat_level_percent",
         )
@@ -272,7 +284,7 @@ class MockRoasterDriver:
 
     def set_fan(self, *, fan_level_percent: int) -> RoasterState:
         """Set mock fan and return normalized state."""
-        self._fan_level_percent = _validate_control_percent(
+        self._fan_level_percent = validate_control_percent(
             fan_level_percent,
             label="fan_level_percent",
         )
@@ -331,12 +343,3 @@ def create_roaster_driver(driver_name: str) -> RoasterDriver:
 def create_roaster_safety_driver(driver_name: str) -> RoasterDriver:
     """Create the configured roaster driver for E2 compatibility."""
     return create_roaster_driver(driver_name)
-
-
-def _validate_control_percent(value: object, *, label: str) -> int:
-    """Validate one percentage control input."""
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise TypeError(f"{label} must be an integer between 0 and 100.")
-    if not 0 <= value <= 100:
-        raise ValueError(f"{label} must be between 0 and 100.")
-    return value

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -1,11 +1,126 @@
-"""Roaster driver safety boundary for the current mock runtime."""
+"""Roaster driver contract and mock-safe implementation for RoastPilot."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Protocol
+from dataclasses import dataclass, field
+from typing import Literal, Protocol
 
 from coffee_roaster_mcp.session import EventPayloadValue
+
+TemperatureUnit = Literal["celsius", "fahrenheit", "unknown"]
+
+
+def _raw_vendor_data_default() -> dict[str, EventPayloadValue]:
+    """Return an empty raw vendor data mapping."""
+    return {}
+
+
+@dataclass(frozen=True)
+class ControlRange:
+    """Supported integer range for one roaster control.
+
+    Attributes:
+        minimum: Lowest accepted control value.
+        maximum: Highest accepted control value.
+        step: Smallest supported increment.
+        unit: Human-readable control unit.
+    """
+
+    minimum: int
+    maximum: int
+    step: int
+    unit: str = "percent"
+
+
+@dataclass(frozen=True)
+class SupportedActions:
+    """Actions supported by one roaster driver.
+
+    Attributes:
+        heat_control: Whether heat percentage commands are supported.
+        fan_control: Whether fan percentage commands are supported.
+        bean_drop: Whether bean drop commands are supported.
+        cooling_control: Whether cooling start and stop commands are supported.
+        emergency_stop: Whether driver-owned emergency stop is supported.
+    """
+
+    heat_control: bool
+    fan_control: bool
+    bean_drop: bool
+    cooling_control: bool
+    emergency_stop: bool
+
+
+@dataclass(frozen=True)
+class SensorUnits:
+    """Temperature units reported by one roaster driver.
+
+    Attributes:
+        bean_temperature: Unit for normalized bean temperature readings.
+        environment_temperature: Unit for normalized environment temperature readings.
+    """
+
+    bean_temperature: TemperatureUnit
+    environment_temperature: TemperatureUnit
+
+
+@dataclass(frozen=True)
+class CommandStreaming:
+    """Command streaming requirements for one roaster driver.
+
+    Attributes:
+        required: Whether the driver needs continuous command streaming.
+        interval_seconds: Required command interval, when streaming is required.
+    """
+
+    required: bool
+    interval_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class RoasterCapabilities:
+    """Static capabilities exposed by one roaster driver.
+
+    Attributes:
+        driver: Stable driver identifier.
+        heat: Supported heat range.
+        fan: Supported fan range.
+        actions: Supported control actions.
+        sensor_units: Units used by normalized temperature readings.
+        command_streaming: Driver command-streaming requirements.
+    """
+
+    driver: str
+    heat: ControlRange
+    fan: ControlRange
+    actions: SupportedActions
+    sensor_units: SensorUnits
+    command_streaming: CommandStreaming
+
+
+@dataclass(frozen=True)
+class RoasterState:
+    """Normalized roaster state returned by the driver boundary.
+
+    Attributes:
+        driver: Stable driver identifier.
+        connected: Whether the driver is connected to its roaster backend.
+        bean_temp_c: Normalized bean temperature in Celsius when available.
+        env_temp_c: Normalized environment temperature in Celsius when available.
+        heat_level_percent: Current heat control level.
+        fan_level_percent: Current fan control level.
+        cooling_on: Whether cooling is active.
+        raw_vendor_data: Optional vendor-specific fields for diagnostics.
+    """
+
+    driver: str
+    connected: bool
+    bean_temp_c: float | None
+    env_temp_c: float | None
+    heat_level_percent: int
+    fan_level_percent: int
+    cooling_on: bool
+    raw_vendor_data: dict[str, EventPayloadValue] = field(default_factory=_raw_vendor_data_default)
 
 
 @dataclass(frozen=True)
@@ -38,39 +153,166 @@ class EmergencyStopResult:
         }
 
 
-class RoasterSafetyDriver(Protocol):
-    """Minimal driver protocol needed before the full E3 driver contract lands."""
+class RoasterDriver(Protocol):
+    """Roaster driver interface used by the RoastPilot runtime."""
+
+    name: str
+
+    @property
+    def capabilities(self) -> RoasterCapabilities:
+        """Return static driver capabilities."""
+        ...
+
+    def connect(self) -> None:
+        """Open the driver connection lifecycle."""
+        ...
+
+    def disconnect(self) -> None:
+        """Close the driver connection lifecycle."""
+        ...
+
+    def read_state(self) -> RoasterState:
+        """Return the latest normalized roaster state."""
+        ...
+
+    def set_heat(self, *, heat_level_percent: int) -> RoasterState:
+        """Apply a heat control update and return normalized state."""
+        ...
+
+    def set_fan(self, *, fan_level_percent: int) -> RoasterState:
+        """Apply a fan control update and return normalized state."""
+        ...
+
+    def drop_beans(self) -> RoasterState:
+        """Trigger the bean drop action and return normalized state."""
+        ...
+
+    def start_cooling(self) -> RoasterState:
+        """Start cooling and return normalized state."""
+        ...
+
+    def stop_cooling(self) -> RoasterState:
+        """Stop cooling and return normalized state."""
+        ...
 
     def emergency_stop(self, *, reason: str) -> EmergencyStopResult:
         """Apply the safest available driver-owned stop behavior."""
         ...
 
 
+RoasterSafetyDriver = RoasterDriver
+
+
 class MockRoasterDriver:
-    """Mock roaster driver with deterministic fail-closed emergency stop behavior."""
+    """Mock roaster driver with deterministic local-only control behavior."""
 
     name = "mock"
+
+    def __init__(self) -> None:
+        """Initialize deterministic mock roaster state."""
+        self._connected = False
+        self._heat_level_percent = 0
+        self._fan_level_percent = 0
+        self._cooling_on = False
+        self._beans_dropped = False
+
+    @property
+    def capabilities(self) -> RoasterCapabilities:
+        """Return mock-safe capabilities for local development."""
+        return RoasterCapabilities(
+            driver=self.name,
+            heat=ControlRange(minimum=0, maximum=100, step=1),
+            fan=ControlRange(minimum=0, maximum=100, step=1),
+            actions=SupportedActions(
+                heat_control=True,
+                fan_control=True,
+                bean_drop=True,
+                cooling_control=True,
+                emergency_stop=True,
+            ),
+            sensor_units=SensorUnits(
+                bean_temperature="celsius",
+                environment_temperature="celsius",
+            ),
+            command_streaming=CommandStreaming(required=False),
+        )
+
+    def connect(self) -> None:
+        """Mark the mock driver connected."""
+        self._connected = True
+
+    def disconnect(self) -> None:
+        """Mark the mock driver disconnected."""
+        self._connected = False
+
+    def read_state(self) -> RoasterState:
+        """Return deterministic mock roaster state."""
+        return RoasterState(
+            driver=self.name,
+            connected=self._connected,
+            bean_temp_c=None,
+            env_temp_c=None,
+            heat_level_percent=self._heat_level_percent,
+            fan_level_percent=self._fan_level_percent,
+            cooling_on=self._cooling_on,
+            raw_vendor_data={"beans_dropped": self._beans_dropped},
+        )
+
+    def set_heat(self, *, heat_level_percent: int) -> RoasterState:
+        """Set mock heat and return normalized state."""
+        self._heat_level_percent = _validate_control_percent(
+            heat_level_percent,
+            label="heat_level_percent",
+        )
+        return self.read_state()
+
+    def set_fan(self, *, fan_level_percent: int) -> RoasterState:
+        """Set mock fan and return normalized state."""
+        self._fan_level_percent = _validate_control_percent(
+            fan_level_percent,
+            label="fan_level_percent",
+        )
+        return self.read_state()
+
+    def drop_beans(self) -> RoasterState:
+        """Record a mock bean drop and force heat off."""
+        self._beans_dropped = True
+        self._heat_level_percent = 0
+        return self.read_state()
+
+    def start_cooling(self) -> RoasterState:
+        """Start mock cooling and return normalized state."""
+        self._cooling_on = True
+        return self.read_state()
+
+    def stop_cooling(self) -> RoasterState:
+        """Stop mock cooling and return normalized state."""
+        self._cooling_on = False
+        return self.read_state()
 
     def emergency_stop(self, *, reason: str) -> EmergencyStopResult:
         """Return deterministic mock-safe emergency stop controls."""
         _ = reason
+        self._heat_level_percent = 0
+        self._fan_level_percent = 100
+        self._cooling_on = True
         return EmergencyStopResult(
             driver=self.name,
             safety_method="emergency_stop",
-            heat_level_percent=0,
-            fan_level_percent=100,
-            cooling_on=True,
+            heat_level_percent=self._heat_level_percent,
+            fan_level_percent=self._fan_level_percent,
+            cooling_on=self._cooling_on,
         )
 
 
-def create_roaster_safety_driver(driver_name: str) -> RoasterSafetyDriver:
-    """Create the configured roaster safety driver.
+def create_roaster_driver(driver_name: str) -> RoasterDriver:
+    """Create the configured roaster driver.
 
     Args:
         driver_name: Roaster driver name from configuration.
 
     Returns:
-        Driver safety adapter for the configured driver.
+        Driver adapter for the configured driver.
 
     Raises:
         ValueError: If the driver is not implemented in the current runtime.
@@ -80,3 +322,17 @@ def create_roaster_safety_driver(driver_name: str) -> RoasterSafetyDriver:
     raise ValueError(
         f"Roaster driver {driver_name!r} is not implemented in this bootstrap runtime."
     )
+
+
+def create_roaster_safety_driver(driver_name: str) -> RoasterDriver:
+    """Create the configured roaster driver for E2 compatibility."""
+    return create_roaster_driver(driver_name)
+
+
+def _validate_control_percent(value: object, *, label: str) -> int:
+    """Validate one percentage control input."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{label} must be an integer between 0 and 100.")
+    if not 0 <= value <= 100:
+        raise ValueError(f"{label} must be between 0 and 100.")
+    return value

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -15,7 +15,7 @@ from mcp.server.session import ServerSession
 
 from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.config import AppConfig, ConfigError, load_config
-from coffee_roaster_mcp.drivers import RoasterSafetyDriver, create_roaster_safety_driver
+from coffee_roaster_mcp.drivers import RoasterDriver, create_roaster_driver
 from coffee_roaster_mcp.exports import export_roast_snapshot
 from coffee_roaster_mcp.session import (
     EventPayloadValue,
@@ -37,14 +37,14 @@ class ServerContext:
         config: Loaded RoastPilot configuration.
         transport: Actual MCP transport used by this server process.
         session_store: Authoritative in-process roast session owner.
-        roaster_driver: Configured driver safety boundary.
+        roaster_driver: Configured driver boundary.
         started_at_utc: UTC time when the MCP process initialized.
     """
 
     config: AppConfig
     transport: str
     session_store: RoastSessionStore
-    roaster_driver: RoasterSafetyDriver
+    roaster_driver: RoasterDriver
     started_at_utc: datetime
 
 
@@ -206,7 +206,7 @@ def build_server_context(
     """
     config = load_config(path=config_path)
     try:
-        roaster_driver = create_roaster_safety_driver(config.roaster.driver)
+        roaster_driver = create_roaster_driver(config.roaster.driver)
     except ValueError as exc:
         raise ConfigError(str(exc)) from exc
     return ServerContext(

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -12,6 +12,8 @@ from threading import RLock
 from typing import Literal
 from uuid import uuid4
 
+from coffee_roaster_mcp.controls import validate_control_percent
+
 RoastPhase = Literal[
     "pre_roast",
     "roasting",
@@ -450,7 +452,7 @@ class RoastSessionStore:
         """Set the latest in-memory heat value for one active session."""
         with self._lock:
             self._assert_latest_active_session(session)
-            validated_heat = _validate_control_percent(
+            validated_heat = validate_control_percent(
                 heat_level_percent,
                 label="heat_level_percent",
             )
@@ -479,7 +481,7 @@ class RoastSessionStore:
         """Set the latest in-memory fan value for one active session."""
         with self._lock:
             self._assert_latest_active_session(session)
-            session.fan_level_percent = _validate_control_percent(
+            session.fan_level_percent = validate_control_percent(
                 fan_level_percent,
                 label="fan_level_percent",
             )
@@ -924,12 +926,3 @@ def _copy_session_for_read(session: RoastSession) -> RoastSession:
         stopped_at_utc=session.stopped_at_utc,
         monotonic_stop=session.monotonic_stop,
     )
-
-
-def _validate_control_percent(value: object, *, label: str) -> int:
-    """Validate one percentage-like control input."""
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise TypeError(f"{label} must be an integer between 0 and 100.")
-    if not 0 <= value <= 100:
-        raise ValueError(f"{label} must be between 0 and 100.")
-    return value

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,16 +1,129 @@
 """Roaster driver safety behavior coverage."""
 
-from coffee_roaster_mcp.drivers import MockRoasterDriver, create_roaster_safety_driver
+import pytest
+
+from coffee_roaster_mcp.drivers import (
+    MockRoasterDriver,
+    RoasterDriver,
+    create_roaster_driver,
+    create_roaster_safety_driver,
+)
 
 
-def test_create_roaster_safety_driver_returns_mock_driver() -> None:
+def _assert_roaster_driver_contract(driver: RoasterDriver) -> None:
+    """Exercise the E3 roaster driver contract against one implementation."""
+    capabilities = driver.capabilities
+    assert capabilities.driver == "mock"
+    assert capabilities.heat.minimum == 0
+    assert capabilities.heat.maximum == 100
+    assert capabilities.heat.step == 1
+    assert capabilities.fan.minimum == 0
+    assert capabilities.fan.maximum == 100
+    assert capabilities.actions.heat_control is True
+    assert capabilities.actions.fan_control is True
+    assert capabilities.actions.bean_drop is True
+    assert capabilities.actions.cooling_control is True
+    assert capabilities.actions.emergency_stop is True
+    assert capabilities.sensor_units.bean_temperature == "celsius"
+    assert capabilities.sensor_units.environment_temperature == "celsius"
+    assert capabilities.command_streaming.required is False
+    assert capabilities.command_streaming.interval_seconds is None
+
+    initial_state = driver.read_state()
+    assert initial_state.driver == "mock"
+    assert initial_state.connected is False
+    assert initial_state.heat_level_percent == 0
+    assert initial_state.fan_level_percent == 0
+    assert initial_state.cooling_on is False
+
+    driver.connect()
+    connected_state = driver.read_state()
+    assert connected_state.connected is True
+
+    heat_state = driver.set_heat(heat_level_percent=55)
+    assert heat_state.heat_level_percent == 55
+    assert heat_state.fan_level_percent == 0
+
+    fan_state = driver.set_fan(fan_level_percent=35)
+    assert fan_state.heat_level_percent == 55
+    assert fan_state.fan_level_percent == 35
+
+    dropped_state = driver.drop_beans()
+    assert dropped_state.heat_level_percent == 0
+    assert dropped_state.raw_vendor_data["beans_dropped"] is True
+
+    cooling_state = driver.start_cooling()
+    assert cooling_state.cooling_on is True
+
+    stopped_cooling_state = driver.stop_cooling()
+    assert stopped_cooling_state.cooling_on is False
+
+    driver.disconnect()
+    disconnected_state = driver.read_state()
+    assert disconnected_state.connected is False
+
+
+def test_create_roaster_driver_returns_mock_driver() -> None:
+    driver = create_roaster_driver("mock")
+
+    assert isinstance(driver, MockRoasterDriver)
+
+
+def test_create_roaster_safety_driver_alias_returns_mock_driver() -> None:
     driver = create_roaster_safety_driver("mock")
 
     assert isinstance(driver, MockRoasterDriver)
 
 
+def test_create_roaster_driver_rejects_unsupported_driver() -> None:
+    with pytest.raises(ValueError, match="not implemented"):
+        create_roaster_driver("hottop")
+
+
+def test_mock_driver_satisfies_roaster_driver_contract() -> None:
+    _assert_roaster_driver_contract(MockRoasterDriver())
+
+
+@pytest.mark.parametrize(
+    ("method_name", "kwargs"),
+    [
+        ("set_heat", {"heat_level_percent": -1}),
+        ("set_heat", {"heat_level_percent": 101}),
+        ("set_fan", {"fan_level_percent": -1}),
+        ("set_fan", {"fan_level_percent": 101}),
+    ],
+)
+def test_mock_driver_rejects_out_of_range_controls(
+    method_name: str,
+    kwargs: dict[str, int],
+) -> None:
+    driver = MockRoasterDriver()
+
+    with pytest.raises(ValueError, match="between 0 and 100"):
+        getattr(driver, method_name)(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "kwargs"),
+    [
+        ("set_heat", {"heat_level_percent": True}),
+        ("set_fan", {"fan_level_percent": True}),
+    ],
+)
+def test_mock_driver_rejects_bool_controls(
+    method_name: str,
+    kwargs: dict[str, bool],
+) -> None:
+    driver = MockRoasterDriver()
+
+    with pytest.raises(TypeError, match="integer between 0 and 100"):
+        getattr(driver, method_name)(**kwargs)
+
+
 def test_mock_driver_emergency_stop_returns_safe_session_state() -> None:
     driver = MockRoasterDriver()
+    driver.set_heat(heat_level_percent=75)
+    driver.set_fan(fan_level_percent=20)
 
     result = driver.emergency_stop(reason="unit-test")
 
@@ -20,3 +133,6 @@ def test_mock_driver_emergency_stop_returns_safe_session_state() -> None:
     assert result.fan_level_percent == 100
     assert result.cooling_on is True
     assert result.as_event_payload()["driver_safety_method_called"] is True
+    assert driver.read_state().heat_level_percent == 0
+    assert driver.read_state().fan_level_percent == 100
+    assert driver.read_state().cooling_on is True

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,4 +1,4 @@
-"""Roaster driver safety behavior coverage."""
+"""Roaster driver contract, capability, and safety behavior coverage."""
 
 import pytest
 

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -3,6 +3,7 @@
 import pytest
 
 from coffee_roaster_mcp.drivers import (
+    CommandStreaming,
     MockRoasterDriver,
     RoasterDriver,
     create_roaster_driver,
@@ -82,6 +83,31 @@ def test_create_roaster_driver_rejects_unsupported_driver() -> None:
 
 def test_mock_driver_satisfies_roaster_driver_contract() -> None:
     _assert_roaster_driver_contract(MockRoasterDriver())
+
+
+def test_command_streaming_allows_required_positive_interval() -> None:
+    streaming = CommandStreaming(required=True, interval_seconds=0.3)
+
+    assert streaming.required is True
+    assert streaming.interval_seconds == 0.3
+
+
+@pytest.mark.parametrize(
+    ("required", "interval_seconds", "match"),
+    [
+        (True, None, "required when command streaming is required"),
+        (True, 0.0, "greater than 0"),
+        (True, -0.1, "greater than 0"),
+        (False, 0.3, "must be None"),
+    ],
+)
+def test_command_streaming_rejects_inconsistent_values(
+    required: bool,
+    interval_seconds: float | None,
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        CommandStreaming(required=required, interval_seconds=interval_seconds)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- define the broader `RoasterDriver` protocol for connection lifecycle, normalized state reads, heat and fan control, drop, cooling, emergency stop, and capabilities
- add typed capability models for control ranges, supported actions, sensor units, and command-streaming requirements
- extend the mock driver to satisfy the contract while preserving existing E2 emergency-stop fail-closed behavior and MCP/session semantics
- update durable epic state to mark E3-S1 complete and move the active pointer to E3-S2

## Validation
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`
- `./.venv/bin/python -m pytest` 74 passed

Closes #23
