### PR TITLE
E3-S7: Wire Hottop control commands

### DIFF
--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E3-S7`
-- Current target: Implement Hottop heat, fan, drop, cooling, stop cooling, and emergency stop
+- Active story: `E3-S8`
+- Current target: Implement Hottop temperature unit handling for `celsius`, `fahrenheit`, and `auto`
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -45,6 +45,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E3-S4` adds the first Hottop driver lifecycle slice. The driver can be constructed for `hottop_kn8828b_2k_plus`, requires an explicit serial port before connect, opens serial transport lazily through pyserial without holding the state-read lock, starts a command-loop lifecycle thread on connect, and disconnects by signalling the loop, joining it, closing serial transport, and clearing runtime references. Review hardening keeps Hottop capabilities accurate while controls are not implemented, passes configured port/baudrate/command interval into the driver, closes serial even when join times out, blocks reconnect while a prior command loop is still alive, and uses deterministic test synchronization for loop iteration tests. Packet sending and hardware commands remain later Epic 3 stories.
 - `E3-S5` keeps packet bytes and status parsing out of scope but completes the Hottop command-loop scheduler. The loop ticks at the configured cadence, can stream injectable command frames to the serial transport, records frame polls, send attempts, successful writes, last write size, and write errors in raw diagnostics, and defaults to sending no unverified hardware bytes until `E3-S6` implements the Hottop packet format.
 - `E3-S6` implements deterministic Hottop packet build/parse primitives without turning on live Hottop hardware commands. The driver module can build 36-byte command packets with checksum bytes, validate packet checksums, parse exact 36-byte status packets, and scan serial buffers for the first valid status packet with raw Celsius bean and environment temperatures. The command loop still keeps the safe no-default-frame behavior until `E3-S7` wires these packet primitives to explicit control commands.
+- `E3-S7` wires Hottop control methods to driver-owned command state and the E3-S6 packet builder. Connected Hottop loops now stream verified safe-zero packets by default and then stream the latest explicit heat, main fan, drop, cooling, stop-cooling, or emergency-stop command state. Command methods remain safe to call before connection because no serial bytes are written until the driver lifecycle is opened.
 - The old `coffee-roasting` prototype was checked as a behavioral reference for E3-S1. It confirmed the need to model Hottop command streaming, temperature-unit normalization, compound drop/cooling behavior, and cleanup through driver lifecycle methods. Drum control remains an internal driver concern for now because E3-S1 and issue #23 do not require a public drum command.
 - ONNX INT8 is the default real model backend.
 - ONNX FP32 is supported by config.
@@ -171,7 +172,7 @@ Goal: support multiple roasters behind one driver contract while preserving curr
 - [x] `E3-S6` Implement Hottop packet build/parse.
   - Done when 36-byte packet construction, status parsing, and checksum validation are unit tested.
 
-- [ ] `E3-S7` Implement Hottop heat, fan, drop, cooling, stop cooling, and emergency stop.
+- [x] `E3-S7` Implement Hottop heat, fan, drop, cooling, stop cooling, and emergency stop.
   - Done when commands preserve safe defaults and known compound drop/cooling behavior.
 
 - [ ] `E3-S8` Implement Hottop temperature unit handling.
@@ -563,6 +564,18 @@ After completing a story:
   - Checked the old `coffee-roasting` Hottop prototype as a behavioral reference for packet layout and status temperature offsets, but kept the new implementation isolated and unit-testable.
   - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 81 passed.
   - Ran `./.venv/bin/python -m pytest`: 145 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E3-S7:
+  - Replaced the Hottop driver's unsupported control stubs with driver-owned command state for heat, roast fan, main fan, solenoid, drum motor, and cooling motor.
+  - The default connected command loop now streams verified E3-S6 Hottop command packets from safe-zero state instead of sending no frame; injected frame providers remain supported for scheduler tests.
+  - Hottop heat turns on the drum when heat is nonzero, fan controls the main-fan packet byte, drop forces heat off, drum off, solenoid open, cooling on, and main fan high, stop-cooling clears cooling, solenoid, and main fan, and emergency stop forces heat off, drum off, solenoid closed, cooling on, and main fan high.
+  - Commands are safe to call before `connect()` because they only mutate driver state; serial writes happen only through the connected command loop.
+  - Added mocked-serial tests proving safe-zero packet streaming, heat/fan packet state, compound drop/cooling packet state, and emergency-stop packet state.
+  - Checked the old `coffee-roasting` Hottop prototype as a behavioral reference for compound drop/cooling behavior and command-state packet fields, but kept this implementation inside the existing driver abstraction.
+  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 84 passed.
+  - Ran `./.venv/bin/python -m pytest`: 148 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,9 +22,9 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E3-S6 is complete. The Hottop driver module now has deterministic 36-byte packet construction, checksum calculation and validation, exact status-packet parsing, and serial-buffer scanning for raw Celsius bean and environment temperatures. The command loop still does not send default Hottop bytes by itself; applying heat, fan, drop, cooling, and emergency-stop commands remains E3-S7 scope.
+E3-S7 is complete. The Hottop driver now owns conservative command state for heat, main fan, drop solenoid, drum motor, and cooling motor. When connected, the command loop streams verified 36-byte command packets from that state. Heat turns on the drum, fan updates the main-fan command, drop applies heat-off/drum-off/solenoid-open/cooling-on/main-fan-high behavior, stop-cooling clears cooling, solenoid, and main fan, and emergency stop applies heat-off/drum-off/cooling-on/main-fan-high with the solenoid closed.
 
-The next story is E3-S7: implement Hottop heat, fan, drop, cooling, stop cooling, and emergency stop.
+The next story is E3-S8: implement Hottop temperature unit handling for `celsius`, `fahrenheit`, and `auto`.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -603,13 +603,12 @@ class MockRoasterDriver:
 
 
 class HottopRoasterDriver:
-    """Hottop KN-8828B-2K+ driver lifecycle skeleton.
+    """Hottop KN-8828B-2K+ driver lifecycle and command-state owner.
 
-    This story intentionally implements only connection ownership and command
-    loop cleanup. Packet construction, status parsing, and hardware commands
-    land in later Epic 3 stories. Until packet construction lands, the default
-    command-frame provider returns no frame so the command loop is lifecycle-
-    testable without sending unverified hardware bytes.
+    The driver owns Hottop command state and streams the latest verified packet
+    whenever the serial command loop is connected. Command methods are safe to
+    call before connect; no serial bytes are written until the lifecycle is
+    explicitly opened.
     """
 
     name = HOTTOP_DRIVER_NAME
@@ -661,21 +660,27 @@ class HottopRoasterDriver:
         self._last_command_write_size = 0
         self._command_loop_error_count = 0
         self._command_loop_iteration_hook = command_loop_iteration_hook
-        self._command_frame_provider = command_frame_provider or self._no_command_frame
+        self._command_frame_provider = command_frame_provider or self._current_command_frame
+        self._heat_level_percent = 0
+        self._roast_fan_level_percent = 0
+        self._main_fan_level_percent = 0
+        self._solenoid_open = False
+        self._drum_motor_on = False
+        self._cooling_motor_on = False
 
     @property
     def capabilities(self) -> RoasterCapabilities:
-        """Return static Hottop capabilities for lifecycle validation."""
+        """Return static Hottop capabilities for command validation."""
         return RoasterCapabilities(
             driver=self.name,
             heat=ControlRange(minimum=0, maximum=100, step=1),
             fan=ControlRange(minimum=0, maximum=100, step=1),
             actions=SupportedActions(
-                heat_control=False,
-                fan_control=False,
-                bean_drop=False,
-                cooling_control=False,
-                emergency_stop=False,
+                heat_control=True,
+                fan_control=True,
+                bean_drop=True,
+                cooling_control=True,
+                emergency_stop=True,
             ),
             sensor_units=SensorUnits(
                 bean_temperature="celsius",
@@ -795,9 +800,9 @@ class HottopRoasterDriver:
                 connected=self._connected,
                 bean_temp_c=None,
                 env_temp_c=None,
-                heat_level_percent=0,
-                fan_level_percent=0,
-                cooling_on=False,
+                heat_level_percent=self._heat_level_percent,
+                fan_level_percent=self._main_fan_level_percent,
+                cooling_on=self._cooling_motor_on,
                 raw_vendor_data={
                     "port": self._port,
                     "baudrate": self._baudrate,
@@ -809,40 +814,79 @@ class HottopRoasterDriver:
                     "command_write_count": self._command_write_count,
                     "last_command_write_size": self._last_command_write_size,
                     "command_loop_error_count": self._command_loop_error_count,
+                    "roast_fan_level_percent": self._roast_fan_level_percent,
+                    "main_fan_level_percent": self._main_fan_level_percent,
+                    "solenoid_open": self._solenoid_open,
+                    "drum_motor_on": self._drum_motor_on,
+                    "cooling_motor_on": self._cooling_motor_on,
                 },
             )
 
     def set_heat(self, *, heat_level_percent: int) -> RoasterState:
-        """Reject Hottop heat control until packet commands land."""
-        validate_control_percent(heat_level_percent, label="heat_level_percent")
-        raise NotImplementedError("Hottop heat control lands in E3-S7.")
+        """Set Hottop heater command state and return normalized state."""
+        heat_level = validate_control_percent(
+            heat_level_percent,
+            label="heat_level_percent",
+        )
+        with self._state_lock:
+            self._heat_level_percent = heat_level
+            if heat_level > 0:
+                self._drum_motor_on = True
+        return self.read_state()
 
     def set_fan(self, *, fan_level_percent: int) -> RoasterState:
-        """Reject Hottop fan control until packet commands land."""
-        validate_control_percent(fan_level_percent, label="fan_level_percent")
-        raise NotImplementedError("Hottop fan control lands in E3-S7.")
+        """Set Hottop main-fan command state and return normalized state."""
+        fan_level = validate_control_percent(
+            fan_level_percent,
+            label="fan_level_percent",
+        )
+        with self._state_lock:
+            self._main_fan_level_percent = fan_level
+        return self.read_state()
 
     def drop_beans(self) -> RoasterState:
-        """Reject Hottop bean drop until packet commands land."""
-        raise NotImplementedError("Hottop bean drop lands in E3-S7.")
+        """Apply Hottop compound bean-drop command state."""
+        with self._state_lock:
+            self._heat_level_percent = 0
+            self._drum_motor_on = False
+            self._solenoid_open = True
+            self._cooling_motor_on = True
+            self._main_fan_level_percent = 100
+        return self.read_state()
 
     def start_cooling(self) -> RoasterState:
-        """Reject Hottop cooling control until packet commands land."""
-        raise NotImplementedError("Hottop cooling control lands in E3-S7.")
+        """Start Hottop cooling motor and main fan."""
+        with self._state_lock:
+            self._cooling_motor_on = True
+            self._main_fan_level_percent = 100
+        return self.read_state()
 
     def stop_cooling(self) -> RoasterState:
-        """Reject Hottop cooling control until packet commands land."""
-        raise NotImplementedError("Hottop cooling control lands in E3-S7.")
+        """Stop Hottop cooling, close drop path, and clear main fan."""
+        with self._state_lock:
+            self._cooling_motor_on = False
+            self._solenoid_open = False
+            self._main_fan_level_percent = 0
+        return self.read_state()
 
     def emergency_stop(self, *, reason: str) -> EmergencyStopResult:
-        """Return safe Hottop emergency-stop payload until packet commands land."""
+        """Apply safe Hottop emergency-stop command state."""
         _ = reason
+        with self._state_lock:
+            self._heat_level_percent = 0
+            self._drum_motor_on = False
+            self._solenoid_open = False
+            self._cooling_motor_on = True
+            self._main_fan_level_percent = 100
+            heat_level_percent = self._heat_level_percent
+            fan_level_percent = self._main_fan_level_percent
+            cooling_on = self._cooling_motor_on
         return EmergencyStopResult(
             driver=self.name,
-            safety_method="emergency_stop_not_yet_hardware_commanded",
-            heat_level_percent=0,
-            fan_level_percent=100,
-            cooling_on=True,
+            safety_method="emergency_stop",
+            heat_level_percent=heat_level_percent,
+            fan_level_percent=fan_level_percent,
+            cooling_on=cooling_on,
         )
 
     def _command_loop(self) -> None:
@@ -901,9 +945,17 @@ class HottopRoasterDriver:
                 self._command_loop_error_count += 1
                 self._last_command_write_size = 0
 
-    def _no_command_frame(self) -> bytes | None:
-        """Return no hardware frame until Hottop packet construction lands."""
-        return None
+    def _current_command_frame(self) -> bytes:
+        """Return the current Hottop command-state packet."""
+        with self._state_lock:
+            return build_hottop_command_packet(
+                heat_level_percent=self._heat_level_percent,
+                fan_level_percent=self._roast_fan_level_percent,
+                main_fan_level_percent=self._main_fan_level_percent,
+                solenoid_open=self._solenoid_open,
+                drum_motor_on=self._drum_motor_on,
+                cooling_motor_on=self._cooling_motor_on,
+            )
 
 
 def _percent_to_hottop_fan_scale(value: int) -> int:

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,6 +1,8 @@
 """Roaster driver contract, capability, and safety behavior coverage."""
 
+from collections.abc import Callable
 from threading import Event, Lock, Thread
+from time import monotonic, sleep
 from typing import cast
 
 import pytest
@@ -44,6 +46,11 @@ class FakeSerialTransport:
         with self._write_lock:
             self.writes.append(data)
         return len(data)
+
+    def writes_snapshot(self) -> list[bytes]:
+        """Return command writes recorded by the fake transport."""
+        with self._write_lock:
+            return list(self.writes)
 
 
 class FailingSerialTransport(FakeSerialTransport):
@@ -237,6 +244,22 @@ def _build_hottop_status_packet(*, env_temp_c: int, bean_temp_c: int) -> bytes:
     return bytes(packet)
 
 
+def _wait_for_hottop_write(
+    transport: FakeSerialTransport,
+    predicate: Callable[[bytes], bool],
+    *,
+    timeout: float = 1.0,
+) -> bytes:
+    """Wait for a Hottop serial write matching the expected command state."""
+    deadline = monotonic() + timeout
+    while monotonic() < deadline:
+        for write in transport.writes_snapshot():
+            if predicate(write):
+                return write
+        sleep(0.01)
+    pytest.fail("Timed out waiting for expected Hottop command write.")
+
+
 def _assert_roaster_driver_contract(driver: RoasterDriver) -> None:
     """Exercise the E3 roaster driver contract against one implementation."""
     capabilities = driver.capabilities
@@ -349,11 +372,11 @@ def test_hottop_driver_capabilities_require_command_streaming() -> None:
     assert capabilities.driver == "hottop_kn8828b_2k_plus"
     assert capabilities.command_streaming.required is True
     assert capabilities.command_streaming.interval_seconds == 0.05
-    assert capabilities.actions.heat_control is False
-    assert capabilities.actions.fan_control is False
-    assert capabilities.actions.bean_drop is False
-    assert capabilities.actions.cooling_control is False
-    assert capabilities.actions.emergency_stop is False
+    assert capabilities.actions.heat_control is True
+    assert capabilities.actions.fan_control is True
+    assert capabilities.actions.bean_drop is True
+    assert capabilities.actions.cooling_control is True
+    assert capabilities.actions.emergency_stop is True
 
 
 def test_build_hottop_command_packet_uses_expected_36_byte_layout() -> None:
@@ -615,7 +638,7 @@ def test_hottop_driver_command_loop_streams_injected_frames() -> None:
     assert streaming_state.raw_vendor_data["command_loop_error_count"] == 0
 
 
-def test_hottop_driver_command_loop_default_frame_provider_sends_no_unverified_bytes() -> None:
+def test_hottop_driver_command_loop_default_frame_provider_sends_safe_zero_packet() -> None:
     serial_factory = FakeSerialFactory()
     command_loop_iterated = Event()
     driver = HottopRoasterDriver(
@@ -630,15 +653,163 @@ def test_hottop_driver_command_loop_default_frame_provider_sends_no_unverified_b
         assert command_loop_iterated.wait(timeout=1.0)
         state = driver.read_state()
 
-        assert serial_factory.transport.writes == []
+        safe_packet = _wait_for_hottop_write(
+            serial_factory.transport,
+            lambda write: (
+                is_hottop_command_packet(write)
+                and validate_hottop_packet_checksum(write)
+                and write[10] == 0
+                and write[11] == 0
+                and write[12] == 0
+                and write[16] == 0
+                and write[17] == 0
+                and write[18] == 0
+            ),
+        )
+        assert len(safe_packet) == HOTTOP_PACKET_LENGTH
         frame_polls = state.raw_vendor_data["command_frame_poll_count"]
         send_attempts = state.raw_vendor_data["command_send_attempts"]
+        write_count = state.raw_vendor_data["command_write_count"]
         assert isinstance(frame_polls, int)
         assert isinstance(send_attempts, int)
+        assert isinstance(write_count, int)
         assert frame_polls >= 1
-        assert send_attempts == 0
-        assert state.raw_vendor_data["command_write_count"] == 0
-        assert state.raw_vendor_data["last_command_write_size"] == 0
+        assert send_attempts >= 1
+        assert write_count >= 1
+        assert state.raw_vendor_data["last_command_write_size"] == HOTTOP_PACKET_LENGTH
+    finally:
+        driver.disconnect()
+
+
+def test_hottop_driver_heat_and_fan_commands_stream_current_packet_state() -> None:
+    serial_factory = FakeSerialFactory()
+    driver = HottopRoasterDriver(
+        port="/dev/test-hottop",
+        command_interval_seconds=0.01,
+        serial_factory=serial_factory,
+    )
+    driver.connect()
+    try:
+        heat_state = driver.set_heat(heat_level_percent=70)
+        heat_packet = _wait_for_hottop_write(
+            serial_factory.transport,
+            lambda write: (
+                is_hottop_command_packet(write)
+                and validate_hottop_packet_checksum(write)
+                and write[10] == 70
+                and write[12] == 0
+                and write[17] == 1
+            ),
+        )
+
+        fan_state = driver.set_fan(fan_level_percent=35)
+        fan_packet = _wait_for_hottop_write(
+            serial_factory.transport,
+            lambda write: (
+                is_hottop_command_packet(write)
+                and validate_hottop_packet_checksum(write)
+                and write[10] == 70
+                and write[11] == 0
+                and write[12] == 4
+                and write[17] == 1
+            ),
+        )
+
+        assert heat_state.heat_level_percent == 70
+        assert heat_state.raw_vendor_data["drum_motor_on"] is True
+        assert fan_state.fan_level_percent == 35
+        assert fan_state.raw_vendor_data["main_fan_level_percent"] == 35
+        assert heat_packet[35] == sum(heat_packet[:35]) & 0xFF
+        assert fan_packet[35] == sum(fan_packet[:35]) & 0xFF
+    finally:
+        driver.disconnect()
+
+
+def test_hottop_driver_drop_and_cooling_commands_stream_safe_compound_states() -> None:
+    serial_factory = FakeSerialFactory()
+    driver = HottopRoasterDriver(
+        port="/dev/test-hottop",
+        command_interval_seconds=0.01,
+        serial_factory=serial_factory,
+    )
+    driver.connect()
+    try:
+        driver.set_heat(heat_level_percent=80)
+        drop_state = driver.drop_beans()
+        drop_packet = _wait_for_hottop_write(
+            serial_factory.transport,
+            lambda write: (
+                is_hottop_command_packet(write)
+                and validate_hottop_packet_checksum(write)
+                and write[10] == 0
+                and write[12] == 10
+                and write[16] == 1
+                and write[17] == 0
+                and write[18] == 1
+            ),
+        )
+
+        stopped_state = driver.stop_cooling()
+        stopped_packet = _wait_for_hottop_write(
+            serial_factory.transport,
+            lambda write: (
+                is_hottop_command_packet(write)
+                and validate_hottop_packet_checksum(write)
+                and write[10] == 0
+                and write[12] == 0
+                and write[16] == 0
+                and write[18] == 0
+            ),
+        )
+
+        assert drop_state.heat_level_percent == 0
+        assert drop_state.fan_level_percent == 100
+        assert drop_state.cooling_on is True
+        assert drop_state.raw_vendor_data["solenoid_open"] is True
+        assert drop_state.raw_vendor_data["drum_motor_on"] is False
+        assert stopped_state.cooling_on is False
+        assert stopped_state.fan_level_percent == 0
+        assert stopped_state.raw_vendor_data["solenoid_open"] is False
+        assert drop_packet[35] == sum(drop_packet[:35]) & 0xFF
+        assert stopped_packet[35] == sum(stopped_packet[:35]) & 0xFF
+    finally:
+        driver.disconnect()
+
+
+def test_hottop_driver_emergency_stop_streams_safe_stop_state() -> None:
+    serial_factory = FakeSerialFactory()
+    driver = HottopRoasterDriver(
+        port="/dev/test-hottop",
+        command_interval_seconds=0.01,
+        serial_factory=serial_factory,
+    )
+    driver.connect()
+    try:
+        driver.set_heat(heat_level_percent=80)
+        driver.set_fan(fan_level_percent=20)
+
+        result = driver.emergency_stop(reason="unit-test")
+        stop_packet = _wait_for_hottop_write(
+            serial_factory.transport,
+            lambda write: (
+                is_hottop_command_packet(write)
+                and validate_hottop_packet_checksum(write)
+                and write[10] == 0
+                and write[12] == 10
+                and write[16] == 0
+                and write[17] == 0
+                and write[18] == 1
+            ),
+        )
+        state = driver.read_state()
+
+        assert result.safety_method == "emergency_stop"
+        assert result.heat_level_percent == 0
+        assert result.fan_level_percent == 100
+        assert result.cooling_on is True
+        assert state.raw_vendor_data["drum_motor_on"] is False
+        assert state.raw_vendor_data["solenoid_open"] is False
+        assert stop_packet[35] == sum(stop_packet[:35]) & 0xFF
     finally:
         driver.disconnect()
 

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -248,12 +248,13 @@ def _wait_for_hottop_write(
     transport: FakeSerialTransport,
     predicate: Callable[[bytes], bool],
     *,
+    start_index: int = 0,
     timeout: float = 1.0,
 ) -> bytes:
     """Wait for a Hottop serial write matching the expected command state."""
     deadline = monotonic() + timeout
     while monotonic() < deadline:
-        for write in transport.writes_snapshot():
+        for write in transport.writes_snapshot()[start_index:]:
             if predicate(write):
                 return write
         sleep(0.01)
@@ -749,6 +750,7 @@ def test_hottop_driver_drop_and_cooling_commands_stream_safe_compound_states() -
             ),
         )
 
+        stop_cooling_start_index = len(serial_factory.transport.writes_snapshot())
         stopped_state = driver.stop_cooling()
         stopped_packet = _wait_for_hottop_write(
             serial_factory.transport,
@@ -760,6 +762,7 @@ def test_hottop_driver_drop_and_cooling_commands_stream_safe_compound_states() -
                 and write[16] == 0
                 and write[18] == 0
             ),
+            start_index=stop_cooling_start_index,
         )
 
         assert drop_state.heat_level_percent == 0


### PR DESCRIPTION
## Summary

- Wire Hottop heat, fan, drop, cooling, stop-cooling, and emergency-stop methods to driver-owned command state.
- Stream verified E3-S6 36-byte Hottop command packets from safe default state when the connected command loop is running.
- Add mocked-serial coverage for safe-zero packets, heat/fan command packets, compound drop/cooling behavior, and emergency-stop safe state.
- Update durable registry and epic state to mark E3-S7 complete and point next to E3-S8.

## Validation

- `./.venv/bin/python -m pytest tests/test_drivers.py`: 84 passed
- `./.venv/bin/python -m pytest`: 148 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: passed
- `./.venv/bin/python -m pyright`: 0 errors

Closes #29