### PR TITLE
Docs: add E3-S7 review summary

### DIFF
--- a/docs/session-summaries/2026-05-12-e3-s7-pr87-hottop-controls-review-cycle.md
+++ b/docs/session-summaries/2026-05-12-e3-s7-pr87-hottop-controls-review-cycle.md
@@ -1,0 +1,117 @@
+# E3-S7 PR 87 Hottop Controls Review Cycle
+
+## Scope
+
+This session resumed after `E3-S6` was complete and the docs-only follow-up PR `#86` had been merged. Work started from updated `main` on branch `feature/29-hottop-controls` for issue `#29`, `E3-S7: Implement Hottop heat, fan, drop, cooling, stop cooling, and emergency stop`.
+
+The story scope was intentionally narrow:
+
+- implement Hottop heat, fan, drop, cooling, stop-cooling, and emergency-stop command behavior
+- preserve the E3-S5 command-loop safety invariants
+- preserve the E3-S6 36-byte Hottop packet builder and parser behavior
+- keep the one-session store boundary and MCP semantics unchanged
+- keep mock-safe defaults and coverage workflow unchanged
+- use `/Users/sertanyamaner/git/coffee-roasting/src` only as a behavioral reference, not an architecture template
+
+## Context Usage
+
+Non-PII Codex status snapshot provided after PR `#87` was merged and before this docs-only summary PR was created:
+
+- Context window: `52% left (129K used / 258K)`
+- 5h limit: `98% left`, reset at `01:30 on 13 May`
+- Weekly limit: `97% left`, reset at `20:39 on 13 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, reset at `02:36 on 13 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, reset at `21:36 on 19 May`
+
+## Implementation Summary
+
+PR `#87` wired the Hottop driver's previously unsupported control methods to driver-owned command state in `src/coffee_roaster_mcp/drivers.py`.
+
+The driver now owns conservative command state for:
+
+- heat level
+- roast fan level
+- main fan level
+- drop solenoid
+- drum motor
+- cooling motor
+
+When connected, the Hottop command loop now streams verified E3-S6 36-byte command packets from that state. Before connection, command methods only mutate driver state and do not write serial bytes.
+
+The implemented behavior follows the old `coffee-roasting` prototype as behavioral reference:
+
+- `set_heat(...)` writes heater percentage to packet byte `10` and turns the drum motor on when heat is nonzero.
+- `set_fan(...)` updates the main-fan command, packet byte `12`, using the Hottop `0-10` packet scale.
+- `drop_beans()` applies the compound drop behavior: heat off, drum off, solenoid open, cooling on, and main fan high.
+- `start_cooling()` turns the cooling motor on and main fan high.
+- `stop_cooling()` turns cooling off, closes the solenoid/drop path, and clears main fan.
+- `emergency_stop(...)` applies a conservative safe state: heat off, drum off, solenoid closed, cooling on, and main fan high.
+
+The implementation intentionally did not add a new MCP connection surface or move command ownership into the session store. It preserved the E2/E3 boundary where the store remains the one-session owner and Hottop-specific hardware command state stays inside the driver.
+
+## Hardware Interface Confidence
+
+The hardware interface is consistent with the old prototype for E3-S7 scope, but this story is not hardware-ready by itself.
+
+Confidence is based on matching the direct command-state behavior from the prototype:
+
+- heat maps directly to packet byte `10`
+- main fan maps to packet byte `12`
+- drop combines heat off, drum off, solenoid open, cooling motor on, and main fan high
+- cooling start and stop match the prototype's cooling motor, solenoid, and main fan state changes
+
+The main caveat is that validation used mocked serial transport only. Real Hottop response still belongs to the later manual integration verification story.
+
+## Review Cycle
+
+One automated review comment was addressed after PR `#87` opened.
+
+### Copilot Review
+
+Copilot found that the `stop_cooling()` test could pass for the wrong reason. The helper `_wait_for_hottop_write(...)` searched all serial writes from the start of the test, and the expected stopped-cooling packet shape matched the initial safe-zero packet written immediately after `connect()`.
+
+This meant the test could pass even if `stop_cooling()` did not cause a new streamed packet.
+
+Response:
+
+- added a `start_index` argument to `_wait_for_hottop_write(...)`
+- recorded the current write count immediately before calling `stop_cooling()`
+- made the stopped-cooling assertion search only writes emitted after that command
+
+Importance: medium. This was a test determinism issue rather than a production driver bug, but it was worth fixing because it protected the acceptance criterion for stop-cooling command streaming.
+
+### Hardware-Scope Check
+
+During the review cycle, the hardware interface was checked against the old prototype to avoid a rabbit hole. The chosen response was to keep the implementation narrow rather than redesign the driver:
+
+- keep command state in the Hottop driver
+- stream current command packets only through the existing command loop
+- keep MCP/session semantics unchanged
+- defer real-machine confirmation to the manual Hottop validation story
+
+## Validation
+
+Validation before PR creation:
+
+- `./.venv/bin/python -m pytest tests/test_drivers.py`: `84 passed`
+- `./.venv/bin/python -m pytest`: `148 passed`
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: `0 errors`
+
+Validation after the Copilot review fix:
+
+- `./.venv/bin/python -m pytest tests/test_drivers.py`: `84 passed`
+- `./.venv/bin/python -m pytest`: `148 passed`
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: `0 errors`
+- GitHub CI on PR `#87`: `Checks` and `Build Package` passed before merge
+
+## Durable State
+
+PR `#87` included `Closes #29` and was squashed and merged on `2026-05-12`. Issue `#29` is closed.
+
+The durable state now marks `E3-S7` complete and points next at `E3-S8: Implement Hottop temperature unit handling for celsius, fahrenheit, and auto`.
+
+This summary was added in a docs-only follow-up PR because PR `#87` had already been merged before the session-summary file was created.


### PR DESCRIPTION
## Summary

- Add the missing E3-S7 PR #87 session summary after the implementation PR was merged.
- Capture context usage, hardware-interface confidence against the old prototype, Copilot review feedback, the narrow test determinism fix, validation, and durable state.

## Validation

- `./.venv/bin/python -m ruff format --check .`: passed
- `./.venv/bin/python -m ruff check .`: passed

Follow-up to #87.