### PR TITLE
E4-S2: Load INT8 ONNX by default

### DIFF
--- a/docs/session-summaries/2026-05-17-e4-s2-load-int8-onnx-by-default.md
+++ b/docs/session-summaries/2026-05-17-e4-s2-load-int8-onnx-by-default.md
@@ -1,0 +1,126 @@
+# E4-S2 Load INT8 ONNX By Default Session
+
+## Scope
+
+This session resumed after `PR #91` for `E4-S1` was squashed and merged, and
+issue `#32` was closed. Work started from updated `main` on branch
+`feature/33-load-int8-onnx-by-default` for issue `#33`, `E4-S2: Load INT8 ONNX
+by default`.
+
+The story goal was intentionally narrow: select the released INT8 ONNX model
+artifact by default using the E4-S1 Hugging Face artifact resolver. The work did
+not add model training, ONNX export, Hugging Face sync, detector startup, audio
+capture, local offline directory handling, artifact validation, or MCP session
+integration.
+
+## Context Usage
+
+Session usage snapshot supplied by the operator near the end of the story:
+
+- Context window: `71% left (83.9K used / 258K)`
+- 5h limit: `94% left`, resets `17:12`
+- Weekly limit: `99% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `20:14`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `15:14 on 24 May`
+- Warning: `limits may be stale - run /status again shortly`
+
+This was a low-code-change story. Most of the session was spent on branch setup
+from updated `main`, reading the required durable state and issue context,
+scoped implementation, validation, state updates, PR creation, and CI
+confirmation.
+
+## Pre-Story Verification
+
+Before starting E4-S2:
+
+- Verified from the operator handoff that `PR #91` was squashed and merged and
+  issue `#32` was closed.
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding to the E4-S1 squash
+  merge commit `a4f54bd7139549b33176f079c6059c17edcb9c83`.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-17-e4-s1-hugging-face-artifact-resolver.md`,
+  and GitHub issue `#33`.
+
+## Implementation
+
+Updated:
+
+- `src/coffee_roaster_mcp/artifacts.py`
+- `tests/test_artifacts.py`
+
+Added:
+
+- `INT8_ONNX_MODEL_FILENAME = "onnx/int8/model_quantized.onnx"`
+- `resolve_first_crack_onnx_model(...)`
+
+The selector:
+
+- uses `FirstCrackConfig.precision`
+- resolves `onnx/int8/model_quantized.onnx` for the default `int8` precision
+- also resolves the same artifact for explicit `precision="int8"`
+- delegates repository, revision, filename validation, and Hub download behavior
+  to `resolve_hugging_face_artifact(...)`
+- keeps `fp32` selection deferred to `E4-S3` and fails before downloader use for
+  that precision
+
+## Documentation And State
+
+Updated durable project state:
+
+- `docs/state/registry.md` now marks E4-S2 complete and points next at E4-S3.
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E4-S2` complete,
+  records the INT8 selector decision, and adds validation notes.
+
+## Pull Request
+
+Opened `PR #92`: <https://github.com/syamaner/coffee-roaster-mcp/pull/92>
+
+PR branch:
+
+- `feature/33-load-int8-onnx-by-default`
+
+Commit before this session-summary update:
+
+- `922ba6df7f576ea624a8b6b46d67d7e8cd7dfc7b` -
+  `feat: select int8 onnx artifact`
+
+PR status before this session-summary update:
+
+- state: open
+- draft: false
+- mergeable: yes
+- GitHub Actions `Checks`: passed
+- GitHub Actions `Build Package`: passed
+
+Issue `#33` was commented with what changed and how it was tested.
+
+## Validation
+
+Before opening PR #92:
+
+- Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: `14 passed`
+- Ran `./.venv/bin/python -m pytest`: `189 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+
+GitHub Actions after opening PR #92:
+
+- `Checks`: passed
+- `Build Package`: passed
+
+## Handoff Notes
+
+After PR #92 merges:
+
+1. Sync `main`.
+2. Verify issue `#33` closes.
+3. Begin E4-S3 from updated `main`.
+4. Keep E4-S3 scoped to selecting `onnx/fp32/model.onnx` for configured
+   `precision: fp32` using the same resolver boundary.
+
+Do not add model training, ONNX export, Hugging Face sync, detector startup,
+audio capture, local offline directory support, artifact validation, or MCP
+session integration as part of E4-S3 unless the story scope explicitly changes.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4-S2`
-- Current target: Load INT8 ONNX by default
+- Active story: `E4-S3`
+- Current target: Load FP32 ONNX by config
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -56,6 +56,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - The `coffee-first-crack-detection` repo remains the source of truth for training, ONNX export, Hugging Face sync, model cards, and dataset cards.
 - This repo consumes released Hugging Face artifacts only.
 - `E4-S1` adds only a narrow Hugging Face Hub artifact resolver. It resolves repository-relative released files from the configured first-crack repo and revision, uses `huggingface_hub` as a declared runtime dependency, and leaves precision-specific ONNX selection, local offline directories, artifact validation, detector startup, and session-timeline integration to later Epic 4 stories.
+- `E4-S2` resolves the configured first-crack ONNX model for default `int8` precision by selecting `onnx/int8/model_quantized.onnx` through the E4-S1 Hugging Face artifact resolver. FP32 selection, local offline directories, artifact validation, detector startup, audio capture, and session-timeline integration remain later Epic 4 work.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -202,7 +203,7 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 - [x] `E4-S1` Add Hugging Face artifact resolver.
   - Done when model files can be resolved from `syamaner/coffee-first-crack-detection` using configured revision.
 
-- [ ] `E4-S2` Load INT8 ONNX by default.
+- [x] `E4-S2` Load INT8 ONNX by default.
   - Done when `onnx/int8/model_quantized.onnx` is selected for `precision: int8`.
 
 - [ ] `E4-S3` Load FP32 ONNX by config.
@@ -655,6 +656,16 @@ After completing a story:
   - Added mocked resolver tests covering the default `syamaner/coffee-first-crack-detection` repository, configured revision handling, configured repository handling, invalid artifact names, and contextual failure messages.
   - Kept model training, ONNX export, Hugging Face sync, precision-specific model selection, local offline directory handling, artifact validation, detector startup, and MCP/session integration out of scope.
   - Ran `./.venv/bin/python -m pytest`: 184 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E4-S2:
+  - Added `resolve_first_crack_onnx_model(...)` as the narrow ONNX model selection entry point on top of the E4-S1 Hugging Face artifact resolver.
+  - The selector resolves `onnx/int8/model_quantized.onnx` for configured `int8` precision, including the default `FirstCrackConfig()` precision.
+  - FP32 selection remains deferred to E4-S3, and model training, ONNX export, Hugging Face sync, detector startup, audio capture, local offline directories, artifact validation, and MCP/session integration remain out of scope.
+  - Added mocked resolver tests for default INT8 selection, explicit INT8 selection with revision propagation, and the deferred FP32 boundary.
+  - Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: 14 passed.
+  - Ran `./.venv/bin/python -m pytest`: 189 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -30,12 +30,13 @@ drop and emergency stop included. A follow-up 60-second stability test also held
 fan at `10%`, heat at `40%` for 30 seconds, then heat at `100%` for 30 seconds
 with continuous command streaming and no command-loop or status-read errors.
 
-E4-S1 is complete. The first-crack path now has a narrow Hugging Face Hub
-artifact resolver that downloads released files from the configured repository
-and revision without adding model training, export, sync, detector startup, or
-MCP session behavior.
+E4-S2 is complete. The first-crack path now resolves the configured ONNX model
+artifact for the default `int8` precision by selecting
+`onnx/int8/model_quantized.onnx` through the Hugging Face artifact resolver. This
+does not add model training, export, sync, detector startup, audio capture, local
+offline directories, or MCP session behavior.
 
-The next story is E4-S2: load INT8 ONNX by default.
+The next story is E4-S3: load FP32 ONNX by config.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/artifacts.py
+++ b/src/coffee_roaster_mcp/artifacts.py
@@ -10,6 +10,8 @@ from typing import Protocol, cast
 
 from coffee_roaster_mcp.config import FirstCrackConfig
 
+INT8_ONNX_MODEL_FILENAME = "onnx/int8/model_quantized.onnx"
+
 
 class ArtifactResolutionError(RuntimeError):
     """Raised when a configured first-crack artifact cannot be resolved."""
@@ -86,6 +88,37 @@ def resolve_hugging_face_artifact(
         revision=config.revision,
         filename=normalized_filename,
         local_path=Path(local_path),
+    )
+
+
+def resolve_first_crack_onnx_model(
+    config: FirstCrackConfig,
+    *,
+    downloader: HuggingFaceDownloader | None = None,
+) -> ResolvedArtifact:
+    """Resolve the configured first-crack ONNX model artifact.
+
+    Args:
+        config: First-crack configuration containing precision, repo, and revision.
+        downloader: Optional test double for the Hugging Face download call.
+
+    Returns:
+        Metadata for the resolved local ONNX model artifact path.
+
+    Raises:
+        ArtifactResolutionError: If the configured precision is not supported yet
+            or the artifact cannot be resolved.
+    """
+    if config.precision != "int8":
+        raise ArtifactResolutionError(
+            "Only first-crack precision 'int8' is supported for ONNX model resolution "
+            "until FP32 selection lands in E4-S3."
+        )
+
+    return resolve_hugging_face_artifact(
+        config,
+        INT8_ONNX_MODEL_FILENAME,
+        downloader=downloader,
     )
 
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -2,7 +2,12 @@ from pathlib import Path
 
 import pytest
 
-from coffee_roaster_mcp.artifacts import ArtifactResolutionError, resolve_hugging_face_artifact
+from coffee_roaster_mcp.artifacts import (
+    INT8_ONNX_MODEL_FILENAME,
+    ArtifactResolutionError,
+    resolve_first_crack_onnx_model,
+    resolve_hugging_face_artifact,
+)
 from coffee_roaster_mcp.config import FirstCrackConfig
 
 
@@ -48,6 +53,53 @@ def test_resolves_first_crack_artifact_from_default_repo() -> None:
             "revision": None,
         }
     ]
+
+
+def test_resolves_int8_onnx_model_for_default_precision() -> None:
+    downloader = RecordingDownloader("/tmp/hf-cache/model_quantized.onnx")
+
+    artifact = resolve_first_crack_onnx_model(FirstCrackConfig(), downloader=downloader)
+
+    assert artifact.filename == INT8_ONNX_MODEL_FILENAME
+    assert artifact.local_path == Path("/tmp/hf-cache/model_quantized.onnx")
+    assert downloader.calls == [
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "onnx/int8/model_quantized.onnx",
+            "revision": None,
+        }
+    ]
+
+
+def test_resolves_int8_onnx_model_for_explicit_int8_precision() -> None:
+    downloader = RecordingDownloader("/tmp/hf-cache/explicit-int8.onnx")
+
+    artifact = resolve_first_crack_onnx_model(
+        FirstCrackConfig(precision="int8", revision="v0.1.0"),
+        downloader=downloader,
+    )
+
+    assert artifact.filename == "onnx/int8/model_quantized.onnx"
+    assert artifact.revision == "v0.1.0"
+    assert downloader.calls == [
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "onnx/int8/model_quantized.onnx",
+            "revision": "v0.1.0",
+        }
+    ]
+
+
+def test_fp32_onnx_model_resolution_is_deferred_to_e4_s3() -> None:
+    downloader = RecordingDownloader()
+
+    with pytest.raises(ArtifactResolutionError, match="E4-S3"):
+        resolve_first_crack_onnx_model(
+            FirstCrackConfig(precision="fp32"),
+            downloader=downloader,
+        )
+
+    assert downloader.calls == []
 
 
 def test_resolver_honors_configured_revision() -> None:


### PR DESCRIPTION
## Summary
- add `resolve_first_crack_onnx_model(...)` as the first precision-aware ONNX model selector
- resolve `onnx/int8/model_quantized.onnx` for default and explicit `int8` precision through the E4-S1 Hugging Face artifact resolver
- keep FP32 selection deferred to E4-S3 and avoid detector startup, training, sync, audio capture, offline directory support, and MCP/session integration
- update durable state docs for E4-S2 completion and E4-S3 as next

## Validation
- `./.venv/bin/python -m pytest tests/test_artifacts.py` -> 14 passed
- `./.venv/bin/python -m pytest` -> 189 passed
- `./.venv/bin/python -m ruff check .` -> passed
- `./.venv/bin/python -m ruff format --check .` -> passed
- `./.venv/bin/python -m pyright` -> 0 errors

Closes #33