### PR TITLE
E3-S8: Handle Hottop temperature units

### DIFF
--- a/docs/session-summaries/2026-05-12-e3-s8-pr89-temperature-units-review-cycle.md
+++ b/docs/session-summaries/2026-05-12-e3-s8-pr89-temperature-units-review-cycle.md
@@ -1,0 +1,147 @@
+# E3-S8 PR 89 Hottop Temperature Units Review Cycle
+
+## Scope
+
+This session resumed after `E3-S7` and the docs-only `E3-S7` summary PR were merged. Work started from updated `main` on branch `feature/30-hottop-temperature-units` for issue `#30`, `E3-S8: Implement Hottop temperature unit handling`.
+
+The story scope was intentionally narrow:
+
+- support Hottop `celsius`, `fahrenheit`, and `auto` raw temperature modes
+- ignore startup zero or implausible readings until plausible telemetry arrives
+- preserve E3-S5 command-loop safety invariants
+- preserve E3-S6 packet parsing/building behavior
+- preserve E3-S7 command-state behavior
+- keep the one-session store boundary and MCP semantics unchanged
+- use `/Users/sertanyamaner/git/coffee-roasting/src` only as behavioral reference, not an architecture template
+
+PR `#89` is still open at the time this summary was added. This summary is included before merge so the implementation and review cycle are captured in the story PR itself.
+
+## Context Usage
+
+Non-PII Codex status snapshot provided before this summary was added:
+
+- Context window: `31% left (181K used / 258K)`
+- 5h limit: `95% left`, reset at `01:30 on 13 May`
+- Weekly limit: `96% left`, reset at `20:39 on 13 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, reset at `03:33 on 13 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, reset at `22:33 on 19 May`
+
+Context usage was driven mostly by the repeated review loop rather than the initial implementation. The initial feature was compact and localized to the Hottop driver, MCP driver construction, tests, and durable state; the later review rounds required repeatedly re-reading PR comments, preserving prior fixes, updating tests, and keeping validation counts current.
+
+## Implementation Summary
+
+PR `#89` added Hottop temperature-unit handling at the driver boundary while keeping `RoasterState` normalized to Celsius.
+
+The implementation:
+
+- accepts configured Hottop raw temperature modes `celsius`, `fahrenheit`, and `auto`
+- normalizes plausible status-packet bean and environment readings to Celsius
+- treats startup zero and implausible readings as unavailable telemetry
+- records raw packet temperatures and resolved raw unit diagnostics in `raw_vendor_data`
+- threads `roaster.temperature_unit` from config into the Hottop driver through `build_server_context(...)`
+- reads available Hottop status bytes from the connected command loop without changing the MCP tool surface or session store boundary
+
+The old `coffee-roasting` prototype was used only to confirm status packet offsets and big-endian temperature extraction. The prototype treated raw Hottop status bytes as Celsius; this story extended the new driver with explicit Fahrenheit and auto handling rather than copying prototype architecture.
+
+## Review Summary
+
+PR `#89` had several automated review rounds. The reviews were valuable because they exposed edge cases around serial buffering, diagnostics consistency, validation robustness, and lock scope. None required changing the story boundary, but several materially hardened the Hottop status-read path.
+
+### Review Round 1
+
+Copilot raised two comments and Codex overlapped on one of them.
+
+Findings:
+
+- Copilot found that `_read_status_packet(...)` cleared the whole status buffer after parsing one packet, dropping any additional complete packet or partial next packet in the same read.
+- Codex independently flagged the same buffer-tail problem as a P2 issue.
+- Copilot also noted that test helper parameters named `env_temp_c` and `bean_temp_c` were misleading when Fahrenheit raw values were passed.
+
+Response:
+
+- changed status-buffer scanning to return the parsed packet plus its end offset
+- preserved the unconsumed tail across loop iterations
+- processed multiple valid packets from one read
+- added tests for burst packets and split partial-packet reads
+- renamed the status-packet test helper parameters to `raw_env_temperature` and `raw_bean_temperature`
+
+Importance: high for the buffer-tail issue because it could drop live telemetry under bursty serial reads. Medium for the helper naming issue because it reduced future test ambiguity but did not affect runtime behavior.
+
+### Review Round 2
+
+Copilot found a diagnostic consistency issue.
+
+Finding:
+
+- when an implausible packet was ignored, the driver updated raw temperature diagnostics but left `resolved_temperature_unit` from the previous plausible packet
+
+Response:
+
+- clear the resolved raw unit diagnostic when the latest raw packet is ignored
+- preserve the last plausible normalized Celsius temperatures so consumers do not regress to `None` after one bad packet
+- add a regression test for plausible Fahrenheit telemetry followed by ignored zero telemetry
+
+Importance: medium. Runtime control safety was unaffected, but diagnostics could otherwise describe two different packets at once.
+
+### Review Round 3
+
+Copilot found a validation robustness issue.
+
+Finding:
+
+- `_validate_hottop_temperature_unit(...)` used set membership on arbitrary objects, so an unhashable value could raise a raw Python `TypeError`
+- driver-side string inputs did not normalize whitespace or case even though config already normalizes tokens
+
+Response:
+
+- validate type first and raise a deterministic `TypeError` for non-string values
+- normalize string inputs with `strip().lower()`
+- return and store the normalized literal in parsed packets and driver state
+- add tests for non-string input and mixed-case/whitespace normalization
+
+Importance: medium. Config already protects normal runtime inputs, but direct driver/parser calls are public testable surfaces and should fail predictably.
+
+### Review Round 4
+
+Copilot found two concurrency and bounded-read issues in the status-read path.
+
+Findings:
+
+- `_send_command_frame(...)` called `_read_status_packet(...)` while holding `_command_write_lock`, so a serial read could delay `disconnect()`
+- `_read_status_packet(...)` read all available bytes with no cap and parsed the buffer while holding `_state_lock`
+
+Response:
+
+- release `_command_write_lock` immediately after the command write and write-counter update
+- cap each status read to four Hottop packets
+- parse complete status packets outside `_state_lock`
+- acquire `_state_lock` only to read the existing buffer/unit mode and later publish parsed updates
+- add a regression test that queued burst data is processed across bounded reads
+
+Importance: high. This reduced disconnect latency risk and bounded work per command-loop tick, which matters for hardware-safe lifecycle behavior.
+
+## Validation
+
+Initial PR validation:
+
+- `./.venv/bin/python -m pytest tests/test_drivers.py`: `90 passed`
+- `./.venv/bin/python -m pytest`: `154 passed`
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: `0 errors`
+
+Final validation after all review fixes before this summary was added:
+
+- `./.venv/bin/python -m pytest tests/test_drivers.py`: `97 passed`
+- `./.venv/bin/python -m pytest`: `161 passed`
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: `0 errors`
+
+GitHub CI on PR `#89` was still pending after the latest push when this summary was created.
+
+## Durable State
+
+PR `#89` includes `Closes #30` and remains open at the time of this summary. Issue `#30` should close automatically after merge.
+
+Durable state has been updated to mark `E3-S8` complete and point the active story to `E3-S9: Run the Hottop integration verification spike`. The durable validation notes in `docs/state/epics/coffee-roaster-mcp-v0.1.md` include the implementation and review-hardening details.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E3-S8`
-- Current target: Implement Hottop temperature unit handling for `celsius`, `fahrenheit`, and `auto`
+- Active story: `E3-S9`
+- Current target: Run the Hottop integration verification spike
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -46,6 +46,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E3-S5` keeps packet bytes and status parsing out of scope but completes the Hottop command-loop scheduler. The loop ticks at the configured cadence, can stream injectable command frames to the serial transport, records frame polls, send attempts, successful writes, last write size, and write errors in raw diagnostics, and defaults to sending no unverified hardware bytes until `E3-S6` implements the Hottop packet format.
 - `E3-S6` implements deterministic Hottop packet build/parse primitives without turning on live Hottop hardware commands. The driver module can build 36-byte command packets with checksum bytes, validate packet checksums, parse exact 36-byte status packets, and scan serial buffers for the first valid status packet with raw Celsius bean and environment temperatures. The command loop still keeps the safe no-default-frame behavior until `E3-S7` wires these packet primitives to explicit control commands.
 - `E3-S7` wires Hottop control methods to driver-owned command state and the E3-S6 packet builder. Connected Hottop loops now stream verified safe-zero packets by default and then stream the latest explicit heat, main fan, drop, cooling, stop-cooling, or emergency-stop command state. Command methods remain safe to call before connection because no serial bytes are written until the driver lifecycle is opened.
+- `E3-S8` adds Hottop temperature unit handling at the driver boundary. Configured `celsius`, `fahrenheit`, and `auto` raw status-packet modes now normalize plausible bean and environment readings to Celsius before `RoasterState` exposure, and startup zero or implausible packet values are ignored until plausible telemetry arrives.
 - The old `coffee-roasting` prototype was checked as a behavioral reference for E3-S1. It confirmed the need to model Hottop command streaming, temperature-unit normalization, compound drop/cooling behavior, and cleanup through driver lifecycle methods. Drum control remains an internal driver concern for now because E3-S1 and issue #23 do not require a public drum command.
 - ONNX INT8 is the default real model backend.
 - ONNX FP32 is supported by config.
@@ -175,7 +176,7 @@ Goal: support multiple roasters behind one driver contract while preserving curr
 - [x] `E3-S7` Implement Hottop heat, fan, drop, cooling, stop cooling, and emergency stop.
   - Done when commands preserve safe defaults and known compound drop/cooling behavior.
 
-- [ ] `E3-S8` Implement Hottop temperature unit handling.
+- [x] `E3-S8` Implement Hottop temperature unit handling.
   - Done when `celsius`, `fahrenheit`, and `auto` modes are supported and tested with plausible readings.
 
 - [ ] `E3-S9` Run Hottop integration verification spike.
@@ -578,4 +579,16 @@ After completing a story:
   - Ran `./.venv/bin/python -m pytest`: 148 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E3-S8:
+  - Added Hottop status-packet temperature normalization for configured `celsius`, `fahrenheit`, and `auto` modes while keeping `RoasterState` temperatures Celsius-only at the driver boundary.
+  - The Hottop command loop now reads available serial status bytes after command writes, records raw temperature diagnostics, and updates latest normalized temperatures only after plausible packet values arrive.
+  - Startup zero and implausible readings are ignored by returning `None` temperatures and incrementing diagnostics instead of publishing misleading normalized telemetry.
+  - `auto` mode prefers plausible Celsius readings to preserve the old prototype's direct-Celsius behavior, then falls back to Fahrenheit conversion when Celsius values are implausible.
+  - Threaded configured `roaster.temperature_unit` from MCP server context into the Hottop driver factory without changing one-session store or MCP tool semantics.
+  - Checked the old `coffee-roasting` Hottop prototype as a behavioral reference for status packet offsets and big-endian temperature extraction, but kept this implementation in the new driver boundary.
+  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 90 passed.
+  - Ran `./.venv/bin/python -m pytest`: 154 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed after applying `ruff format`.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -587,9 +587,9 @@ After completing a story:
   - `auto` mode prefers plausible Celsius readings to preserve the old prototype's direct-Celsius behavior, then falls back to Fahrenheit conversion when Celsius values are implausible.
   - Threaded configured `roaster.temperature_unit` from MCP server context into the Hottop driver factory without changing one-session store or MCP tool semantics.
   - Checked the old `coffee-roasting` Hottop prototype as a behavioral reference for status packet offsets and big-endian temperature extraction, but kept this implementation in the new driver boundary.
-  - Review hardening preserved unread status-buffer bytes across burst and partial serial reads, processed multiple valid status packets from one read, renamed status-packet test helper fields from Celsius-specific names to raw-temperature names, and clears the resolved raw unit diagnostic when the latest raw packet is ignored as implausible.
-  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 93 passed.
-  - Ran `./.venv/bin/python -m pytest`: 157 passed.
+  - Review hardening preserved unread status-buffer bytes across burst and partial serial reads, processed multiple valid status packets from one read, renamed status-packet test helper fields from Celsius-specific names to raw-temperature names, clears the resolved raw unit diagnostic when the latest raw packet is ignored as implausible, and makes Hottop temperature-unit validation deterministic for non-string and mixed-case inputs.
+  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 96 passed.
+  - Ran `./.venv/bin/python -m pytest`: 160 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed after applying `ruff format`.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -587,9 +587,9 @@ After completing a story:
   - `auto` mode prefers plausible Celsius readings to preserve the old prototype's direct-Celsius behavior, then falls back to Fahrenheit conversion when Celsius values are implausible.
   - Threaded configured `roaster.temperature_unit` from MCP server context into the Hottop driver factory without changing one-session store or MCP tool semantics.
   - Checked the old `coffee-roasting` Hottop prototype as a behavioral reference for status packet offsets and big-endian temperature extraction, but kept this implementation in the new driver boundary.
-  - Review hardening preserved unread status-buffer bytes across burst and partial serial reads, processed multiple valid status packets from one read, and renamed status-packet test helper fields from Celsius-specific names to raw-temperature names.
-  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 92 passed.
-  - Ran `./.venv/bin/python -m pytest`: 156 passed.
+  - Review hardening preserved unread status-buffer bytes across burst and partial serial reads, processed multiple valid status packets from one read, renamed status-packet test helper fields from Celsius-specific names to raw-temperature names, and clears the resolved raw unit diagnostic when the latest raw packet is ignored as implausible.
+  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 93 passed.
+  - Ran `./.venv/bin/python -m pytest`: 157 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed after applying `ruff format`.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -587,9 +587,9 @@ After completing a story:
   - `auto` mode prefers plausible Celsius readings to preserve the old prototype's direct-Celsius behavior, then falls back to Fahrenheit conversion when Celsius values are implausible.
   - Threaded configured `roaster.temperature_unit` from MCP server context into the Hottop driver factory without changing one-session store or MCP tool semantics.
   - Checked the old `coffee-roasting` Hottop prototype as a behavioral reference for status packet offsets and big-endian temperature extraction, but kept this implementation in the new driver boundary.
-  - Review hardening preserved unread status-buffer bytes across burst and partial serial reads, processed multiple valid status packets from one read, renamed status-packet test helper fields from Celsius-specific names to raw-temperature names, clears the resolved raw unit diagnostic when the latest raw packet is ignored as implausible, and makes Hottop temperature-unit validation deterministic for non-string and mixed-case inputs.
-  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 96 passed.
-  - Ran `./.venv/bin/python -m pytest`: 160 passed.
+  - Review hardening preserved unread status-buffer bytes across burst and partial serial reads, processed multiple valid status packets from one read, renamed status-packet test helper fields from Celsius-specific names to raw-temperature names, clears the resolved raw unit diagnostic when the latest raw packet is ignored as implausible, makes Hottop temperature-unit validation deterministic for non-string and mixed-case inputs, releases the command write lock before status reads, caps per-loop status reads, and parses status buffers outside the state lock before publishing results.
+  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 97 passed.
+  - Ran `./.venv/bin/python -m pytest`: 161 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed after applying `ruff format`.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -587,8 +587,9 @@ After completing a story:
   - `auto` mode prefers plausible Celsius readings to preserve the old prototype's direct-Celsius behavior, then falls back to Fahrenheit conversion when Celsius values are implausible.
   - Threaded configured `roaster.temperature_unit` from MCP server context into the Hottop driver factory without changing one-session store or MCP tool semantics.
   - Checked the old `coffee-roasting` Hottop prototype as a behavioral reference for status packet offsets and big-endian temperature extraction, but kept this implementation in the new driver boundary.
-  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 90 passed.
-  - Ran `./.venv/bin/python -m pytest`: 154 passed.
+  - Review hardening preserved unread status-buffer bytes across burst and partial serial reads, processed multiple valid status packets from one read, and renamed status-packet test helper fields from Celsius-specific names to raw-temperature names.
+  - Ran `./.venv/bin/python -m pytest tests/test_drivers.py`: 92 passed.
+  - Ran `./.venv/bin/python -m pytest`: 156 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed after applying `ruff format`.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,9 +22,9 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-E3-S7 is complete. The Hottop driver now owns conservative command state for heat, main fan, drop solenoid, drum motor, and cooling motor. When connected, the command loop streams verified 36-byte command packets from that state. Heat turns on the drum, fan updates the main-fan command, drop applies heat-off/drum-off/solenoid-open/cooling-on/main-fan-high behavior, stop-cooling clears cooling, solenoid, and main fan, and emergency stop applies heat-off/drum-off/cooling-on/main-fan-high with the solenoid closed.
+E3-S8 is complete. The Hottop driver now accepts configured `celsius`, `fahrenheit`, and `auto` raw temperature modes, normalizes plausible status-packet readings to Celsius before exposing `RoasterState`, and ignores startup zero or otherwise implausible telemetry until a plausible packet arrives. When connected, the command loop can consume available serial status bytes while preserving E3-S7 command-state safety behavior.
 
-The next story is E3-S8: implement Hottop temperature unit handling for `celsius`, `fahrenheit`, and `auto`.
+The next story is E3-S9: run the Hottop integration verification spike.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -416,7 +416,7 @@ def parse_hottop_status_packet(
 ) -> HottopStatusPacket:
     """Parse and validate one exact Hottop 36-byte status packet."""
     _validate_hottop_packet(packet)
-    _validate_hottop_temperature_unit(temperature_unit)
+    normalized_temperature_unit = _validate_hottop_temperature_unit(temperature_unit)
     raw_env_temperature = _read_big_endian_uint16(
         packet,
         high_index=_HOTTOP_STATUS_ENV_TEMP_HIGH_INDEX,
@@ -430,14 +430,14 @@ def parse_hottop_status_packet(
     bean_temp_c, env_temp_c, resolved_unit = _normalize_hottop_temperatures(
         raw_bean_temperature=raw_bean_temperature,
         raw_env_temperature=raw_env_temperature,
-        temperature_unit=temperature_unit,
+        temperature_unit=normalized_temperature_unit,
     )
     return HottopStatusPacket(
         bean_temp_c=bean_temp_c,
         env_temp_c=env_temp_c,
         raw_bean_temperature=raw_bean_temperature,
         raw_env_temperature=raw_env_temperature,
-        temperature_unit=temperature_unit,
+        temperature_unit=normalized_temperature_unit,
         resolved_temperature_unit=resolved_unit,
         raw_packet=bytes(packet),
     )
@@ -464,7 +464,7 @@ def _find_hottop_status_packet_in_buffer(
     temperature_unit: HottopTemperatureUnit,
 ) -> tuple[HottopStatusPacket, int] | None:
     """Return the first valid Hottop packet plus its exclusive end offset."""
-    _validate_hottop_temperature_unit(temperature_unit)
+    normalized_temperature_unit = _validate_hottop_temperature_unit(temperature_unit)
     search_limit = len(buffer) - HOTTOP_PACKET_LENGTH + 1
     for offset in range(max(0, search_limit)):
         if not buffer.startswith(HOTTOP_PACKET_PREFIX, offset):
@@ -473,7 +473,10 @@ def _find_hottop_status_packet_in_buffer(
         if is_hottop_command_packet(candidate):
             continue
         if validate_hottop_packet_checksum(candidate):
-            status = parse_hottop_status_packet(candidate, temperature_unit=temperature_unit)
+            status = parse_hottop_status_packet(
+                candidate,
+                temperature_unit=normalized_temperature_unit,
+            )
             return status, offset + HOTTOP_PACKET_LENGTH
     return None
 
@@ -688,10 +691,10 @@ class HottopRoasterDriver:
             raise ValueError("command_interval_seconds must be greater than 0.")
         if join_timeout_seconds <= 0:
             raise ValueError("join_timeout_seconds must be greater than 0.")
-        _validate_hottop_temperature_unit(temperature_unit)
+        normalized_temperature_unit = _validate_hottop_temperature_unit(temperature_unit)
         self._port = port
         self._baudrate = baudrate
-        self._temperature_unit: HottopTemperatureUnit = temperature_unit
+        self._temperature_unit: HottopTemperatureUnit = normalized_temperature_unit
         self._command_interval_seconds = command_interval_seconds
         self._serial_factory = serial_factory or _create_pyserial_transport
         self._join_timeout_seconds = join_timeout_seconds
@@ -1138,10 +1141,14 @@ def _normalize_hottop_temperature(
     return round(temperature_c, 1)
 
 
-def _validate_hottop_temperature_unit(value: object) -> None:
+def _validate_hottop_temperature_unit(value: object) -> HottopTemperatureUnit:
     """Validate a configured Hottop temperature unit mode."""
-    if value not in {"celsius", "fahrenheit", "auto"}:
+    if not isinstance(value, str):
+        raise TypeError("temperature_unit must be a string.")
+    normalized = value.strip().lower()
+    if normalized not in {"celsius", "fahrenheit", "auto"}:
         raise ValueError("temperature_unit must be one of: celsius, fahrenheit, auto.")
+    return cast(HottopTemperatureUnit, normalized)
 
 
 def _validate_hottop_packet(packet: bytes) -> None:

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -13,6 +13,8 @@ from coffee_roaster_mcp.controls import validate_control_percent
 from coffee_roaster_mcp.session import EventPayloadValue
 
 ReportedTemperatureUnit = Literal["celsius", "unknown"]
+HottopTemperatureUnit = Literal["celsius", "fahrenheit", "auto"]
+ResolvedHottopTemperatureUnit = Literal["celsius", "fahrenheit"]
 HOTTOP_DRIVER_NAME = "hottop_kn8828b_2k_plus"
 
 
@@ -294,6 +296,8 @@ _HOTTOP_STATUS_ENV_TEMP_LOW_INDEX = 24
 _HOTTOP_STATUS_BEAN_TEMP_HIGH_INDEX = 25
 _HOTTOP_STATUS_BEAN_TEMP_LOW_INDEX = 26
 _HOTTOP_CHECKSUM_INDEX = HOTTOP_PACKET_LENGTH - 1
+_HOTTOP_MIN_PLAUSIBLE_TEMP_C = 1.0
+_HOTTOP_MAX_PLAUSIBLE_TEMP_C = 320.0
 
 
 @dataclass(frozen=True)
@@ -367,13 +371,21 @@ class HottopStatusPacket:
     """Parsed Hottop 36-byte status packet.
 
     Attributes:
-        bean_temp_c: Raw bean temperature reported by the roaster in Celsius.
-        env_temp_c: Raw environment temperature reported by the roaster in Celsius.
+        bean_temp_c: Normalized plausible bean temperature in Celsius.
+        env_temp_c: Normalized plausible environment temperature in Celsius.
+        raw_bean_temperature: Raw bean temperature value from the packet.
+        raw_env_temperature: Raw environment temperature value from the packet.
+        temperature_unit: Configured Hottop raw temperature mode.
+        resolved_temperature_unit: Raw unit selected for this packet, when plausible.
         raw_packet: Original validated 36-byte status packet.
     """
 
-    bean_temp_c: int
-    env_temp_c: int
+    bean_temp_c: float | None
+    env_temp_c: float | None
+    raw_bean_temperature: int
+    raw_env_temperature: int
+    temperature_unit: HottopTemperatureUnit
+    resolved_temperature_unit: ResolvedHottopTemperatureUnit | None
     raw_packet: bytes
 
 
@@ -397,28 +409,47 @@ def build_hottop_command_packet(
     ).to_bytes()
 
 
-def parse_hottop_status_packet(packet: bytes) -> HottopStatusPacket:
+def parse_hottop_status_packet(
+    packet: bytes,
+    *,
+    temperature_unit: HottopTemperatureUnit = "celsius",
+) -> HottopStatusPacket:
     """Parse and validate one exact Hottop 36-byte status packet."""
     _validate_hottop_packet(packet)
-    env_temp_c = _read_big_endian_uint16(
+    _validate_hottop_temperature_unit(temperature_unit)
+    raw_env_temperature = _read_big_endian_uint16(
         packet,
         high_index=_HOTTOP_STATUS_ENV_TEMP_HIGH_INDEX,
         low_index=_HOTTOP_STATUS_ENV_TEMP_LOW_INDEX,
     )
-    bean_temp_c = _read_big_endian_uint16(
+    raw_bean_temperature = _read_big_endian_uint16(
         packet,
         high_index=_HOTTOP_STATUS_BEAN_TEMP_HIGH_INDEX,
         low_index=_HOTTOP_STATUS_BEAN_TEMP_LOW_INDEX,
     )
+    bean_temp_c, env_temp_c, resolved_unit = _normalize_hottop_temperatures(
+        raw_bean_temperature=raw_bean_temperature,
+        raw_env_temperature=raw_env_temperature,
+        temperature_unit=temperature_unit,
+    )
     return HottopStatusPacket(
         bean_temp_c=bean_temp_c,
         env_temp_c=env_temp_c,
+        raw_bean_temperature=raw_bean_temperature,
+        raw_env_temperature=raw_env_temperature,
+        temperature_unit=temperature_unit,
+        resolved_temperature_unit=resolved_unit,
         raw_packet=bytes(packet),
     )
 
 
-def find_hottop_status_packet(buffer: bytes) -> HottopStatusPacket | None:
+def find_hottop_status_packet(
+    buffer: bytes,
+    *,
+    temperature_unit: HottopTemperatureUnit = "celsius",
+) -> HottopStatusPacket | None:
     """Return the first valid Hottop status packet found in serial bytes."""
+    _validate_hottop_temperature_unit(temperature_unit)
     search_limit = len(buffer) - HOTTOP_PACKET_LENGTH + 1
     for offset in range(max(0, search_limit)):
         if not buffer.startswith(HOTTOP_PACKET_PREFIX, offset):
@@ -427,7 +458,10 @@ def find_hottop_status_packet(buffer: bytes) -> HottopStatusPacket | None:
         if is_hottop_command_packet(candidate):
             continue
         if validate_hottop_packet_checksum(candidate):
-            return parse_hottop_status_packet(candidate)
+            return parse_hottop_status_packet(
+                candidate,
+                temperature_unit=temperature_unit,
+            )
     return None
 
 
@@ -618,6 +652,7 @@ class HottopRoasterDriver:
         *,
         port: str | None = None,
         baudrate: int = 115_200,
+        temperature_unit: HottopTemperatureUnit = "celsius",
         command_interval_seconds: float = 0.3,
         serial_factory: SerialTransportFactory | None = None,
         join_timeout_seconds: float = 1.0,
@@ -629,6 +664,7 @@ class HottopRoasterDriver:
         Args:
             port: Serial port path for the Hottop controller.
             baudrate: Serial baudrate.
+            temperature_unit: Raw Hottop temperature unit mode.
             command_interval_seconds: Command-loop cadence.
             serial_factory: Optional injectable serial transport factory for tests.
             join_timeout_seconds: Maximum disconnect wait for command-loop cleanup.
@@ -639,8 +675,10 @@ class HottopRoasterDriver:
             raise ValueError("command_interval_seconds must be greater than 0.")
         if join_timeout_seconds <= 0:
             raise ValueError("join_timeout_seconds must be greater than 0.")
+        _validate_hottop_temperature_unit(temperature_unit)
         self._port = port
         self._baudrate = baudrate
+        self._temperature_unit: HottopTemperatureUnit = temperature_unit
         self._command_interval_seconds = command_interval_seconds
         self._serial_factory = serial_factory or _create_pyserial_transport
         self._join_timeout_seconds = join_timeout_seconds
@@ -667,6 +705,15 @@ class HottopRoasterDriver:
         self._solenoid_open = False
         self._drum_motor_on = False
         self._cooling_motor_on = False
+        self._latest_bean_temp_c: float | None = None
+        self._latest_env_temp_c: float | None = None
+        self._latest_raw_bean_temperature: int | None = None
+        self._latest_raw_env_temperature: int | None = None
+        self._latest_resolved_temperature_unit: ResolvedHottopTemperatureUnit | None = None
+        self._status_packet_count = 0
+        self._ignored_temperature_packet_count = 0
+        self._status_read_error_count = 0
+        self._status_buffer = b""
 
     @property
     def capabilities(self) -> RoasterCapabilities:
@@ -798,14 +845,21 @@ class HottopRoasterDriver:
             return RoasterState(
                 driver=self.name,
                 connected=self._connected,
-                bean_temp_c=None,
-                env_temp_c=None,
+                bean_temp_c=self._latest_bean_temp_c,
+                env_temp_c=self._latest_env_temp_c,
                 heat_level_percent=self._heat_level_percent,
                 fan_level_percent=self._main_fan_level_percent,
                 cooling_on=self._cooling_motor_on,
                 raw_vendor_data={
                     "port": self._port,
                     "baudrate": self._baudrate,
+                    "temperature_unit": self._temperature_unit,
+                    "resolved_temperature_unit": self._latest_resolved_temperature_unit,
+                    "raw_bean_temperature": self._latest_raw_bean_temperature,
+                    "raw_env_temperature": self._latest_raw_env_temperature,
+                    "status_packet_count": self._status_packet_count,
+                    "ignored_temperature_packet_count": self._ignored_temperature_packet_count,
+                    "status_read_error_count": self._status_read_error_count,
                     "command_interval_seconds": self._command_interval_seconds,
                     "command_loop_running": command_loop_running,
                     "command_loop_iterations": self._command_loop_iterations,
@@ -940,10 +994,45 @@ class HottopRoasterDriver:
                         self._command_write_count += 1
                     else:
                         self._command_loop_error_count += 1
+                self._read_status_packet(serial_transport)
         except Exception:
             with self._state_lock:
                 self._command_loop_error_count += 1
                 self._last_command_write_size = 0
+
+    def _read_status_packet(self, serial_transport: SerialTransport) -> None:
+        """Read available Hottop status bytes and update normalized temperatures."""
+        try:
+            waiting = getattr(serial_transport, "in_waiting", 0)
+            if not isinstance(waiting, int) or waiting <= 0:
+                return
+            read = getattr(serial_transport, "read", None)
+            if not callable(read):
+                return
+            chunk = read(waiting)
+            if not isinstance(chunk, bytes) or len(chunk) == 0:
+                return
+            with self._state_lock:
+                self._status_buffer = (self._status_buffer + chunk)[-HOTTOP_PACKET_LENGTH * 2 :]
+                status = find_hottop_status_packet(
+                    self._status_buffer,
+                    temperature_unit=self._temperature_unit,
+                )
+                if status is None:
+                    return
+                self._status_buffer = b""
+                self._status_packet_count += 1
+                self._latest_raw_bean_temperature = status.raw_bean_temperature
+                self._latest_raw_env_temperature = status.raw_env_temperature
+                if status.bean_temp_c is None or status.env_temp_c is None:
+                    self._ignored_temperature_packet_count += 1
+                    return
+                self._latest_bean_temp_c = status.bean_temp_c
+                self._latest_env_temp_c = status.env_temp_c
+                self._latest_resolved_temperature_unit = status.resolved_temperature_unit
+        except Exception:
+            with self._state_lock:
+                self._status_read_error_count += 1
 
     def _current_command_frame(self) -> bytes:
         """Return the current Hottop command-state packet."""
@@ -961,6 +1050,81 @@ class HottopRoasterDriver:
 def _percent_to_hottop_fan_scale(value: int) -> int:
     """Map normalized fan percentage to the Hottop 0-10 byte scale."""
     return (value + 5) // 10
+
+
+def _normalize_hottop_temperatures(
+    *,
+    raw_bean_temperature: int,
+    raw_env_temperature: int,
+    temperature_unit: HottopTemperatureUnit,
+) -> tuple[float | None, float | None, ResolvedHottopTemperatureUnit | None]:
+    """Normalize raw Hottop temperature readings to plausible Celsius values."""
+    if temperature_unit == "celsius":
+        return _normalize_explicit_hottop_temperatures(
+            raw_bean_temperature=raw_bean_temperature,
+            raw_env_temperature=raw_env_temperature,
+            resolved_unit="celsius",
+        )
+    if temperature_unit == "fahrenheit":
+        return _normalize_explicit_hottop_temperatures(
+            raw_bean_temperature=raw_bean_temperature,
+            raw_env_temperature=raw_env_temperature,
+            resolved_unit="fahrenheit",
+        )
+
+    celsius_values = _normalize_explicit_hottop_temperatures(
+        raw_bean_temperature=raw_bean_temperature,
+        raw_env_temperature=raw_env_temperature,
+        resolved_unit="celsius",
+    )
+    if celsius_values[2] is not None:
+        return celsius_values
+    return _normalize_explicit_hottop_temperatures(
+        raw_bean_temperature=raw_bean_temperature,
+        raw_env_temperature=raw_env_temperature,
+        resolved_unit="fahrenheit",
+    )
+
+
+def _normalize_explicit_hottop_temperatures(
+    *,
+    raw_bean_temperature: int,
+    raw_env_temperature: int,
+    resolved_unit: ResolvedHottopTemperatureUnit,
+) -> tuple[float | None, float | None, ResolvedHottopTemperatureUnit | None]:
+    """Normalize one explicit Hottop raw unit mode."""
+    bean_temp_c = _normalize_hottop_temperature(
+        raw_bean_temperature,
+        resolved_unit=resolved_unit,
+    )
+    env_temp_c = _normalize_hottop_temperature(
+        raw_env_temperature,
+        resolved_unit=resolved_unit,
+    )
+    if bean_temp_c is None or env_temp_c is None:
+        return None, None, None
+    return bean_temp_c, env_temp_c, resolved_unit
+
+
+def _normalize_hottop_temperature(
+    raw_temperature: int,
+    *,
+    resolved_unit: ResolvedHottopTemperatureUnit,
+) -> float | None:
+    """Normalize one raw Hottop temperature reading to plausible Celsius."""
+    if resolved_unit == "fahrenheit":
+        temperature_c = (raw_temperature - 32.0) * 5.0 / 9.0
+    else:
+        temperature_c = float(raw_temperature)
+    if not (_HOTTOP_MIN_PLAUSIBLE_TEMP_C <= temperature_c <= _HOTTOP_MAX_PLAUSIBLE_TEMP_C):
+        return None
+    return round(temperature_c, 1)
+
+
+def _validate_hottop_temperature_unit(value: object) -> None:
+    """Validate a configured Hottop temperature unit mode."""
+    if value not in {"celsius", "fahrenheit", "auto"}:
+        raise ValueError("temperature_unit must be one of: celsius, fahrenheit, auto.")
 
 
 def _validate_hottop_packet(packet: bytes) -> None:
@@ -1042,6 +1206,7 @@ def create_roaster_driver(
     *,
     port: str | None = None,
     baudrate: int = 115_200,
+    temperature_unit: HottopTemperatureUnit = "celsius",
     command_interval_seconds: float = 0.3,
 ) -> RoasterDriver:
     """Create the configured roaster driver.
@@ -1050,6 +1215,7 @@ def create_roaster_driver(
         driver_name: Roaster driver name from configuration.
         port: Optional roaster serial port.
         baudrate: Configured roaster baudrate.
+        temperature_unit: Configured roaster temperature unit.
         command_interval_seconds: Configured command interval.
 
     Returns:
@@ -1064,6 +1230,7 @@ def create_roaster_driver(
         return HottopRoasterDriver(
             port=port,
             baudrate=baudrate,
+            temperature_unit=temperature_unit,
             command_interval_seconds=command_interval_seconds,
         )
     raise ValueError(

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -298,6 +298,7 @@ _HOTTOP_STATUS_BEAN_TEMP_LOW_INDEX = 26
 _HOTTOP_CHECKSUM_INDEX = HOTTOP_PACKET_LENGTH - 1
 _HOTTOP_MIN_PLAUSIBLE_TEMP_C = 1.0
 _HOTTOP_MAX_PLAUSIBLE_TEMP_C = 320.0
+_HOTTOP_STATUS_READ_MAX_BYTES = HOTTOP_PACKET_LENGTH * 4
 
 
 @dataclass(frozen=True)
@@ -479,6 +480,26 @@ def _find_hottop_status_packet_in_buffer(
             )
             return status, offset + HOTTOP_PACKET_LENGTH
     return None
+
+
+def _parse_hottop_status_buffer(
+    buffer: bytes,
+    *,
+    temperature_unit: HottopTemperatureUnit,
+) -> tuple[list[HottopStatusPacket], bytes]:
+    """Parse all complete Hottop status packets and return the unconsumed tail."""
+    statuses: list[HottopStatusPacket] = []
+    remaining = buffer
+    while True:
+        result = _find_hottop_status_packet_in_buffer(
+            remaining,
+            temperature_unit=temperature_unit,
+        )
+        if result is None:
+            return statuses, remaining[-(HOTTOP_PACKET_LENGTH - 1) :]
+        status, end_offset = result
+        statuses.append(status)
+        remaining = remaining[end_offset:]
 
 
 def calculate_hottop_packet_checksum(packet: bytes | bytearray) -> int:
@@ -1010,7 +1031,7 @@ class HottopRoasterDriver:
                         self._command_write_count += 1
                     else:
                         self._command_loop_error_count += 1
-                self._read_status_packet(serial_transport)
+            self._read_status_packet(serial_transport)
         except Exception:
             with self._state_lock:
                 self._command_loop_error_count += 1
@@ -1025,21 +1046,19 @@ class HottopRoasterDriver:
             read = getattr(serial_transport, "read", None)
             if not callable(read):
                 return
-            chunk = read(waiting)
+            chunk = read(min(waiting, _HOTTOP_STATUS_READ_MAX_BYTES))
             if not isinstance(chunk, bytes) or len(chunk) == 0:
                 return
             with self._state_lock:
-                self._status_buffer += chunk
-                while True:
-                    result = _find_hottop_status_packet_in_buffer(
-                        self._status_buffer,
-                        temperature_unit=self._temperature_unit,
-                    )
-                    if result is None:
-                        self._status_buffer = self._status_buffer[-(HOTTOP_PACKET_LENGTH - 1) :]
-                        return
-                    status, end_offset = result
-                    self._status_buffer = self._status_buffer[end_offset:]
+                status_buffer = self._status_buffer + chunk
+                temperature_unit = self._temperature_unit
+            statuses, remaining_buffer = _parse_hottop_status_buffer(
+                status_buffer,
+                temperature_unit=temperature_unit,
+            )
+            with self._state_lock:
+                self._status_buffer = remaining_buffer
+                for status in statuses:
                     self._status_packet_count += 1
                     self._latest_raw_bean_temperature = status.raw_bean_temperature
                     self._latest_raw_env_temperature = status.raw_env_temperature

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -449,6 +449,21 @@ def find_hottop_status_packet(
     temperature_unit: HottopTemperatureUnit = "celsius",
 ) -> HottopStatusPacket | None:
     """Return the first valid Hottop status packet found in serial bytes."""
+    result = _find_hottop_status_packet_in_buffer(
+        buffer,
+        temperature_unit=temperature_unit,
+    )
+    if result is None:
+        return None
+    return result[0]
+
+
+def _find_hottop_status_packet_in_buffer(
+    buffer: bytes,
+    *,
+    temperature_unit: HottopTemperatureUnit,
+) -> tuple[HottopStatusPacket, int] | None:
+    """Return the first valid Hottop packet plus its exclusive end offset."""
     _validate_hottop_temperature_unit(temperature_unit)
     search_limit = len(buffer) - HOTTOP_PACKET_LENGTH + 1
     for offset in range(max(0, search_limit)):
@@ -458,10 +473,8 @@ def find_hottop_status_packet(
         if is_hottop_command_packet(candidate):
             continue
         if validate_hottop_packet_checksum(candidate):
-            return parse_hottop_status_packet(
-                candidate,
-                temperature_unit=temperature_unit,
-            )
+            status = parse_hottop_status_packet(candidate, temperature_unit=temperature_unit)
+            return status, offset + HOTTOP_PACKET_LENGTH
     return None
 
 
@@ -1013,23 +1026,26 @@ class HottopRoasterDriver:
             if not isinstance(chunk, bytes) or len(chunk) == 0:
                 return
             with self._state_lock:
-                self._status_buffer = (self._status_buffer + chunk)[-HOTTOP_PACKET_LENGTH * 2 :]
-                status = find_hottop_status_packet(
-                    self._status_buffer,
-                    temperature_unit=self._temperature_unit,
-                )
-                if status is None:
-                    return
-                self._status_buffer = b""
-                self._status_packet_count += 1
-                self._latest_raw_bean_temperature = status.raw_bean_temperature
-                self._latest_raw_env_temperature = status.raw_env_temperature
-                if status.bean_temp_c is None or status.env_temp_c is None:
-                    self._ignored_temperature_packet_count += 1
-                    return
-                self._latest_bean_temp_c = status.bean_temp_c
-                self._latest_env_temp_c = status.env_temp_c
-                self._latest_resolved_temperature_unit = status.resolved_temperature_unit
+                self._status_buffer += chunk
+                while True:
+                    result = _find_hottop_status_packet_in_buffer(
+                        self._status_buffer,
+                        temperature_unit=self._temperature_unit,
+                    )
+                    if result is None:
+                        self._status_buffer = self._status_buffer[-(HOTTOP_PACKET_LENGTH - 1) :]
+                        return
+                    status, end_offset = result
+                    self._status_buffer = self._status_buffer[end_offset:]
+                    self._status_packet_count += 1
+                    self._latest_raw_bean_temperature = status.raw_bean_temperature
+                    self._latest_raw_env_temperature = status.raw_env_temperature
+                    if status.bean_temp_c is None or status.env_temp_c is None:
+                        self._ignored_temperature_packet_count += 1
+                        continue
+                    self._latest_bean_temp_c = status.bean_temp_c
+                    self._latest_env_temp_c = status.env_temp_c
+                    self._latest_resolved_temperature_unit = status.resolved_temperature_unit
         except Exception:
             with self._state_lock:
                 self._status_read_error_count += 1

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -1042,6 +1042,7 @@ class HottopRoasterDriver:
                     self._latest_raw_env_temperature = status.raw_env_temperature
                     if status.bean_temp_c is None or status.env_temp_c is None:
                         self._ignored_temperature_packet_count += 1
+                        self._latest_resolved_temperature_unit = status.resolved_temperature_unit
                         continue
                     self._latest_bean_temp_c = status.bean_temp_c
                     self._latest_env_temp_c = status.env_temp_c

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -210,6 +210,7 @@ def build_server_context(
             config.roaster.driver,
             port=config.roaster.port,
             baudrate=config.roaster.baudrate,
+            temperature_unit=config.roaster.temperature_unit,
             command_interval_seconds=config.roaster.command_interval_seconds,
         )
     except ValueError as exc:

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -35,7 +35,9 @@ class FakeSerialTransport:
         self.close_calls = 0
         self.closed = Event()
         self.writes: list[bytes] = []
+        self._read_buffer = bytearray()
         self._write_lock = Lock()
+        self._read_lock = Lock()
 
     def close(self) -> None:
         self.close_calls += 1
@@ -46,6 +48,24 @@ class FakeSerialTransport:
         with self._write_lock:
             self.writes.append(data)
         return len(data)
+
+    @property
+    def in_waiting(self) -> int:
+        """Return the number of queued bytes available for reads."""
+        with self._read_lock:
+            return len(self._read_buffer)
+
+    def queue_read_data(self, data: bytes) -> None:
+        """Queue bytes that the fake transport will return from read."""
+        with self._read_lock:
+            self._read_buffer.extend(data)
+
+    def read(self, size: int) -> bytes:
+        """Read queued bytes from the fake transport."""
+        with self._read_lock:
+            chunk = bytes(self._read_buffer[:size])
+            del self._read_buffer[:size]
+            return chunk
 
     def writes_snapshot(self) -> list[bytes]:
         """Return command writes recorded by the fake transport."""
@@ -261,6 +281,24 @@ def _wait_for_hottop_write(
     pytest.fail("Timed out waiting for expected Hottop command write.")
 
 
+def _wait_for_hottop_status_count(
+    driver: HottopRoasterDriver,
+    expected_count: int,
+    *,
+    timeout: float = 1.0,
+) -> RoasterState:
+    """Wait until the Hottop driver has recorded status packets."""
+    deadline = monotonic() + timeout
+    while monotonic() < deadline:
+        state = driver.read_state()
+        status_count = state.raw_vendor_data["status_packet_count"]
+        assert isinstance(status_count, int)
+        if status_count >= expected_count:
+            return state
+        sleep(0.01)
+    pytest.fail("Timed out waiting for expected Hottop status packet count.")
+
+
 def _assert_roaster_driver_contract(driver: RoasterDriver) -> None:
     """Exercise the E3 roaster driver contract against one implementation."""
     capabilities = driver.capabilities
@@ -341,9 +379,13 @@ def test_create_roaster_driver_returns_mock_driver() -> None:
 
 
 def test_create_roaster_driver_returns_hottop_driver() -> None:
-    driver = create_roaster_driver("hottop_kn8828b_2k_plus")
+    driver = create_roaster_driver(
+        "hottop_kn8828b_2k_plus",
+        temperature_unit="fahrenheit",
+    )
 
     assert isinstance(driver, HottopRoasterDriver)
+    assert driver.read_state().raw_vendor_data["temperature_unit"] == "fahrenheit"
 
 
 def test_create_roaster_safety_driver_alias_returns_mock_driver() -> None:
@@ -472,7 +514,55 @@ def test_parse_hottop_status_packet_extracts_temperatures_and_preserves_raw_pack
 
     assert status.env_temp_c == 205
     assert status.bean_temp_c == 187
+    assert status.raw_env_temperature == 205
+    assert status.raw_bean_temperature == 187
+    assert status.temperature_unit == "celsius"
+    assert status.resolved_temperature_unit == "celsius"
     assert status.raw_packet == packet
+
+
+def test_parse_hottop_status_packet_converts_fahrenheit_to_celsius() -> None:
+    packet = _build_hottop_status_packet(env_temp_c=401, bean_temp_c=386)
+
+    status = parse_hottop_status_packet(packet, temperature_unit="fahrenheit")
+
+    assert status.env_temp_c == 205.0
+    assert status.bean_temp_c == 196.7
+    assert status.raw_env_temperature == 401
+    assert status.raw_bean_temperature == 386
+    assert status.resolved_temperature_unit == "fahrenheit"
+
+
+def test_parse_hottop_status_packet_auto_uses_plausible_fahrenheit_readings() -> None:
+    packet = _build_hottop_status_packet(env_temp_c=401, bean_temp_c=386)
+
+    status = parse_hottop_status_packet(packet, temperature_unit="auto")
+
+    assert status.env_temp_c == 205.0
+    assert status.bean_temp_c == 196.7
+    assert status.resolved_temperature_unit == "fahrenheit"
+
+
+def test_parse_hottop_status_packet_ignores_startup_zero_temperatures() -> None:
+    packet = _build_hottop_status_packet(env_temp_c=0, bean_temp_c=0)
+
+    status = parse_hottop_status_packet(packet, temperature_unit="auto")
+
+    assert status.env_temp_c is None
+    assert status.bean_temp_c is None
+    assert status.raw_env_temperature == 0
+    assert status.raw_bean_temperature == 0
+    assert status.resolved_temperature_unit is None
+
+
+def test_parse_hottop_status_packet_rejects_invalid_temperature_unit() -> None:
+    packet = _build_hottop_status_packet(env_temp_c=205, bean_temp_c=187)
+
+    with pytest.raises(ValueError, match="temperature_unit"):
+        parse_hottop_status_packet(
+            packet,
+            temperature_unit="kelvin",  # pyright: ignore[reportArgumentType]
+        )
 
 
 def test_parse_hottop_status_packet_rejects_command_packet_echo() -> None:
@@ -678,6 +768,64 @@ def test_hottop_driver_command_loop_default_frame_provider_sends_safe_zero_packe
         assert send_attempts >= 1
         assert write_count >= 1
         assert state.raw_vendor_data["last_command_write_size"] == HOTTOP_PACKET_LENGTH
+    finally:
+        driver.disconnect()
+
+
+def test_hottop_driver_command_loop_updates_latest_celsius_status_temperatures() -> None:
+    serial_factory = FakeSerialFactory()
+    serial_factory.transport.queue_read_data(
+        _build_hottop_status_packet(env_temp_c=205, bean_temp_c=187)
+    )
+    driver = HottopRoasterDriver(
+        port="/dev/test-hottop",
+        command_interval_seconds=0.01,
+        serial_factory=serial_factory,
+    )
+
+    driver.connect()
+    try:
+        state = _wait_for_hottop_status_count(driver, 1)
+
+        assert state.env_temp_c == 205.0
+        assert state.bean_temp_c == 187.0
+        assert state.raw_vendor_data["temperature_unit"] == "celsius"
+        assert state.raw_vendor_data["resolved_temperature_unit"] == "celsius"
+        assert state.raw_vendor_data["raw_env_temperature"] == 205
+        assert state.raw_vendor_data["raw_bean_temperature"] == 187
+        assert state.raw_vendor_data["ignored_temperature_packet_count"] == 0
+    finally:
+        driver.disconnect()
+
+
+def test_hottop_driver_command_loop_ignores_unready_temperatures_until_plausible() -> None:
+    serial_factory = FakeSerialFactory()
+    serial_factory.transport.queue_read_data(
+        _build_hottop_status_packet(env_temp_c=0, bean_temp_c=0)
+    )
+    driver = HottopRoasterDriver(
+        port="/dev/test-hottop",
+        temperature_unit="auto",
+        command_interval_seconds=0.01,
+        serial_factory=serial_factory,
+    )
+
+    driver.connect()
+    try:
+        unready_state = _wait_for_hottop_status_count(driver, 1)
+        serial_factory.transport.queue_read_data(
+            _build_hottop_status_packet(env_temp_c=401, bean_temp_c=386)
+        )
+        plausible_state = _wait_for_hottop_status_count(driver, 2)
+
+        assert unready_state.env_temp_c is None
+        assert unready_state.bean_temp_c is None
+        assert unready_state.raw_vendor_data["ignored_temperature_packet_count"] == 1
+        assert plausible_state.env_temp_c == 205.0
+        assert plausible_state.bean_temp_c == 196.7
+        assert plausible_state.raw_vendor_data["temperature_unit"] == "auto"
+        assert plausible_state.raw_vendor_data["resolved_temperature_unit"] == "fahrenheit"
+        assert plausible_state.raw_vendor_data["ignored_temperature_packet_count"] == 1
     finally:
         driver.disconnect()
 

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -35,6 +35,7 @@ class FakeSerialTransport:
         self.close_calls = 0
         self.closed = Event()
         self.writes: list[bytes] = []
+        self.read_sizes: list[int] = []
         self._read_buffer = bytearray()
         self._write_lock = Lock()
         self._read_lock = Lock()
@@ -63,6 +64,7 @@ class FakeSerialTransport:
     def read(self, size: int) -> bytes:
         """Read queued bytes from the fake transport."""
         with self._read_lock:
+            self.read_sizes.append(size)
             chunk = bytes(self._read_buffer[:size])
             del self._read_buffer[:size]
             return chunk
@@ -923,6 +925,34 @@ def test_hottop_driver_command_loop_processes_burst_status_packets() -> None:
         assert state.bean_temp_c == 188.0
         assert state.raw_vendor_data["raw_env_temperature"] == 206
         assert state.raw_vendor_data["raw_bean_temperature"] == 188
+    finally:
+        driver.disconnect()
+
+
+def test_hottop_driver_command_loop_caps_status_read_size() -> None:
+    serial_factory = FakeSerialFactory()
+    queued_packets = b"".join(
+        _build_hottop_status_packet(
+            raw_env_temperature=205 + index,
+            raw_bean_temperature=187 + index,
+        )
+        for index in range(6)
+    )
+    serial_factory.transport.queue_read_data(queued_packets)
+    driver = HottopRoasterDriver(
+        port="/dev/test-hottop",
+        command_interval_seconds=0.01,
+        serial_factory=serial_factory,
+    )
+
+    driver.connect()
+    try:
+        state = _wait_for_hottop_status_count(driver, 6)
+
+        assert state.env_temp_c == 210.0
+        assert state.bean_temp_c == 192.0
+        assert max(serial_factory.transport.read_sizes) <= HOTTOP_PACKET_LENGTH * 4
+        assert serial_factory.transport.read_sizes[0] == HOTTOP_PACKET_LENGTH * 4
     finally:
         driver.disconnect()
 

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -569,6 +569,36 @@ def test_parse_hottop_status_packet_rejects_invalid_temperature_unit() -> None:
         )
 
 
+def test_parse_hottop_status_packet_rejects_non_string_temperature_unit() -> None:
+    packet = _build_hottop_status_packet(raw_env_temperature=205, raw_bean_temperature=187)
+
+    with pytest.raises(TypeError, match="temperature_unit"):
+        parse_hottop_status_packet(
+            packet,
+            temperature_unit=[],  # pyright: ignore[reportArgumentType]
+        )
+
+
+def test_parse_hottop_status_packet_normalizes_temperature_unit_token() -> None:
+    packet = _build_hottop_status_packet(raw_env_temperature=401, raw_bean_temperature=386)
+
+    status = parse_hottop_status_packet(packet, temperature_unit=" Fahrenheit ")  # pyright: ignore[reportArgumentType]
+
+    assert status.temperature_unit == "fahrenheit"
+    assert status.env_temp_c == 205.0
+    assert status.bean_temp_c == 196.7
+
+
+def test_hottop_driver_normalizes_temperature_unit_token() -> None:
+    driver = HottopRoasterDriver(
+        port="/dev/test-hottop",
+        temperature_unit=" Auto ",  # pyright: ignore[reportArgumentType]
+        serial_factory=FakeSerialFactory(),
+    )
+
+    assert driver.read_state().raw_vendor_data["temperature_unit"] == "auto"
+
+
 def test_parse_hottop_status_packet_rejects_command_packet_echo() -> None:
     packet = build_hottop_command_packet(
         heat_level_percent=75,

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -840,6 +840,39 @@ def test_hottop_driver_command_loop_ignores_unready_temperatures_until_plausible
         driver.disconnect()
 
 
+def test_hottop_driver_command_loop_clears_resolved_unit_for_ignored_packet() -> None:
+    serial_factory = FakeSerialFactory()
+    serial_factory.transport.queue_read_data(
+        _build_hottop_status_packet(raw_env_temperature=401, raw_bean_temperature=386)
+    )
+    driver = HottopRoasterDriver(
+        port="/dev/test-hottop",
+        temperature_unit="auto",
+        command_interval_seconds=0.01,
+        serial_factory=serial_factory,
+    )
+
+    driver.connect()
+    try:
+        plausible_state = _wait_for_hottop_status_count(driver, 1)
+        serial_factory.transport.queue_read_data(
+            _build_hottop_status_packet(raw_env_temperature=0, raw_bean_temperature=0)
+        )
+        ignored_state = _wait_for_hottop_status_count(driver, 2)
+
+        assert plausible_state.env_temp_c == 205.0
+        assert plausible_state.bean_temp_c == 196.7
+        assert plausible_state.raw_vendor_data["resolved_temperature_unit"] == "fahrenheit"
+        assert ignored_state.env_temp_c == 205.0
+        assert ignored_state.bean_temp_c == 196.7
+        assert ignored_state.raw_vendor_data["raw_env_temperature"] == 0
+        assert ignored_state.raw_vendor_data["raw_bean_temperature"] == 0
+        assert ignored_state.raw_vendor_data["resolved_temperature_unit"] is None
+        assert ignored_state.raw_vendor_data["ignored_temperature_packet_count"] == 1
+    finally:
+        driver.disconnect()
+
+
 def test_hottop_driver_command_loop_processes_burst_status_packets() -> None:
     serial_factory = FakeSerialFactory()
     serial_factory.transport.queue_read_data(

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -252,14 +252,18 @@ class StuckHottopRoasterDriver(HottopRoasterDriver):
         self._release_command_loop.wait()
 
 
-def _build_hottop_status_packet(*, env_temp_c: int, bean_temp_c: int) -> bytes:
+def _build_hottop_status_packet(
+    *,
+    raw_env_temperature: int,
+    raw_bean_temperature: int,
+) -> bytes:
     """Build a minimal valid Hottop status packet for parser tests."""
     packet = bytearray(HOTTOP_PACKET_LENGTH)
     packet[: len(HOTTOP_PACKET_PREFIX)] = HOTTOP_PACKET_PREFIX
-    packet[23] = env_temp_c // 256
-    packet[24] = env_temp_c % 256
-    packet[25] = bean_temp_c // 256
-    packet[26] = bean_temp_c % 256
+    packet[23] = raw_env_temperature // 256
+    packet[24] = raw_env_temperature % 256
+    packet[25] = raw_bean_temperature // 256
+    packet[26] = raw_bean_temperature % 256
     packet[35] = calculate_hottop_packet_checksum(packet)
     return bytes(packet)
 
@@ -508,7 +512,7 @@ def test_build_hottop_command_packet_rejects_invalid_fields(
 
 
 def test_parse_hottop_status_packet_extracts_temperatures_and_preserves_raw_packet() -> None:
-    packet = _build_hottop_status_packet(env_temp_c=205, bean_temp_c=187)
+    packet = _build_hottop_status_packet(raw_env_temperature=205, raw_bean_temperature=187)
 
     status = parse_hottop_status_packet(packet)
 
@@ -522,7 +526,7 @@ def test_parse_hottop_status_packet_extracts_temperatures_and_preserves_raw_pack
 
 
 def test_parse_hottop_status_packet_converts_fahrenheit_to_celsius() -> None:
-    packet = _build_hottop_status_packet(env_temp_c=401, bean_temp_c=386)
+    packet = _build_hottop_status_packet(raw_env_temperature=401, raw_bean_temperature=386)
 
     status = parse_hottop_status_packet(packet, temperature_unit="fahrenheit")
 
@@ -534,7 +538,7 @@ def test_parse_hottop_status_packet_converts_fahrenheit_to_celsius() -> None:
 
 
 def test_parse_hottop_status_packet_auto_uses_plausible_fahrenheit_readings() -> None:
-    packet = _build_hottop_status_packet(env_temp_c=401, bean_temp_c=386)
+    packet = _build_hottop_status_packet(raw_env_temperature=401, raw_bean_temperature=386)
 
     status = parse_hottop_status_packet(packet, temperature_unit="auto")
 
@@ -544,7 +548,7 @@ def test_parse_hottop_status_packet_auto_uses_plausible_fahrenheit_readings() ->
 
 
 def test_parse_hottop_status_packet_ignores_startup_zero_temperatures() -> None:
-    packet = _build_hottop_status_packet(env_temp_c=0, bean_temp_c=0)
+    packet = _build_hottop_status_packet(raw_env_temperature=0, raw_bean_temperature=0)
 
     status = parse_hottop_status_packet(packet, temperature_unit="auto")
 
@@ -556,7 +560,7 @@ def test_parse_hottop_status_packet_ignores_startup_zero_temperatures() -> None:
 
 
 def test_parse_hottop_status_packet_rejects_invalid_temperature_unit() -> None:
-    packet = _build_hottop_status_packet(env_temp_c=205, bean_temp_c=187)
+    packet = _build_hottop_status_packet(raw_env_temperature=205, raw_bean_temperature=187)
 
     with pytest.raises(ValueError, match="temperature_unit"):
         parse_hottop_status_packet(
@@ -582,9 +586,11 @@ def test_parse_hottop_status_packet_rejects_command_packet_echo() -> None:
 
 
 def test_find_hottop_status_packet_skips_noise_and_invalid_candidates() -> None:
-    invalid_packet = bytearray(_build_hottop_status_packet(env_temp_c=99, bean_temp_c=88))
+    invalid_packet = bytearray(
+        _build_hottop_status_packet(raw_env_temperature=99, raw_bean_temperature=88)
+    )
     invalid_packet[35] ^= 0x01
-    valid_packet = _build_hottop_status_packet(env_temp_c=205, bean_temp_c=187)
+    valid_packet = _build_hottop_status_packet(raw_env_temperature=205, raw_bean_temperature=187)
     buffer = b"noise" + bytes(invalid_packet) + b"more-noise" + valid_packet + b"tail"
 
     status = find_hottop_status_packet(buffer)
@@ -604,7 +610,7 @@ def test_find_hottop_status_packet_skips_command_packet_echoes() -> None:
         drum_motor_on=True,
         cooling_motor_on=False,
     )
-    valid_packet = _build_hottop_status_packet(env_temp_c=205, bean_temp_c=187)
+    valid_packet = _build_hottop_status_packet(raw_env_temperature=205, raw_bean_temperature=187)
     buffer = b"noise" + command_packet + valid_packet
 
     status = find_hottop_status_packet(buffer)
@@ -616,7 +622,9 @@ def test_find_hottop_status_packet_skips_command_packet_echoes() -> None:
 
 
 def test_find_hottop_status_packet_returns_none_when_buffer_has_no_valid_packet() -> None:
-    invalid_packet = bytearray(_build_hottop_status_packet(env_temp_c=99, bean_temp_c=88))
+    invalid_packet = bytearray(
+        _build_hottop_status_packet(raw_env_temperature=99, raw_bean_temperature=88)
+    )
     invalid_packet[35] ^= 0x01
 
     assert find_hottop_status_packet(b"noise" + bytes(invalid_packet)) is None
@@ -638,7 +646,9 @@ def test_parse_hottop_status_packet_rejects_invalid_packet_shape(
 
 
 def test_parse_hottop_status_packet_rejects_invalid_checksum() -> None:
-    packet = bytearray(_build_hottop_status_packet(env_temp_c=205, bean_temp_c=187))
+    packet = bytearray(
+        _build_hottop_status_packet(raw_env_temperature=205, raw_bean_temperature=187)
+    )
     packet[35] ^= 0x01
 
     assert validate_hottop_packet_checksum(bytes(packet)) is False
@@ -775,7 +785,7 @@ def test_hottop_driver_command_loop_default_frame_provider_sends_safe_zero_packe
 def test_hottop_driver_command_loop_updates_latest_celsius_status_temperatures() -> None:
     serial_factory = FakeSerialFactory()
     serial_factory.transport.queue_read_data(
-        _build_hottop_status_packet(env_temp_c=205, bean_temp_c=187)
+        _build_hottop_status_packet(raw_env_temperature=205, raw_bean_temperature=187)
     )
     driver = HottopRoasterDriver(
         port="/dev/test-hottop",
@@ -801,7 +811,7 @@ def test_hottop_driver_command_loop_updates_latest_celsius_status_temperatures()
 def test_hottop_driver_command_loop_ignores_unready_temperatures_until_plausible() -> None:
     serial_factory = FakeSerialFactory()
     serial_factory.transport.queue_read_data(
-        _build_hottop_status_packet(env_temp_c=0, bean_temp_c=0)
+        _build_hottop_status_packet(raw_env_temperature=0, raw_bean_temperature=0)
     )
     driver = HottopRoasterDriver(
         port="/dev/test-hottop",
@@ -814,7 +824,7 @@ def test_hottop_driver_command_loop_ignores_unready_temperatures_until_plausible
     try:
         unready_state = _wait_for_hottop_status_count(driver, 1)
         serial_factory.transport.queue_read_data(
-            _build_hottop_status_packet(env_temp_c=401, bean_temp_c=386)
+            _build_hottop_status_packet(raw_env_temperature=401, raw_bean_temperature=386)
         )
         plausible_state = _wait_for_hottop_status_count(driver, 2)
 
@@ -826,6 +836,61 @@ def test_hottop_driver_command_loop_ignores_unready_temperatures_until_plausible
         assert plausible_state.raw_vendor_data["temperature_unit"] == "auto"
         assert plausible_state.raw_vendor_data["resolved_temperature_unit"] == "fahrenheit"
         assert plausible_state.raw_vendor_data["ignored_temperature_packet_count"] == 1
+    finally:
+        driver.disconnect()
+
+
+def test_hottop_driver_command_loop_processes_burst_status_packets() -> None:
+    serial_factory = FakeSerialFactory()
+    serial_factory.transport.queue_read_data(
+        _build_hottop_status_packet(raw_env_temperature=205, raw_bean_temperature=187)
+        + _build_hottop_status_packet(raw_env_temperature=206, raw_bean_temperature=188)
+    )
+    driver = HottopRoasterDriver(
+        port="/dev/test-hottop",
+        command_interval_seconds=0.01,
+        serial_factory=serial_factory,
+    )
+
+    driver.connect()
+    try:
+        state = _wait_for_hottop_status_count(driver, 2)
+
+        assert state.env_temp_c == 206.0
+        assert state.bean_temp_c == 188.0
+        assert state.raw_vendor_data["raw_env_temperature"] == 206
+        assert state.raw_vendor_data["raw_bean_temperature"] == 188
+    finally:
+        driver.disconnect()
+
+
+def test_hottop_driver_command_loop_preserves_partial_status_packet_tail() -> None:
+    serial_factory = FakeSerialFactory()
+    first_packet = _build_hottop_status_packet(
+        raw_env_temperature=205,
+        raw_bean_temperature=187,
+    )
+    second_packet = _build_hottop_status_packet(
+        raw_env_temperature=207,
+        raw_bean_temperature=189,
+    )
+    serial_factory.transport.queue_read_data(first_packet + second_packet[:12])
+    driver = HottopRoasterDriver(
+        port="/dev/test-hottop",
+        command_interval_seconds=0.01,
+        serial_factory=serial_factory,
+    )
+
+    driver.connect()
+    try:
+        first_state = _wait_for_hottop_status_count(driver, 1)
+        serial_factory.transport.queue_read_data(second_packet[12:])
+        second_state = _wait_for_hottop_status_count(driver, 2)
+
+        assert first_state.env_temp_c == 205.0
+        assert first_state.bean_temp_c == 187.0
+        assert second_state.env_temp_c == 207.0
+        assert second_state.bean_temp_c == 189.0
     finally:
         driver.disconnect()
 


### PR DESCRIPTION
## Summary
- Add Hottop `celsius`, `fahrenheit`, and `auto` raw temperature handling while keeping `RoasterState` normalized to Celsius.
- Filter startup zero and implausible Hottop status readings until plausible telemetry arrives.
- Thread configured `roaster.temperature_unit` into the Hottop driver and update Epic 3 durable state.

## Validation
- `./.venv/bin/python -m pytest tests/test_drivers.py` (90 passed)
- `./.venv/bin/python -m pytest` (154 passed)
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`

Closes #30