### PR TITLE
Docs: add E3-S6 review summary

### DIFF
--- a/docs/session-summaries/2026-05-12-e3-s6-pr85-hottop-packet-build-parse-review-cycle.md
+++ b/docs/session-summaries/2026-05-12-e3-s6-pr85-hottop-packet-build-parse-review-cycle.md
@@ -1,0 +1,103 @@
+# E3-S6 PR 85 Hottop Packet Build Parse Review Cycle
+
+## Scope
+
+This session resumed after `E3-S5` was complete and the docs-only follow-up PR `#84` had been merged. Work started from updated `main` on branch `feature/28-hottop-packet-build-parse` for issue `#28`, `E3-S6: Implement Hottop packet build/parse`.
+
+The story scope was intentionally narrow:
+
+- implement deterministic Hottop 36-byte command packet construction
+- implement checksum calculation and validation
+- implement status-packet parsing
+- keep heat, fan, drop, cooling, stop-cooling, and emergency-stop hardware command behavior out of scope for `E3-S7`
+- preserve the E3-S5 command-loop safety invariants, especially no default Hottop bytes before explicit command wiring
+- use `/Users/sertanyamaner/git/coffee-roasting/src` only as a behavioral reference, not an architecture template
+
+## Context Usage
+
+Non-PII Codex status snapshot provided after PR `#85` was accidentally merged before this summary was added:
+
+- Context window: `47% left (142K used / 258K)`
+- 5h limit: `99% left`, reset at `01:30 on 13 May`
+- Weekly limit: `97% left`, reset at `20:39 on 13 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, reset at `01:47 on 13 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, reset at `20:47 on 19 May`
+- Warning: limits may be stale; run `/status` again shortly
+
+## Implementation Summary
+
+PR `#85` added Hottop packet primitives in `src/coffee_roaster_mcp/drivers.py`:
+
+- `HottopCommandPacket`
+- `HottopStatusPacket`
+- `build_hottop_command_packet`
+- `calculate_hottop_packet_checksum`
+- `validate_hottop_packet_checksum`
+- `parse_hottop_status_packet`
+- `find_hottop_status_packet`
+- `is_hottop_command_packet`
+
+The command packet layout follows the old prototype as behavioral reference:
+
+- 36-byte packet length
+- command header bytes `A5 96 B0 A0 01 01 24`
+- heat at byte `10`
+- roast fan and main fan on the Hottop `0-10` scale at bytes `11` and `12`
+- solenoid, drum motor, and cooling motor bits at bytes `16`, `17`, and `18`
+- checksum at byte `35`, computed as the low byte of the sum of bytes `0-34`
+
+Status packet parsing validates exact length, `A5 96` prefix, command-header rejection, and checksum before extracting raw Celsius environment temperature from bytes `23-24` and raw Celsius bean temperature from bytes `25-26`. The serial-buffer scanner skips leading noise, invalid checksum candidates, and echoed command packets.
+
+## Review Cycle
+
+Two automated review comments were addressed after the initial PR opened.
+
+### Copilot Review
+
+Copilot found that `_percent_to_hottop_fan_scale()` used Python `round(value / 10.0)`. Python uses banker's rounding, so ties such as `5`, `25`, and `45` can round down to the nearest even result. This was worth fixing before hardware command wiring because fan scaling will become hardware-visible in `E3-S7`.
+
+Response:
+
+- replaced `round(value / 10.0)` with explicit half-up integer scaling: `(value + 5) // 10`
+- added boundary tests for `x5` percentage values from `5` through `95`
+
+Importance: medium. It was not yet controlling hardware because E3-S6 does not wire packet sending to real commands, but it would have become a hardware-control bug in the next story.
+
+### Codex Review
+
+Codex found that `find_hottop_status_packet()` accepted any valid `A5 96` 36-byte packet with a correct checksum. Since command packets also satisfy that shape, echoed serial writes or loopback adapters could be parsed as status telemetry and produce bogus zero temperatures from bytes `23-26`.
+
+Response:
+
+- added `is_hottop_command_packet()`
+- made exact status parsing reject command-header packets
+- made buffer scanning skip command-packet echoes and continue looking for a real status packet
+- added tests proving exact parse rejection and scanner behavior when a command packet precedes a valid status packet
+
+Importance: high. This directly protects telemetry correctness before serial read integration and prevents echoed writes from hiding the actual status packet that follows.
+
+## Validation
+
+Validation after the initial implementation:
+
+- `./.venv/bin/python -m pytest tests/test_drivers.py`: `67 passed`
+- `./.venv/bin/python -m pytest`: `131 passed`
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: `0 errors`
+- GitHub CI on the initial PR: `Checks` and `Build Package` passed
+
+Validation after the review fixes:
+
+- `./.venv/bin/python -m pytest tests/test_drivers.py`: `81 passed`
+- `./.venv/bin/python -m pytest`: `145 passed`
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: `0 errors`
+- GitHub CI after commit `0546a39`: `Checks` and `Build Package` passed
+
+## Durable State
+
+PR `#85` included `Closes #28` and was squashed and merged on `2026-05-12`. The durable state now marks `E3-S6` complete and points next at `E3-S7: Implement Hottop heat, fan, drop, cooling, stop cooling, and emergency stop`.
+
+This summary was added in a docs-only follow-up PR because PR `#85` had already been merged before the session-summary file was created.


### PR DESCRIPTION
## Summary
- Add the missing E3-S6 PR #85 session summary after the implementation PR was already merged.
- Capture the provided context usage snapshot.
- Summarize the Copilot and Codex review comments, their importance, and the fixes applied.

## Validation
- `./.venv/bin/python -m ruff check .` - passed
- `./.venv/bin/python -m ruff format --check .` - passed

Follow-up to #85.