### PR TITLE
E4-S1: Add Hugging Face artifact resolver

### DIFF
--- a/docs/session-summaries/2026-05-17-e4-s1-hugging-face-artifact-resolver.md
+++ b/docs/session-summaries/2026-05-17-e4-s1-hugging-face-artifact-resolver.md
@@ -1,0 +1,159 @@
+# E4-S1 Hugging Face Artifact Resolver Session
+
+## Scope
+
+This session resumed after `PR #90` for `E3-S9` was merged, issue `#31` was
+closed, and issue `#62` was closed. Work started from updated `main` on branch
+`feature/32-hugging-face-artifact-resolver` for issue `#32`, `E4-S1: Add
+Hugging Face artifact resolver`.
+
+The story goal was intentionally narrow: resolve released Hugging Face model
+artifacts from the configured first-crack repository and revision. The work did
+not add model training, ONNX export, Hugging Face sync, detector startup,
+precision-specific ONNX selection, local offline directory handling, or MCP
+session integration.
+
+## Context Usage
+
+Session usage snapshot supplied by the operator near the end of the story:
+
+- Context window: `65% left (97.5K used / 258K)`
+- 5h limit: `95% left`, resets `17:12`
+- Weekly limit: `99% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `20:03`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `15:03 on 24 May`
+
+This was a moderate-context story. The implementation itself was small, but the
+session included post-merge verification for Epic 3, branch setup from updated
+`main`, E4 durable-state updates, PR creation, and one automated review-fix
+round.
+
+## Pre-Story Verification
+
+Before starting E4-S1:
+
+- Verified `PR #90` was merged into `main`.
+- Verified issue `#31` was closed as completed.
+- Verified issue `#62` was closed as completed.
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding to commit
+  `5a5796d321941bc90575a36b1ecf3d0740b986f6`.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`, and GitHub issue `#32`.
+
+## Implementation
+
+Added:
+
+- `src/coffee_roaster_mcp/artifacts.py`
+- `tests/test_artifacts.py`
+
+The resolver:
+
+- accepts a repository-relative artifact filename
+- uses `FirstCrackConfig.repo_id`
+- uses `FirstCrackConfig.revision`
+- calls Hugging Face Hub through a small injectable downloader boundary
+- returns the local Hugging Face cache path plus repo, revision, and filename
+  metadata
+- wraps download failures with artifact, repo, and revision context
+- rejects empty, absolute, parent-traversal, and Windows-style backslash paths
+  before calling the downloader
+
+Added runtime dependency:
+
+- `huggingface_hub>=0.23,<1`
+
+The Hub import is lazy so mocked resolver tests do not require network access or
+a real download.
+
+## Documentation And State
+
+Updated durable project state:
+
+- `docs/state/registry.md` now marks E4-S1 complete and points next at E4-S2.
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E4-S1` complete,
+  records the resolver decision, and adds validation notes.
+
+## Pull Request
+
+Opened `PR #91`: <https://github.com/syamaner/coffee-roaster-mcp/pull/91>
+
+PR branch:
+
+- `feature/32-hugging-face-artifact-resolver`
+
+Commits:
+
+- `84797b851f2b06199cf526bbd7296fb71f5919f0` -
+  `feat: add hugging face artifact resolver`
+- `cd95f95238b077dab3a954f955d2c6c9dcbce6a5` -
+  `fix: reject backslash artifact paths`
+
+PR status after the review fix:
+
+- state: open
+- draft: false
+- mergeable: yes
+- GitHub Actions `Checks`: passed
+- GitHub Actions `Build Package`: passed
+
+Issue `#32` was commented with what changed and how it was tested.
+
+## Review Response
+
+Codex review `4305540514` found one actionable issue:
+
+- `_validate_hub_filename` rejected POSIX `..` traversal but allowed
+  Windows-style backslash paths such as `..\model.onnx` and
+  `onnx\..\model.onnx`.
+
+Fix:
+
+- `_validate_hub_filename` now rejects any backslash before path parsing.
+- Regression tests cover both Windows-style examples from the review.
+
+No Copilot code review findings were available because Copilot reported a review
+error.
+
+## Validation
+
+Before opening PR #91:
+
+- Ran `./.venv/bin/python -m pytest`: `184 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+
+After the review fix:
+
+- Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: `11 passed`
+- Ran `./.venv/bin/python -m ruff check src/coffee_roaster_mcp/artifacts.py tests/test_artifacts.py`: passed
+- Ran `./.venv/bin/python -m ruff format --check src/coffee_roaster_mcp/artifacts.py tests/test_artifacts.py`: passed
+- Ran `./.venv/bin/python -m pyright src/coffee_roaster_mcp/artifacts.py tests/test_artifacts.py`: `0 errors`
+- Ran `./.venv/bin/python -m pytest`: `186 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+
+GitHub Actions after pushing the review fix:
+
+- `Checks`: passed
+- `Build Package`: passed
+
+## Handoff Notes
+
+The branch is clean and pushed at
+`cd95f95238b077dab3a954f955d2c6c9dcbce6a5`.
+
+After PR #91 merges:
+
+1. Sync `main`.
+2. Verify issue `#32` closes.
+3. Begin E4-S2 from updated `main`.
+4. Keep E4-S2 scoped to default INT8 ONNX selection, using the resolver from
+   this story.
+
+Do not add model training, ONNX export, Hugging Face sync, local offline
+directory support, detector startup, or MCP session integration as part of
+E4-S2 unless the story scope is explicitly changed.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4-S1`
-- Current target: Add the Hugging Face artifact resolver
+- Active story: `E4-S2`
+- Current target: Load INT8 ONNX by default
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -55,6 +55,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - ONNX FP32 is supported by config.
 - The `coffee-first-crack-detection` repo remains the source of truth for training, ONNX export, Hugging Face sync, model cards, and dataset cards.
 - This repo consumes released Hugging Face artifacts only.
+- `E4-S1` adds only a narrow Hugging Face Hub artifact resolver. It resolves repository-relative released files from the configured first-crack repo and revision, uses `huggingface_hub` as a declared runtime dependency, and leaves precision-specific ONNX selection, local offline directories, artifact validation, detector startup, and session-timeline integration to later Epic 4 stories.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -198,7 +199,7 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 
 ### Stories
 
-- [ ] `E4-S1` Add Hugging Face artifact resolver.
+- [x] `E4-S1` Add Hugging Face artifact resolver.
   - Done when model files can be resolved from `syamaner/coffee-first-crack-detection` using configured revision.
 
 - [ ] `E4-S2` Load INT8 ONNX by default.
@@ -644,6 +645,16 @@ After completing a story:
   - Added SHA-256 checksums for all three hardware evidence files instead of committing raw JSON evidence.
   - Updated the session summary with review quality, overlap, and response details.
   - Ran `./.venv/bin/python -m pytest`: 170 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E4-S1:
+  - Added `src/coffee_roaster_mcp/artifacts.py` with a small Hugging Face Hub artifact resolver for released first-crack model files.
+  - The resolver accepts a repository-relative filename, uses `FirstCrackConfig.repo_id` and `FirstCrackConfig.revision`, returns the local Hub cache path, and wraps download failures with repository, revision, and artifact context.
+  - Added `huggingface_hub>=0.23,<1` as a declared runtime dependency while keeping the Hub import lazy so mocked resolver tests do not require network access or a real download.
+  - Added mocked resolver tests covering the default `syamaner/coffee-first-crack-detection` repository, configured revision handling, configured repository handling, invalid artifact names, and contextual failure messages.
+  - Kept model training, ONNX export, Hugging Face sync, precision-specific model selection, local offline directory handling, artifact validation, detector startup, and MCP/session integration out of scope.
+  - Ran `./.venv/bin/python -m pytest`: 184 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -30,7 +30,12 @@ drop and emergency stop included. A follow-up 60-second stability test also held
 fan at `10%`, heat at `40%` for 30 seconds, then heat at `100%` for 30 seconds
 with continuous command streaming and no command-loop or status-read errors.
 
-The next story is E4-S1: add the Hugging Face artifact resolver.
+E4-S1 is complete. The first-crack path now has a narrow Hugging Face Hub
+artifact resolver that downloads released files from the configured repository
+and revision without adding model training, export, sync, detector startup, or
+MCP session behavior.
+
+The next story is E4-S2: load INT8 ONNX by default.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence"
 ]
 dependencies = [
+  "huggingface_hub>=0.23,<1",
   "mcp>=1.0.0,<2",
   "pyserial>=3.5",
   "PyYAML>=6.0.2"

--- a/src/coffee_roaster_mcp/artifacts.py
+++ b/src/coffee_roaster_mcp/artifacts.py
@@ -93,6 +93,10 @@ def _validate_hub_filename(filename: str) -> str:
     normalized = filename.strip()
     if not normalized:
         raise ArtifactResolutionError("Hugging Face artifact filename must not be empty.")
+    if "\\" in normalized:
+        raise ArtifactResolutionError(
+            "Hugging Face artifact filename must use repository-relative POSIX separators."
+        )
 
     path = PurePosixPath(normalized)
     if path.is_absolute() or ".." in path.parts:

--- a/src/coffee_roaster_mcp/artifacts.py
+++ b/src/coffee_roaster_mcp/artifacts.py
@@ -1,0 +1,113 @@
+"""Hugging Face artifact resolution for first-crack model files."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from importlib import import_module
+from pathlib import Path, PurePosixPath
+from typing import Protocol, cast
+
+from coffee_roaster_mcp.config import FirstCrackConfig
+
+
+class ArtifactResolutionError(RuntimeError):
+    """Raised when a configured first-crack artifact cannot be resolved."""
+
+
+class HuggingFaceDownloader(Protocol):
+    """Callable interface for Hugging Face Hub artifact downloads."""
+
+    def __call__(
+        self,
+        *,
+        repo_id: str,
+        filename: str,
+        revision: str | None,
+    ) -> str:
+        """Download one artifact from a Hugging Face Hub repository."""
+        ...
+
+
+@dataclass(frozen=True)
+class ResolvedArtifact:
+    """Resolved first-crack artifact metadata.
+
+    Attributes:
+        repo_id: Hugging Face repository that supplied the artifact.
+        revision: Configured repository revision, or `None` for the Hub default.
+        filename: Repository-relative artifact path.
+        local_path: Local cache path returned by the Hugging Face Hub client.
+    """
+
+    repo_id: str
+    revision: str | None
+    filename: str
+    local_path: Path
+
+
+def resolve_hugging_face_artifact(
+    config: FirstCrackConfig,
+    filename: str,
+    *,
+    downloader: HuggingFaceDownloader | None = None,
+) -> ResolvedArtifact:
+    """Resolve one released first-crack artifact from Hugging Face Hub.
+
+    Args:
+        config: First-crack configuration containing the model repo and revision.
+        filename: Repository-relative artifact path to resolve.
+        downloader: Optional test double for the Hugging Face download call.
+
+    Returns:
+        Metadata for the resolved local artifact path.
+
+    Raises:
+        ArtifactResolutionError: If the filename is invalid or the download fails.
+    """
+    normalized_filename = _validate_hub_filename(filename)
+    download = _hf_hub_download if downloader is None else downloader
+
+    try:
+        local_path = download(
+            repo_id=config.repo_id,
+            filename=normalized_filename,
+            revision=config.revision,
+        )
+    except Exception as exc:
+        revision_label = config.revision or "default"
+        raise ArtifactResolutionError(
+            "Could not resolve Hugging Face artifact "
+            f"{normalized_filename!r} from {config.repo_id!r} at revision {revision_label!r}: {exc}"
+        ) from exc
+
+    return ResolvedArtifact(
+        repo_id=config.repo_id,
+        revision=config.revision,
+        filename=normalized_filename,
+        local_path=Path(local_path),
+    )
+
+
+def _validate_hub_filename(filename: str) -> str:
+    normalized = filename.strip()
+    if not normalized:
+        raise ArtifactResolutionError("Hugging Face artifact filename must not be empty.")
+
+    path = PurePosixPath(normalized)
+    if path.is_absolute() or ".." in path.parts:
+        raise ArtifactResolutionError(
+            "Hugging Face artifact filename must be a repository-relative path."
+        )
+    return path.as_posix()
+
+
+def _hf_hub_download(
+    *,
+    repo_id: str,
+    filename: str,
+    revision: str | None,
+) -> str:
+    hub_module = import_module("huggingface_hub")
+    download = cast(Callable[..., str], hub_module.__dict__["hf_hub_download"])
+    return download(repo_id=repo_id, filename=filename, revision=revision)

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -80,7 +80,16 @@ def test_resolver_honors_configured_repo_id() -> None:
 
 
 @pytest.mark.parametrize(
-    "filename", ["", "  ", "/model.onnx", "../model.onnx", "onnx/../model.onnx"]
+    "filename",
+    [
+        "",
+        "  ",
+        "/model.onnx",
+        "../model.onnx",
+        "onnx/../model.onnx",
+        r"..\model.onnx",
+        r"onnx\..\model.onnx",
+    ],
 )
 def test_invalid_artifact_filename_fails_before_download(filename: str) -> None:
     downloader = RecordingDownloader()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+
+import pytest
+
+from coffee_roaster_mcp.artifacts import ArtifactResolutionError, resolve_hugging_face_artifact
+from coffee_roaster_mcp.config import FirstCrackConfig
+
+
+class RecordingDownloader:
+    def __init__(self, local_path: str = "/tmp/hf-cache/model.onnx") -> None:
+        self.local_path = local_path
+        self.calls: list[dict[str, str | None]] = []
+
+    def __call__(
+        self,
+        *,
+        repo_id: str,
+        filename: str,
+        revision: str | None,
+    ) -> str:
+        self.calls.append(
+            {
+                "repo_id": repo_id,
+                "filename": filename,
+                "revision": revision,
+            }
+        )
+        return self.local_path
+
+
+def test_resolves_first_crack_artifact_from_default_repo() -> None:
+    downloader = RecordingDownloader("/tmp/hf-cache/model_quantized.onnx")
+
+    artifact = resolve_hugging_face_artifact(
+        FirstCrackConfig(),
+        "onnx/int8/model_quantized.onnx",
+        downloader=downloader,
+    )
+
+    assert artifact.repo_id == "syamaner/coffee-first-crack-detection"
+    assert artifact.revision is None
+    assert artifact.filename == "onnx/int8/model_quantized.onnx"
+    assert artifact.local_path == Path("/tmp/hf-cache/model_quantized.onnx")
+    assert downloader.calls == [
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "onnx/int8/model_quantized.onnx",
+            "revision": None,
+        }
+    ]
+
+
+def test_resolver_honors_configured_revision() -> None:
+    downloader = RecordingDownloader()
+    config = FirstCrackConfig(revision="v0.1.0")
+
+    artifact = resolve_hugging_face_artifact(
+        config,
+        "feature_extractor/preprocessor_config.json",
+        downloader=downloader,
+    )
+
+    assert artifact.revision == "v0.1.0"
+    assert downloader.calls == [
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "feature_extractor/preprocessor_config.json",
+            "revision": "v0.1.0",
+        }
+    ]
+
+
+def test_resolver_honors_configured_repo_id() -> None:
+    downloader = RecordingDownloader()
+    config = FirstCrackConfig(repo_id="syamaner/custom-first-crack")
+
+    resolve_hugging_face_artifact(config, "model.onnx", downloader=downloader)
+
+    assert downloader.calls[0]["repo_id"] == "syamaner/custom-first-crack"
+
+
+@pytest.mark.parametrize(
+    "filename", ["", "  ", "/model.onnx", "../model.onnx", "onnx/../model.onnx"]
+)
+def test_invalid_artifact_filename_fails_before_download(filename: str) -> None:
+    downloader = RecordingDownloader()
+
+    with pytest.raises(ArtifactResolutionError, match="filename"):
+        resolve_hugging_face_artifact(FirstCrackConfig(), filename, downloader=downloader)
+
+    assert downloader.calls == []
+
+
+def test_download_failure_includes_artifact_context() -> None:
+    def failing_downloader(*, repo_id: str, filename: str, revision: str | None) -> str:
+        raise RuntimeError("not found")
+
+    with pytest.raises(ArtifactResolutionError) as exc_info:
+        resolve_hugging_face_artifact(
+            FirstCrackConfig(revision="pinned-release"),
+            "onnx/int8/model_quantized.onnx",
+            downloader=failing_downloader,
+        )
+
+    message = str(exc_info.value)
+    assert "onnx/int8/model_quantized.onnx" in message
+    assert "syamaner/coffee-first-crack-detection" in message
+    assert "pinned-release" in message


### PR DESCRIPTION
## Summary
- Add a narrow Hugging Face Hub artifact resolver for released first-crack model files.
- Honor configured first-crack repo and revision while keeping precision-specific selection, local offline directories, detector startup, and MCP/session integration out of scope.
- Add mocked resolver coverage and update durable state for E4-S1 completion.
- Reject Windows-style backslash artifact paths before calling the downloader.

Closes #32.

## Validation
- `./.venv/bin/python -m pytest` (186 passed)
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`