### PR TITLE
E3-S6: Implement Hottop packet build/parse

### DIFF
--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E3-S6`
-- Current target: Implement Hottop packet build/parse
+- Active story: `E3-S7`
+- Current target: Implement Hottop heat, fan, drop, cooling, stop cooling, and emergency stop
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -44,6 +44,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E3-S3` hardens `RoasterState` as the normalized driver-boundary model. State construction now validates non-empty driver ids, exact boolean connection/cooling flags, finite Celsius temperatures, heat and fan control percentages, and flat raw-vendor diagnostic payloads.
 - `E3-S4` adds the first Hottop driver lifecycle slice. The driver can be constructed for `hottop_kn8828b_2k_plus`, requires an explicit serial port before connect, opens serial transport lazily through pyserial without holding the state-read lock, starts a command-loop lifecycle thread on connect, and disconnects by signalling the loop, joining it, closing serial transport, and clearing runtime references. Review hardening keeps Hottop capabilities accurate while controls are not implemented, passes configured port/baudrate/command interval into the driver, closes serial even when join times out, blocks reconnect while a prior command loop is still alive, and uses deterministic test synchronization for loop iteration tests. Packet sending and hardware commands remain later Epic 3 stories.
 - `E3-S5` keeps packet bytes and status parsing out of scope but completes the Hottop command-loop scheduler. The loop ticks at the configured cadence, can stream injectable command frames to the serial transport, records frame polls, send attempts, successful writes, last write size, and write errors in raw diagnostics, and defaults to sending no unverified hardware bytes until `E3-S6` implements the Hottop packet format.
+- `E3-S6` implements deterministic Hottop packet build/parse primitives without turning on live Hottop hardware commands. The driver module can build 36-byte command packets with checksum bytes, validate packet checksums, parse exact 36-byte status packets, and scan serial buffers for the first valid status packet with raw Celsius bean and environment temperatures. The command loop still keeps the safe no-default-frame behavior until `E3-S7` wires these packet primitives to explicit control commands.
 - The old `coffee-roasting` prototype was checked as a behavioral reference for E3-S1. It confirmed the need to model Hottop command streaming, temperature-unit normalization, compound drop/cooling behavior, and cleanup through driver lifecycle methods. Drum control remains an internal driver concern for now because E3-S1 and issue #23 do not require a public drum command.
 - ONNX INT8 is the default real model backend.
 - ONNX FP32 is supported by config.
@@ -167,7 +168,7 @@ Goal: support multiple roasters behind one driver contract while preserving curr
 - [x] `E3-S5` Implement Hottop command loop.
   - Done when continuous command streaming around 0.3s is implemented and lifecycle-tested.
 
-- [ ] `E3-S6` Implement Hottop packet build/parse.
+- [x] `E3-S6` Implement Hottop packet build/parse.
   - Done when 36-byte packet construction, status parsing, and checksum validation are unit tested.
 
 - [ ] `E3-S7` Implement Hottop heat, fan, drop, cooling, stop cooling, and emergency stop.
@@ -550,6 +551,17 @@ After completing a story:
   - Checked the old `coffee-roasting` Hottop prototype as a behavioral reference for the 0.3s continuous-command requirement, while leaving 36-byte packet construction and parsing to `E3-S6`.
   - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 52 passed.
   - Ran `./.venv/bin/python -m pytest`: 116 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E3-S6:
+  - Added Hottop packet primitives for 36-byte command construction, checksum calculation, checksum validation, exact status-packet parsing, and serial-buffer scanning for the first valid status packet.
+  - Command packets preserve the direct-serial behavioral reference layout: `A5 96 B0 A0 01 01 24` header fields, heat at byte `10`, roast fan and main fan on the Hottop `0-10` scale at bytes `11` and `12`, solenoid/drum/cooling bits at bytes `16` through `18`, and checksum at byte `35`.
+  - Status packet parsing validates length, `A5 96` prefix, and checksum before extracting raw Celsius environment temperature from bytes `23-24` and raw Celsius bean temperature from bytes `25-26`; buffer scanning skips leading noise and invalid checksum candidates.
+  - Kept command-loop safe defaults unchanged; E3-S6 does not enable heat, fan, drop, cooling, stop-cooling, or emergency-stop hardware commands.
+  - Checked the old `coffee-roasting` Hottop prototype as a behavioral reference for packet layout and status temperature offsets, but kept the new implementation isolated and unit-testable.
+  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 67 passed.
+  - Ran `./.venv/bin/python -m pytest`: 131 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -557,11 +557,12 @@ After completing a story:
 - Validation run for E3-S6:
   - Added Hottop packet primitives for 36-byte command construction, checksum calculation, checksum validation, exact status-packet parsing, and serial-buffer scanning for the first valid status packet.
   - Command packets preserve the direct-serial behavioral reference layout: `A5 96 B0 A0 01 01 24` header fields, heat at byte `10`, roast fan and main fan on the Hottop `0-10` scale at bytes `11` and `12`, solenoid/drum/cooling bits at bytes `16` through `18`, and checksum at byte `35`.
-  - Status packet parsing validates length, `A5 96` prefix, and checksum before extracting raw Celsius environment temperature from bytes `23-24` and raw Celsius bean temperature from bytes `25-26`; buffer scanning skips leading noise and invalid checksum candidates.
+  - Status packet parsing validates length, `A5 96` prefix, rejects command-header echoes, and validates checksum before extracting raw Celsius environment temperature from bytes `23-24` and raw Celsius bean temperature from bytes `25-26`; buffer scanning skips leading noise, invalid checksum candidates, and echoed command packets.
+  - Review hardening replaced Python banker's rounding in fan-scale mapping with explicit half-up integer scaling and added boundary tests for `x5` percentages.
   - Kept command-loop safe defaults unchanged; E3-S6 does not enable heat, fan, drop, cooling, stop-cooling, or emergency-stop hardware commands.
   - Checked the old `coffee-roasting` Hottop prototype as a behavioral reference for packet layout and status temperature offsets, but kept the new implementation isolated and unit-testable.
-  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 67 passed.
-  - Ran `./.venv/bin/python -m pytest`: 131 passed.
+  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 81 passed.
+  - Ran `./.venv/bin/python -m pytest`: 145 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,9 +22,9 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E3-S5 is complete. The Hottop driver now owns a lifecycle-tested command loop that ticks at the configured cadence, can stream injectable command frames to the serial transport, records frame polls, send attempts, writes, and errors in raw diagnostics, and defaults to sending no unverified hardware bytes until packet construction lands.
+E3-S6 is complete. The Hottop driver module now has deterministic 36-byte packet construction, checksum calculation and validation, exact status-packet parsing, and serial-buffer scanning for raw Celsius bean and environment temperatures. The command loop still does not send default Hottop bytes by itself; applying heat, fan, drop, cooling, and emergency-stop commands remains E3-S7 scope.
 
-The next story is E3-S6: implement Hottop packet build/parse.
+The next story is E3-S7: implement Hottop heat, fan, drop, cooling, stop cooling, and emergency stop.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -280,6 +280,167 @@ class SerialTransport(Protocol):
 
 SerialTransportFactory = Callable[..., SerialTransport]
 HottopCommandFrameProvider = Callable[[], bytes | None]
+HOTTOP_PACKET_LENGTH = 36
+HOTTOP_PACKET_PREFIX = bytes((0xA5, 0x96))
+_HOTTOP_COMMAND_HEADER = bytes((0xA5, 0x96, 0xB0, 0xA0, 0x01, 0x01, 0x24))
+_HOTTOP_COMMAND_HEAT_INDEX = 10
+_HOTTOP_COMMAND_FAN_INDEX = 11
+_HOTTOP_COMMAND_MAIN_FAN_INDEX = 12
+_HOTTOP_COMMAND_SOLENOID_INDEX = 16
+_HOTTOP_COMMAND_DRUM_MOTOR_INDEX = 17
+_HOTTOP_COMMAND_COOLING_MOTOR_INDEX = 18
+_HOTTOP_STATUS_ENV_TEMP_HIGH_INDEX = 23
+_HOTTOP_STATUS_ENV_TEMP_LOW_INDEX = 24
+_HOTTOP_STATUS_BEAN_TEMP_HIGH_INDEX = 25
+_HOTTOP_STATUS_BEAN_TEMP_LOW_INDEX = 26
+_HOTTOP_CHECKSUM_INDEX = HOTTOP_PACKET_LENGTH - 1
+
+
+@dataclass(frozen=True)
+class HottopCommandPacket:
+    """Hottop 36-byte command packet inputs.
+
+    Attributes:
+        heat_level_percent: Heater level in normalized 0-100 percent.
+        fan_level_percent: Roast fan level in normalized 0-100 percent.
+        main_fan_level_percent: Main fan level in normalized 0-100 percent.
+        solenoid_open: Whether the drop solenoid path is active.
+        drum_motor_on: Whether the drum motor command bit is active.
+        cooling_motor_on: Whether the cooling motor command bit is active.
+    """
+
+    heat_level_percent: int = 0
+    fan_level_percent: int = 0
+    main_fan_level_percent: int = 0
+    solenoid_open: bool = False
+    drum_motor_on: bool = False
+    cooling_motor_on: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate normalized Hottop command packet fields."""
+        object.__setattr__(
+            self,
+            "heat_level_percent",
+            validate_control_percent(
+                self.heat_level_percent,
+                label="heat_level_percent",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "fan_level_percent",
+            validate_control_percent(
+                self.fan_level_percent,
+                label="fan_level_percent",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "main_fan_level_percent",
+            validate_control_percent(
+                self.main_fan_level_percent,
+                label="main_fan_level_percent",
+            ),
+        )
+        _validate_exact_bool(self.solenoid_open, label="solenoid_open")
+        _validate_exact_bool(self.drum_motor_on, label="drum_motor_on")
+        _validate_exact_bool(self.cooling_motor_on, label="cooling_motor_on")
+
+    def to_bytes(self) -> bytes:
+        """Build the Hottop 36-byte command packet with checksum."""
+        packet = bytearray(HOTTOP_PACKET_LENGTH)
+        packet[: len(_HOTTOP_COMMAND_HEADER)] = _HOTTOP_COMMAND_HEADER
+        packet[_HOTTOP_COMMAND_HEAT_INDEX] = self.heat_level_percent
+        packet[_HOTTOP_COMMAND_FAN_INDEX] = _percent_to_hottop_fan_scale(self.fan_level_percent)
+        packet[_HOTTOP_COMMAND_MAIN_FAN_INDEX] = _percent_to_hottop_fan_scale(
+            self.main_fan_level_percent
+        )
+        packet[_HOTTOP_COMMAND_SOLENOID_INDEX] = int(self.solenoid_open)
+        packet[_HOTTOP_COMMAND_DRUM_MOTOR_INDEX] = int(self.drum_motor_on)
+        packet[_HOTTOP_COMMAND_COOLING_MOTOR_INDEX] = int(self.cooling_motor_on)
+        packet[_HOTTOP_CHECKSUM_INDEX] = calculate_hottop_packet_checksum(packet)
+        return bytes(packet)
+
+
+@dataclass(frozen=True)
+class HottopStatusPacket:
+    """Parsed Hottop 36-byte status packet.
+
+    Attributes:
+        bean_temp_c: Raw bean temperature reported by the roaster in Celsius.
+        env_temp_c: Raw environment temperature reported by the roaster in Celsius.
+        raw_packet: Original validated 36-byte status packet.
+    """
+
+    bean_temp_c: int
+    env_temp_c: int
+    raw_packet: bytes
+
+
+def build_hottop_command_packet(
+    *,
+    heat_level_percent: int = 0,
+    fan_level_percent: int = 0,
+    main_fan_level_percent: int = 0,
+    solenoid_open: bool = False,
+    drum_motor_on: bool = False,
+    cooling_motor_on: bool = False,
+) -> bytes:
+    """Build a Hottop 36-byte command packet from normalized controls."""
+    return HottopCommandPacket(
+        heat_level_percent=heat_level_percent,
+        fan_level_percent=fan_level_percent,
+        main_fan_level_percent=main_fan_level_percent,
+        solenoid_open=solenoid_open,
+        drum_motor_on=drum_motor_on,
+        cooling_motor_on=cooling_motor_on,
+    ).to_bytes()
+
+
+def parse_hottop_status_packet(packet: bytes) -> HottopStatusPacket:
+    """Parse and validate one exact Hottop 36-byte status packet."""
+    _validate_hottop_packet(packet)
+    env_temp_c = _read_big_endian_uint16(
+        packet,
+        high_index=_HOTTOP_STATUS_ENV_TEMP_HIGH_INDEX,
+        low_index=_HOTTOP_STATUS_ENV_TEMP_LOW_INDEX,
+    )
+    bean_temp_c = _read_big_endian_uint16(
+        packet,
+        high_index=_HOTTOP_STATUS_BEAN_TEMP_HIGH_INDEX,
+        low_index=_HOTTOP_STATUS_BEAN_TEMP_LOW_INDEX,
+    )
+    return HottopStatusPacket(
+        bean_temp_c=bean_temp_c,
+        env_temp_c=env_temp_c,
+        raw_packet=bytes(packet),
+    )
+
+
+def find_hottop_status_packet(buffer: bytes) -> HottopStatusPacket | None:
+    """Return the first valid Hottop status packet found in serial bytes."""
+    search_limit = len(buffer) - HOTTOP_PACKET_LENGTH + 1
+    for offset in range(max(0, search_limit)):
+        if not buffer.startswith(HOTTOP_PACKET_PREFIX, offset):
+            continue
+        candidate = buffer[offset : offset + HOTTOP_PACKET_LENGTH]
+        if validate_hottop_packet_checksum(candidate):
+            return parse_hottop_status_packet(candidate)
+    return None
+
+
+def calculate_hottop_packet_checksum(packet: bytes | bytearray) -> int:
+    """Calculate the Hottop checksum over the first 35 packet bytes."""
+    if len(packet) != HOTTOP_PACKET_LENGTH:
+        raise ValueError(f"Hottop packet must be {HOTTOP_PACKET_LENGTH} bytes.")
+    return sum(packet[:_HOTTOP_CHECKSUM_INDEX]) & 0xFF
+
+
+def validate_hottop_packet_checksum(packet: bytes) -> bool:
+    """Return whether a Hottop packet has a valid checksum byte."""
+    if len(packet) != HOTTOP_PACKET_LENGTH:
+        return False
+    return packet[_HOTTOP_CHECKSUM_INDEX] == calculate_hottop_packet_checksum(packet)
 
 
 class MockRoasterDriver:
@@ -736,6 +897,26 @@ class HottopRoasterDriver:
     def _no_command_frame(self) -> bytes | None:
         """Return no hardware frame until Hottop packet construction lands."""
         return None
+
+
+def _percent_to_hottop_fan_scale(value: int) -> int:
+    """Map normalized fan percentage to the Hottop 0-10 byte scale."""
+    return int(round(value / 10.0))
+
+
+def _validate_hottop_packet(packet: bytes) -> None:
+    """Validate exact Hottop status packet length, prefix, and checksum."""
+    if len(packet) != HOTTOP_PACKET_LENGTH:
+        raise ValueError(f"Hottop packet must be {HOTTOP_PACKET_LENGTH} bytes.")
+    if not packet.startswith(HOTTOP_PACKET_PREFIX):
+        raise ValueError("Hottop packet must start with A5 96.")
+    if not validate_hottop_packet_checksum(packet):
+        raise ValueError("Hottop packet checksum is invalid.")
+
+
+def _read_big_endian_uint16(packet: bytes, *, high_index: int, low_index: int) -> int:
+    """Read one unsigned big-endian 16-bit value from packet bytes."""
+    return packet[high_index] * 256 + packet[low_index]
 
 
 def _clamp_float(value: float, *, minimum: float, maximum: float) -> float:

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -424,6 +424,8 @@ def find_hottop_status_packet(buffer: bytes) -> HottopStatusPacket | None:
         if not buffer.startswith(HOTTOP_PACKET_PREFIX, offset):
             continue
         candidate = buffer[offset : offset + HOTTOP_PACKET_LENGTH]
+        if is_hottop_command_packet(candidate):
+            continue
         if validate_hottop_packet_checksum(candidate):
             return parse_hottop_status_packet(candidate)
     return None
@@ -441,6 +443,11 @@ def validate_hottop_packet_checksum(packet: bytes) -> bool:
     if len(packet) != HOTTOP_PACKET_LENGTH:
         return False
     return packet[_HOTTOP_CHECKSUM_INDEX] == calculate_hottop_packet_checksum(packet)
+
+
+def is_hottop_command_packet(packet: bytes) -> bool:
+    """Return whether a packet has the Hottop command-frame header."""
+    return len(packet) == HOTTOP_PACKET_LENGTH and packet.startswith(_HOTTOP_COMMAND_HEADER)
 
 
 class MockRoasterDriver:
@@ -901,7 +908,7 @@ class HottopRoasterDriver:
 
 def _percent_to_hottop_fan_scale(value: int) -> int:
     """Map normalized fan percentage to the Hottop 0-10 byte scale."""
-    return int(round(value / 10.0))
+    return (value + 5) // 10
 
 
 def _validate_hottop_packet(packet: bytes) -> None:
@@ -910,6 +917,8 @@ def _validate_hottop_packet(packet: bytes) -> None:
         raise ValueError(f"Hottop packet must be {HOTTOP_PACKET_LENGTH} bytes.")
     if not packet.startswith(HOTTOP_PACKET_PREFIX):
         raise ValueError("Hottop packet must start with A5 96.")
+    if is_hottop_command_packet(packet):
+        raise ValueError("Hottop status packet must not use the command header.")
     if not validate_hottop_packet_checksum(packet):
         raise ValueError("Hottop packet checksum is invalid.")
 

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -19,6 +19,7 @@ from coffee_roaster_mcp.drivers import (
     create_roaster_driver,
     create_roaster_safety_driver,
     find_hottop_status_packet,
+    is_hottop_command_packet,
     parse_hottop_status_packet,
     validate_hottop_packet_checksum,
 )
@@ -391,6 +392,36 @@ def test_build_hottop_command_packet_defaults_to_safe_zero_state() -> None:
 
 
 @pytest.mark.parametrize(
+    ("fan_level_percent", "expected_hottop_scale"),
+    [
+        (0, 0),
+        (5, 1),
+        (15, 2),
+        (25, 3),
+        (35, 4),
+        (45, 5),
+        (55, 6),
+        (65, 7),
+        (75, 8),
+        (85, 9),
+        (95, 10),
+        (100, 10),
+    ],
+)
+def test_build_hottop_command_packet_uses_half_up_fan_scale(
+    fan_level_percent: int,
+    expected_hottop_scale: int,
+) -> None:
+    packet = build_hottop_command_packet(
+        fan_level_percent=fan_level_percent,
+        main_fan_level_percent=fan_level_percent,
+    )
+
+    assert packet[11] == expected_hottop_scale
+    assert packet[12] == expected_hottop_scale
+
+
+@pytest.mark.parametrize(
     ("kwargs", "error_type", "match"),
     [
         ({"heat_level_percent": -1}, ValueError, "heat_level_percent"),
@@ -420,11 +451,47 @@ def test_parse_hottop_status_packet_extracts_temperatures_and_preserves_raw_pack
     assert status.raw_packet == packet
 
 
+def test_parse_hottop_status_packet_rejects_command_packet_echo() -> None:
+    packet = build_hottop_command_packet(
+        heat_level_percent=75,
+        fan_level_percent=55,
+        main_fan_level_percent=30,
+        solenoid_open=True,
+        drum_motor_on=True,
+        cooling_motor_on=False,
+    )
+
+    assert is_hottop_command_packet(packet) is True
+    assert validate_hottop_packet_checksum(packet) is True
+    with pytest.raises(ValueError, match="command header"):
+        parse_hottop_status_packet(packet)
+
+
 def test_find_hottop_status_packet_skips_noise_and_invalid_candidates() -> None:
     invalid_packet = bytearray(_build_hottop_status_packet(env_temp_c=99, bean_temp_c=88))
     invalid_packet[35] ^= 0x01
     valid_packet = _build_hottop_status_packet(env_temp_c=205, bean_temp_c=187)
     buffer = b"noise" + bytes(invalid_packet) + b"more-noise" + valid_packet + b"tail"
+
+    status = find_hottop_status_packet(buffer)
+
+    assert status is not None
+    assert status.env_temp_c == 205
+    assert status.bean_temp_c == 187
+    assert status.raw_packet == valid_packet
+
+
+def test_find_hottop_status_packet_skips_command_packet_echoes() -> None:
+    command_packet = build_hottop_command_packet(
+        heat_level_percent=75,
+        fan_level_percent=55,
+        main_fan_level_percent=30,
+        solenoid_open=True,
+        drum_motor_on=True,
+        cooling_motor_on=False,
+    )
+    valid_packet = _build_hottop_status_packet(env_temp_c=205, bean_temp_c=187)
+    buffer = b"noise" + command_packet + valid_packet
 
     status = find_hottop_status_packet(buffer)
 

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -6,14 +6,21 @@ from typing import cast
 import pytest
 
 from coffee_roaster_mcp.drivers import (
+    HOTTOP_PACKET_LENGTH,
+    HOTTOP_PACKET_PREFIX,
     CommandStreaming,
     HottopRoasterDriver,
     MockRoasterDriver,
     RoasterDriver,
     RoasterState,
     SerialTransportFactory,
+    build_hottop_command_packet,
+    calculate_hottop_packet_checksum,
     create_roaster_driver,
     create_roaster_safety_driver,
+    find_hottop_status_packet,
+    parse_hottop_status_packet,
+    validate_hottop_packet_checksum,
 )
 
 
@@ -217,6 +224,18 @@ class StuckHottopRoasterDriver(HottopRoasterDriver):
         self._release_command_loop.wait()
 
 
+def _build_hottop_status_packet(*, env_temp_c: int, bean_temp_c: int) -> bytes:
+    """Build a minimal valid Hottop status packet for parser tests."""
+    packet = bytearray(HOTTOP_PACKET_LENGTH)
+    packet[: len(HOTTOP_PACKET_PREFIX)] = HOTTOP_PACKET_PREFIX
+    packet[23] = env_temp_c // 256
+    packet[24] = env_temp_c % 256
+    packet[25] = bean_temp_c // 256
+    packet[26] = bean_temp_c % 256
+    packet[35] = calculate_hottop_packet_checksum(packet)
+    return bytes(packet)
+
+
 def _assert_roaster_driver_contract(driver: RoasterDriver) -> None:
     """Exercise the E3 roaster driver contract against one implementation."""
     capabilities = driver.capabilities
@@ -334,6 +353,116 @@ def test_hottop_driver_capabilities_require_command_streaming() -> None:
     assert capabilities.actions.bean_drop is False
     assert capabilities.actions.cooling_control is False
     assert capabilities.actions.emergency_stop is False
+
+
+def test_build_hottop_command_packet_uses_expected_36_byte_layout() -> None:
+    packet = build_hottop_command_packet(
+        heat_level_percent=75,
+        fan_level_percent=55,
+        main_fan_level_percent=30,
+        solenoid_open=True,
+        drum_motor_on=True,
+        cooling_motor_on=False,
+    )
+
+    assert len(packet) == HOTTOP_PACKET_LENGTH
+    assert packet[:7] == bytes((0xA5, 0x96, 0xB0, 0xA0, 0x01, 0x01, 0x24))
+    assert packet[10] == 75
+    assert packet[11] == 6
+    assert packet[12] == 3
+    assert packet[16] == 1
+    assert packet[17] == 1
+    assert packet[18] == 0
+    assert validate_hottop_packet_checksum(packet) is True
+    assert packet[35] == sum(packet[:35]) & 0xFF
+
+
+def test_build_hottop_command_packet_defaults_to_safe_zero_state() -> None:
+    packet = build_hottop_command_packet()
+
+    assert len(packet) == HOTTOP_PACKET_LENGTH
+    assert packet[10] == 0
+    assert packet[11] == 0
+    assert packet[12] == 0
+    assert packet[16] == 0
+    assert packet[17] == 0
+    assert packet[18] == 0
+    assert validate_hottop_packet_checksum(packet) is True
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error_type", "match"),
+    [
+        ({"heat_level_percent": -1}, ValueError, "heat_level_percent"),
+        ({"fan_level_percent": 101}, ValueError, "fan_level_percent"),
+        ({"main_fan_level_percent": True}, TypeError, "main_fan_level_percent"),
+        ({"solenoid_open": 1}, TypeError, "solenoid_open"),
+        ({"drum_motor_on": 0}, TypeError, "drum_motor_on"),
+        ({"cooling_motor_on": "yes"}, TypeError, "cooling_motor_on"),
+    ],
+)
+def test_build_hottop_command_packet_rejects_invalid_fields(
+    kwargs: dict[str, object],
+    error_type: type[Exception],
+    match: str,
+) -> None:
+    with pytest.raises(error_type, match=match):
+        build_hottop_command_packet(**kwargs)  # pyright: ignore[reportArgumentType]
+
+
+def test_parse_hottop_status_packet_extracts_temperatures_and_preserves_raw_packet() -> None:
+    packet = _build_hottop_status_packet(env_temp_c=205, bean_temp_c=187)
+
+    status = parse_hottop_status_packet(packet)
+
+    assert status.env_temp_c == 205
+    assert status.bean_temp_c == 187
+    assert status.raw_packet == packet
+
+
+def test_find_hottop_status_packet_skips_noise_and_invalid_candidates() -> None:
+    invalid_packet = bytearray(_build_hottop_status_packet(env_temp_c=99, bean_temp_c=88))
+    invalid_packet[35] ^= 0x01
+    valid_packet = _build_hottop_status_packet(env_temp_c=205, bean_temp_c=187)
+    buffer = b"noise" + bytes(invalid_packet) + b"more-noise" + valid_packet + b"tail"
+
+    status = find_hottop_status_packet(buffer)
+
+    assert status is not None
+    assert status.env_temp_c == 205
+    assert status.bean_temp_c == 187
+    assert status.raw_packet == valid_packet
+
+
+def test_find_hottop_status_packet_returns_none_when_buffer_has_no_valid_packet() -> None:
+    invalid_packet = bytearray(_build_hottop_status_packet(env_temp_c=99, bean_temp_c=88))
+    invalid_packet[35] ^= 0x01
+
+    assert find_hottop_status_packet(b"noise" + bytes(invalid_packet)) is None
+
+
+@pytest.mark.parametrize(
+    ("packet", "match"),
+    [
+        (b"", "36 bytes"),
+        (bytes([0x00] * HOTTOP_PACKET_LENGTH), "A5 96"),
+    ],
+)
+def test_parse_hottop_status_packet_rejects_invalid_packet_shape(
+    packet: bytes,
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        parse_hottop_status_packet(packet)
+
+
+def test_parse_hottop_status_packet_rejects_invalid_checksum() -> None:
+    packet = bytearray(_build_hottop_status_packet(env_temp_c=205, bean_temp_c=187))
+    packet[35] ^= 0x01
+
+    assert validate_hottop_packet_checksum(bytes(packet)) is False
+    with pytest.raises(ValueError, match="checksum"):
+        parse_hottop_status_packet(bytes(packet))
 
 
 def test_hottop_driver_connect_requires_explicit_port() -> None:


### PR DESCRIPTION
## Summary
- Add deterministic Hottop 36-byte command packet construction with checksum bytes.
- Add checksum validation, exact status-packet parsing, and serial-buffer scanning for the first valid status packet.
- Harden review feedback by using explicit half-up fan scaling and rejecting/skipping echoed command packets during status parsing.
- Keep command-loop safe defaults unchanged so E3-S6 does not enable live Hottop control commands.
- Update durable epic and registry state to mark E3-S6 complete and point next at E3-S7.

## Validation
- `./.venv/bin/python -m pytest tests/test_drivers.py` - 81 passed
- `./.venv/bin/python -m pytest` - 145 passed
- `./.venv/bin/python -m ruff check .` - passed
- `./.venv/bin/python -m ruff format --check .` - passed
- `./.venv/bin/python -m pyright` - 0 errors

Closes #28