### PR TITLE
E3-S3: Implement normalized roaster state model

### DIFF
--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E3-S3`
-- Current target: Implement normalized roaster state model details before Hottop driver work
+- Active story: `E3-S4`
+- Current target: Implement Hottop serial connection lifecycle
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -41,6 +41,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E2-S8` completed the final Epic 2 hardening story before broader driver contract work. Pull-request CI now runs tests with coverage for `coffee_roaster_mcp`, writes an easy-to-read GitHub Actions Markdown summary, and uploads an `html-coverage-report` artifact without adding an external hosted coverage service.
 - `E3-S1` defines the broader `RoasterDriver` contract without changing MCP tool semantics. Drivers now expose connection lifecycle, normalized state reads, heat and fan controls, drop, cooling, driver-owned emergency stop, and static capabilities for ranges, supported actions, sensor units, and command-streaming requirements. The current mock driver implements this contract while preserving E2 emergency-stop fail-closed behavior.
 - `E3-S2` keeps the mock driver deterministic and local-only by advancing a fixed one-second thermal sample on `read_state`. Mock heat raises environment temperature, fan and cooling reduce it, bean temperature follows environment temperature with lag, and control commands return the current state without advancing telemetry. This preserves the current one-session MCP/store semantics while giving later stories a stable driver telemetry source.
+- `E3-S3` hardens `RoasterState` as the normalized driver-boundary model. State construction now validates non-empty driver ids, exact boolean connection/cooling flags, finite Celsius temperatures, heat and fan control percentages, and flat raw-vendor diagnostic payloads.
 - The old `coffee-roasting` prototype was checked as a behavioral reference for E3-S1. It confirmed the need to model Hottop command streaming, temperature-unit normalization, compound drop/cooling behavior, and cleanup through driver lifecycle methods. Drum control remains an internal driver concern for now because E3-S1 and issue #23 do not require a public drum command.
 - ONNX INT8 is the default real model backend.
 - ONNX FP32 is supported by config.
@@ -155,7 +156,7 @@ Goal: support multiple roasters behind one driver contract while preserving curr
 - [x] `E3-S2` Implement mock driver.
   - Done when the mock driver supports deterministic telemetry and passes contract tests.
 
-- [ ] `E3-S3` Implement normalized roaster state model.
+- [x] `E3-S3` Implement normalized roaster state model.
   - Done when driver state includes bean temp C, env temp C, heat %, fan %, cooling on/off, connected, and raw vendor data.
 
 - [ ] `E3-S4` Implement Hottop serial connection lifecycle.
@@ -517,4 +518,13 @@ After completing a story:
   - Ran `./.venv/bin/python -m pytest`: 82 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed after applying `ruff format`.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E3-S3:
+  - Hardened `RoasterState` with construction-time validation for normalized driver-boundary state.
+  - State validation now rejects empty driver ids, non-boolean connection and cooling flags, non-finite or non-numeric Celsius temperatures, invalid heat and fan percentages, and nested or non-string-key raw vendor diagnostics.
+  - Kept the existing `RoasterDriver` contract and mock-driver control behavior unchanged; this story only tightened normalized state model invariants.
+  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 34 passed.
+  - Ran `./.venv/bin/python -m pytest`: 97 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,9 +22,9 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E3-S2 is complete. The mock driver now implements deterministic fixed-step telemetry against the `RoasterDriver` contract while preserving mock-safe controls, fail-closed emergency-stop behavior, and the current MCP/session-store boundary.
+E3-S3 is complete. `RoasterState` now validates normalized driver-boundary state for driver id, connection and cooling booleans, finite Celsius temperatures, heat and fan percentages, and raw vendor diagnostic payload shape.
 
-The next story is E3-S3: implement the normalized roaster state model details needed before Hottop driver work.
+The next story is E3-S4: implement the Hottop serial connection lifecycle.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal, Protocol
+from math import isfinite
+from typing import Literal, Protocol, cast
 
 from coffee_roaster_mcp.controls import validate_control_percent
 from coffee_roaster_mcp.session import EventPayloadValue
@@ -137,6 +138,43 @@ class RoasterState:
     fan_level_percent: int
     cooling_on: bool
     raw_vendor_data: dict[str, EventPayloadValue] = field(default_factory=_raw_vendor_data_default)
+
+    def __post_init__(self) -> None:
+        """Validate normalized roaster state at the driver boundary."""
+        _validate_driver_name(self.driver)
+        _validate_exact_bool(self.connected, label="connected")
+        _validate_exact_bool(self.cooling_on, label="cooling_on")
+        object.__setattr__(
+            self,
+            "bean_temp_c",
+            _validate_optional_temperature_c(self.bean_temp_c, label="bean_temp_c"),
+        )
+        object.__setattr__(
+            self,
+            "env_temp_c",
+            _validate_optional_temperature_c(self.env_temp_c, label="env_temp_c"),
+        )
+        object.__setattr__(
+            self,
+            "heat_level_percent",
+            validate_control_percent(
+                self.heat_level_percent,
+                label="heat_level_percent",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "fan_level_percent",
+            validate_control_percent(
+                self.fan_level_percent,
+                label="fan_level_percent",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "raw_vendor_data",
+            _validate_raw_vendor_data(self.raw_vendor_data),
+        )
 
 
 @dataclass(frozen=True)
@@ -374,6 +412,50 @@ class MockRoasterDriver:
 def _clamp_float(value: float, *, minimum: float, maximum: float) -> float:
     """Clamp a float and keep telemetry output stable at one decimal place."""
     return round(max(minimum, min(maximum, value)), 1)
+
+
+def _validate_exact_bool(value: object, *, label: str) -> None:
+    """Validate that a state field is exactly a bool."""
+    if not isinstance(value, bool):
+        raise TypeError(f"{label} must be a boolean.")
+
+
+def _validate_driver_name(value: object) -> None:
+    """Validate the stable driver identifier on normalized state."""
+    if not isinstance(value, str) or value.strip() == "":
+        raise ValueError("driver must be a non-empty string.")
+
+
+def _validate_optional_temperature_c(value: object, *, label: str) -> float | None:
+    """Validate one normalized Celsius temperature value."""
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{label} must be a finite Celsius temperature or None.")
+    normalized = float(value)
+    if not isfinite(normalized):
+        raise ValueError(f"{label} must be finite.")
+    return normalized
+
+
+def _validate_raw_vendor_data(
+    raw_vendor_data: object,
+) -> dict[str, EventPayloadValue]:
+    """Validate and copy raw vendor diagnostics for normalized state."""
+    if not isinstance(raw_vendor_data, dict):
+        raise TypeError("raw_vendor_data must be a dictionary.")
+    raw_vendor_mapping = cast(dict[object, object], raw_vendor_data)
+    copied: dict[str, EventPayloadValue] = {}
+    allowed_value_types = (str, int, float, bool, type(None))
+    for key, value in raw_vendor_mapping.items():
+        if not isinstance(key, str):
+            raise TypeError("raw_vendor_data keys must be strings.")
+        if not isinstance(value, allowed_value_types):
+            raise TypeError(
+                "raw_vendor_data values must be strings, integers, floats, booleans, or None."
+            )
+        copied[key] = value
+    return copied
 
 
 def create_roaster_driver(driver_name: str) -> RoasterDriver:

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,11 +1,14 @@
 """Roaster driver contract, capability, and safety behavior coverage."""
 
+from typing import cast
+
 import pytest
 
 from coffee_roaster_mcp.drivers import (
     CommandStreaming,
     MockRoasterDriver,
     RoasterDriver,
+    RoasterState,
     create_roaster_driver,
     create_roaster_safety_driver,
 )
@@ -103,6 +106,116 @@ def test_create_roaster_driver_rejects_unsupported_driver() -> None:
 
 def test_mock_driver_satisfies_roaster_driver_contract() -> None:
     _assert_roaster_driver_contract(MockRoasterDriver())
+
+
+def test_roaster_state_normalizes_integer_temperatures_and_copies_raw_vendor_data() -> None:
+    raw_vendor_data: dict[str, str | int | float | bool | None] = {"vendor_code": 7}
+
+    state = RoasterState(
+        driver="mock",
+        connected=True,
+        bean_temp_c=20,
+        env_temp_c=21,
+        heat_level_percent=10,
+        fan_level_percent=20,
+        cooling_on=False,
+        raw_vendor_data=raw_vendor_data,
+    )
+    raw_vendor_data["vendor_code"] = 8
+
+    assert state.bean_temp_c == 20.0
+    assert state.env_temp_c == 21.0
+    assert state.raw_vendor_data == {"vendor_code": 7}
+
+
+@pytest.mark.parametrize("driver", ["", "   "])
+def test_roaster_state_rejects_empty_driver(driver: str) -> None:
+    with pytest.raises(ValueError, match="driver"):
+        RoasterState(
+            driver=driver,
+            connected=True,
+            bean_temp_c=20.0,
+            env_temp_c=21.0,
+            heat_level_percent=10,
+            fan_level_percent=20,
+            cooling_on=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value", "error_type", "match"),
+    [
+        ("connected", 1, TypeError, "connected"),
+        ("cooling_on", 0, TypeError, "cooling_on"),
+        ("bean_temp_c", True, TypeError, "bean_temp_c"),
+        ("env_temp_c", "21.0", TypeError, "env_temp_c"),
+        ("bean_temp_c", float("nan"), ValueError, "bean_temp_c"),
+        ("env_temp_c", float("inf"), ValueError, "env_temp_c"),
+        ("heat_level_percent", -1, ValueError, "heat_level_percent"),
+        ("fan_level_percent", 101, ValueError, "fan_level_percent"),
+        ("heat_level_percent", True, TypeError, "heat_level_percent"),
+        ("fan_level_percent", False, TypeError, "fan_level_percent"),
+    ],
+)
+def test_roaster_state_rejects_invalid_normalized_fields(
+    field_name: str,
+    field_value: object,
+    error_type: type[Exception],
+    match: str,
+) -> None:
+    kwargs: dict[str, object] = {
+        "driver": "mock",
+        "connected": True,
+        "bean_temp_c": 20.0,
+        "env_temp_c": 21.0,
+        "heat_level_percent": 10,
+        "fan_level_percent": 20,
+        "cooling_on": False,
+    }
+    kwargs[field_name] = field_value
+
+    with pytest.raises(error_type, match=match):
+        RoasterState(**kwargs)  # pyright: ignore[reportArgumentType]
+
+
+def test_roaster_state_rejects_non_dict_raw_vendor_data() -> None:
+    with pytest.raises(TypeError, match="raw_vendor_data"):
+        RoasterState(
+            driver="mock",
+            connected=True,
+            bean_temp_c=20.0,
+            env_temp_c=21.0,
+            heat_level_percent=10,
+            fan_level_percent=20,
+            cooling_on=False,
+            raw_vendor_data=cast(dict[str, str | int | float | bool | None], []),
+        )
+
+
+def test_roaster_state_rejects_invalid_raw_vendor_data() -> None:
+    with pytest.raises(TypeError, match="keys"):
+        RoasterState(
+            driver="mock",
+            connected=True,
+            bean_temp_c=20.0,
+            env_temp_c=21.0,
+            heat_level_percent=10,
+            fan_level_percent=20,
+            cooling_on=False,
+            raw_vendor_data=cast(dict[str, str | int | float | bool | None], {1: "value"}),
+        )
+
+    with pytest.raises(TypeError, match="values"):
+        RoasterState(
+            driver="mock",
+            connected=True,
+            bean_temp_c=20.0,
+            env_temp_c=21.0,
+            heat_level_percent=10,
+            fan_level_percent=20,
+            cooling_on=False,
+            raw_vendor_data=cast(dict[str, str | int | float | bool | None], {"nested": {}}),
+        )
 
 
 def test_mock_driver_returns_reproducible_telemetry_sequence() -> None:


### PR DESCRIPTION
## Summary

- Hardens `RoasterState` with normalized driver-boundary validation.
- Adds state-model tests for driver id, booleans, Celsius temperatures, heat/fan percentages, and raw vendor diagnostics.
- Updates durable E3 state to mark E3-S3 complete and move the active story to E3-S4.

## Validation

- `./.venv/bin/python -m pytest tests/test_drivers.py`
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`

Closes #25
