### PR TITLE
E3-S2: Implement mock driver

### DIFF
--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E3-S2`
-- Current target: Implement the mock driver against the broader driver contract
+- Active story: `E3-S3`
+- Current target: Implement normalized roaster state model details before Hottop driver work
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -40,6 +40,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E2-S7` completes the first one-process mock vertical slice. `export_roast_log` now writes snapshot JSONL, CSV, and summary files from the current session state, and `get_roast_state` exposes minimal timestamp-derived roast and development metrics. Append-only telemetry writers and final export schemas remain Epic 5 work.
 - `E2-S8` completed the final Epic 2 hardening story before broader driver contract work. Pull-request CI now runs tests with coverage for `coffee_roaster_mcp`, writes an easy-to-read GitHub Actions Markdown summary, and uploads an `html-coverage-report` artifact without adding an external hosted coverage service.
 - `E3-S1` defines the broader `RoasterDriver` contract without changing MCP tool semantics. Drivers now expose connection lifecycle, normalized state reads, heat and fan controls, drop, cooling, driver-owned emergency stop, and static capabilities for ranges, supported actions, sensor units, and command-streaming requirements. The current mock driver implements this contract while preserving E2 emergency-stop fail-closed behavior.
+- `E3-S2` keeps the mock driver deterministic and local-only by advancing a fixed one-second thermal sample on `read_state`. Mock heat raises environment temperature, fan and cooling reduce it, bean temperature follows environment temperature with lag, and control commands return the current state without advancing telemetry. This preserves the current one-session MCP/store semantics while giving later stories a stable driver telemetry source.
 - The old `coffee-roasting` prototype was checked as a behavioral reference for E3-S1. It confirmed the need to model Hottop command streaming, temperature-unit normalization, compound drop/cooling behavior, and cleanup through driver lifecycle methods. Drum control remains an internal driver concern for now because E3-S1 and issue #23 do not require a public drum command.
 - ONNX INT8 is the default real model backend.
 - ONNX FP32 is supported by config.
@@ -151,7 +152,7 @@ Goal: support multiple roasters behind one driver contract while preserving curr
 - [x] `E3-S1` Define `RoasterDriver` interface and capabilities model.
   - Done when drivers expose connection lifecycle, read state, heat/fan control, drop, cooling, emergency stop, and capabilities.
 
-- [ ] `E3-S2` Implement mock driver.
+- [x] `E3-S2` Implement mock driver.
   - Done when the mock driver supports deterministic telemetry and passes contract tests.
 
 - [ ] `E3-S3` Implement normalized roaster state model.
@@ -506,4 +507,14 @@ After completing a story:
   - Ran `./.venv/bin/python -m pytest`: 74 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E3-S2:
+  - Extended `MockRoasterDriver` with deterministic fixed-step telemetry for normalized bean and environment temperatures.
+  - Mock `read_state` advances one sample at a time and records `sample_index` plus the telemetry model in raw vendor diagnostics.
+  - Mock heat, fan, drop, cooling, stop cooling, and emergency stop keep their E3-S1 control semantics; command methods return the current state without advancing telemetry.
+  - Checked the old `coffee-roasting` mock roaster as a behavioral reference for heat/fan/cooling temperature effects and bean-temperature lag, but kept this implementation simpler and contract-focused.
+  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 19 passed.
+  - Ran `./.venv/bin/python -m pytest`: 82 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed after applying `ruff format`.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,9 +22,9 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E3-S1 is complete. RoastPilot now has a typed `RoasterDriver` contract covering connection lifecycle, normalized state reads, heat and fan control, drop, cooling, driver-owned emergency stop, and static capabilities.
+E3-S2 is complete. The mock driver now implements deterministic fixed-step telemetry against the `RoasterDriver` contract while preserving mock-safe controls, fail-closed emergency-stop behavior, and the current MCP/session-store boundary.
 
-The next story is E3-S2: implement the mock driver against the broader driver contract with deterministic telemetry and contract tests.
+The next story is E3-S3: implement the normalized roaster state model details needed before Hottop driver work.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -220,17 +220,29 @@ RoasterSafetyDriver = RoasterDriver
 
 
 class MockRoasterDriver:
-    """Mock roaster driver with deterministic local-only control behavior."""
+    """Mock roaster driver with deterministic local-only telemetry and controls."""
 
     name = "mock"
+    _SAMPLE_INTERVAL_SECONDS = 1.0
+    _INITIAL_TEMP_C = 20.0
+    _MIN_TEMP_C = 15.0
+    _MAX_ENV_TEMP_C = 300.0
+    _MAX_BEAN_TEMP_C = 250.0
+    _MAX_HEAT_RATE_C_PER_SEC = 2.0
+    _MAX_FAN_COOLING_C_PER_SEC = 0.5
+    _COOLING_MODE_RATE_C_PER_SEC = 5.0
+    _BEAN_THERMAL_LAG_FACTOR = 0.1
 
     def __init__(self) -> None:
         """Initialize deterministic mock roaster state."""
         self._connected = False
+        self._bean_temp_c = self._INITIAL_TEMP_C
+        self._env_temp_c = self._INITIAL_TEMP_C
         self._heat_level_percent = 0
         self._fan_level_percent = 0
         self._cooling_on = False
         self._beans_dropped = False
+        self._sample_index = 0
 
     @property
     def capabilities(self) -> RoasterCapabilities:
@@ -263,15 +275,24 @@ class MockRoasterDriver:
 
     def read_state(self) -> RoasterState:
         """Return deterministic mock roaster state."""
+        self._advance_telemetry()
+        return self._state_snapshot()
+
+    def _state_snapshot(self) -> RoasterState:
+        """Return the current mock roaster state without advancing telemetry."""
         return RoasterState(
             driver=self.name,
             connected=self._connected,
-            bean_temp_c=None,
-            env_temp_c=None,
+            bean_temp_c=self._bean_temp_c,
+            env_temp_c=self._env_temp_c,
             heat_level_percent=self._heat_level_percent,
             fan_level_percent=self._fan_level_percent,
             cooling_on=self._cooling_on,
-            raw_vendor_data={"beans_dropped": self._beans_dropped},
+            raw_vendor_data={
+                "beans_dropped": self._beans_dropped,
+                "sample_index": self._sample_index,
+                "telemetry_model": "fixed_step_thermal_v1",
+            },
         )
 
     def set_heat(self, *, heat_level_percent: int) -> RoasterState:
@@ -280,7 +301,7 @@ class MockRoasterDriver:
             heat_level_percent,
             label="heat_level_percent",
         )
-        return self.read_state()
+        return self._state_snapshot()
 
     def set_fan(self, *, fan_level_percent: int) -> RoasterState:
         """Set mock fan and return normalized state."""
@@ -288,23 +309,23 @@ class MockRoasterDriver:
             fan_level_percent,
             label="fan_level_percent",
         )
-        return self.read_state()
+        return self._state_snapshot()
 
     def drop_beans(self) -> RoasterState:
         """Record a mock bean drop and force heat off."""
         self._beans_dropped = True
         self._heat_level_percent = 0
-        return self.read_state()
+        return self._state_snapshot()
 
     def start_cooling(self) -> RoasterState:
         """Start mock cooling and return normalized state."""
         self._cooling_on = True
-        return self.read_state()
+        return self._state_snapshot()
 
     def stop_cooling(self) -> RoasterState:
         """Stop mock cooling and return normalized state."""
         self._cooling_on = False
-        return self.read_state()
+        return self._state_snapshot()
 
     def emergency_stop(self, *, reason: str) -> EmergencyStopResult:
         """Return deterministic mock-safe emergency stop controls."""
@@ -319,6 +340,40 @@ class MockRoasterDriver:
             fan_level_percent=self._fan_level_percent,
             cooling_on=self._cooling_on,
         )
+
+    def _advance_telemetry(self) -> None:
+        """Advance one deterministic mock telemetry sample."""
+        self._sample_index += 1
+        env_delta_c = self._environment_delta_c()
+        self._env_temp_c = _clamp_float(
+            self._env_temp_c + env_delta_c,
+            minimum=self._MIN_TEMP_C,
+            maximum=self._MAX_ENV_TEMP_C,
+        )
+
+        bean_target_c = self._env_temp_c
+        bean_delta_c = (
+            (bean_target_c - self._bean_temp_c)
+            * self._BEAN_THERMAL_LAG_FACTOR
+            * self._SAMPLE_INTERVAL_SECONDS
+        )
+        self._bean_temp_c = _clamp_float(
+            self._bean_temp_c + bean_delta_c,
+            minimum=self._MIN_TEMP_C,
+            maximum=self._MAX_BEAN_TEMP_C,
+        )
+
+    def _environment_delta_c(self) -> float:
+        """Return one fixed-step environment temperature delta."""
+        heat_effect = (self._heat_level_percent / 100.0) * self._MAX_HEAT_RATE_C_PER_SEC
+        fan_effect = (self._fan_level_percent / 100.0) * self._MAX_FAN_COOLING_C_PER_SEC
+        cooling_effect = self._COOLING_MODE_RATE_C_PER_SEC if self._cooling_on else 0.0
+        return (heat_effect - fan_effect - cooling_effect) * self._SAMPLE_INTERVAL_SECONDS
+
+
+def _clamp_float(value: float, *, minimum: float, maximum: float) -> float:
+    """Clamp a float and keep telemetry output stable at one decimal place."""
+    return round(max(minimum, min(maximum, value)), 1)
 
 
 def create_roaster_driver(driver_name: str) -> RoasterDriver:

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -33,25 +33,32 @@ def _assert_roaster_driver_contract(driver: RoasterDriver) -> None:
     initial_state = driver.read_state()
     assert initial_state.driver == "mock"
     assert initial_state.connected is False
+    assert initial_state.bean_temp_c == 20.0
+    assert initial_state.env_temp_c == 20.0
     assert initial_state.heat_level_percent == 0
     assert initial_state.fan_level_percent == 0
     assert initial_state.cooling_on is False
+    assert initial_state.raw_vendor_data["sample_index"] == 1
 
     driver.connect()
     connected_state = driver.read_state()
     assert connected_state.connected is True
+    assert connected_state.raw_vendor_data["sample_index"] == 2
 
     heat_state = driver.set_heat(heat_level_percent=55)
     assert heat_state.heat_level_percent == 55
     assert heat_state.fan_level_percent == 0
+    assert heat_state.raw_vendor_data["sample_index"] == 2
 
     fan_state = driver.set_fan(fan_level_percent=35)
     assert fan_state.heat_level_percent == 55
     assert fan_state.fan_level_percent == 35
+    assert fan_state.raw_vendor_data["sample_index"] == 2
 
     dropped_state = driver.drop_beans()
     assert dropped_state.heat_level_percent == 0
     assert dropped_state.raw_vendor_data["beans_dropped"] is True
+    assert dropped_state.raw_vendor_data["sample_index"] == 2
 
     cooling_state = driver.start_cooling()
     assert cooling_state.cooling_on is True
@@ -62,6 +69,19 @@ def _assert_roaster_driver_contract(driver: RoasterDriver) -> None:
     driver.disconnect()
     disconnected_state = driver.read_state()
     assert disconnected_state.connected is False
+
+
+def _read_temperature_sequence(
+    driver: RoasterDriver,
+    *,
+    sample_count: int,
+) -> list[tuple[float | None, float | None]]:
+    """Read a deterministic sequence of bean and environment temperatures."""
+    sequence: list[tuple[float | None, float | None]] = []
+    for _ in range(sample_count):
+        state = driver.read_state()
+        sequence.append((state.bean_temp_c, state.env_temp_c))
+    return sequence
 
 
 def test_create_roaster_driver_returns_mock_driver() -> None:
@@ -83,6 +103,62 @@ def test_create_roaster_driver_rejects_unsupported_driver() -> None:
 
 def test_mock_driver_satisfies_roaster_driver_contract() -> None:
     _assert_roaster_driver_contract(MockRoasterDriver())
+
+
+def test_mock_driver_returns_reproducible_telemetry_sequence() -> None:
+    first_driver = MockRoasterDriver()
+    second_driver = MockRoasterDriver()
+
+    for driver in (first_driver, second_driver):
+        driver.connect()
+        driver.set_heat(heat_level_percent=100)
+        driver.set_fan(fan_level_percent=0)
+
+    first_sequence = _read_temperature_sequence(first_driver, sample_count=3)
+    second_sequence = _read_temperature_sequence(second_driver, sample_count=3)
+
+    assert first_sequence == second_sequence
+
+
+def test_mock_driver_telemetry_responds_to_heat_and_cooling() -> None:
+    driver = MockRoasterDriver()
+    driver.connect()
+
+    initial_state = driver.read_state()
+    assert initial_state.bean_temp_c == 20.0
+    assert initial_state.env_temp_c == 20.0
+
+    driver.set_heat(heat_level_percent=100)
+    heating_state = driver.read_state()
+    assert heating_state.env_temp_c == 22.0
+    assert heating_state.bean_temp_c == 20.2
+
+    hotter_state = driver.read_state()
+    assert hotter_state.env_temp_c == 24.0
+    assert hotter_state.bean_temp_c == 20.6
+
+    driver.start_cooling()
+    cooling_state = driver.read_state()
+    assert cooling_state.cooling_on is True
+    assert cooling_state.env_temp_c == 21.0
+    assert cooling_state.bean_temp_c == 20.6
+
+
+def test_mock_driver_control_commands_do_not_advance_telemetry() -> None:
+    driver = MockRoasterDriver()
+    driver.connect()
+    sampled_state = driver.read_state()
+
+    heat_state = driver.set_heat(heat_level_percent=70)
+    fan_state = driver.set_fan(fan_level_percent=30)
+    drop_state = driver.drop_beans()
+
+    assert sampled_state.raw_vendor_data["sample_index"] == 1
+    assert heat_state.raw_vendor_data["sample_index"] == 1
+    assert fan_state.raw_vendor_data["sample_index"] == 1
+    assert drop_state.raw_vendor_data["sample_index"] == 1
+    assert drop_state.bean_temp_c == sampled_state.bean_temp_c
+    assert drop_state.env_temp_c == sampled_state.env_temp_c
 
 
 def test_command_streaming_allows_required_positive_interval() -> None:


### PR DESCRIPTION
## Summary

- Adds deterministic fixed-step telemetry to `MockRoasterDriver`.
- Keeps control commands stable by returning current driver state without advancing telemetry.
- Updates E3 durable state to mark E3-S2 complete and move the active story to E3-S3.

## Validation

- `./.venv/bin/python -m pytest tests/test_drivers.py`
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`

Closes #24
