### PR TITLE
E4-S3: Load FP32 ONNX by config

### DIFF
--- a/docs/session-summaries/2026-05-17-e4-s3-load-fp32-onnx-by-config.md
+++ b/docs/session-summaries/2026-05-17-e4-s3-load-fp32-onnx-by-config.md
@@ -1,0 +1,147 @@
+# E4-S3 Load FP32 ONNX By Config Session
+
+## Scope
+
+This session resumed after `PR #92` for `E4-S2` was squashed and merged, and
+issue `#33` was closed. Work started from updated `main` on branch
+`feature/34-load-fp32-onnx-by-config` for issue `#34`, `E4-S3: Load FP32 ONNX
+by config`.
+
+The story goal was intentionally narrow: select the released FP32 ONNX model
+artifact when first-crack precision is configured as `fp32`, using the existing
+E4-S1/E4-S2 Hugging Face artifact resolver boundary. The work did not add model
+training, ONNX export, Hugging Face sync, detector startup, audio capture, local
+offline directory handling, artifact validation, or MCP session integration.
+
+## Context Usage
+
+Session usage snapshot supplied by the operator after the PR review fix:
+
+- Context window: `68% left (90.1K used / 258K)`
+- 5h limit: `93% left`, resets `17:12`
+- Weekly limit: `99% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `20:48`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `15:48 on 24 May`
+- Warning: `limits may be stale - run /status again shortly`
+
+## Pre-Story Verification
+
+Before starting E4-S3:
+
+- Verified from the operator handoff that `PR #92` was squashed and merged and
+  issue `#33` was closed.
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding to the E4-S2 squash
+  merge commit `4979dbb51ea328607e00dd25c9ebf8ab13658f72`.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-17-e4-s2-load-int8-onnx-by-default.md`,
+  and GitHub issue `#34`.
+
+## Implementation
+
+Updated:
+
+- `src/coffee_roaster_mcp/artifacts.py`
+- `tests/test_artifacts.py`
+
+Added:
+
+- `FP32_ONNX_MODEL_FILENAME = "onnx/fp32/model.onnx"`
+- FP32 selection in `resolve_first_crack_onnx_model(...)`
+
+The selector now:
+
+- resolves `onnx/int8/model_quantized.onnx` for `precision="int8"`
+- resolves `onnx/fp32/model.onnx` for `precision="fp32"`
+- delegates repository, revision, filename validation, and Hub download behavior
+  to `resolve_hugging_face_artifact(...)`
+- preserves mock-safe behavior by using mocked downloaders in tests
+
+## Review Fix
+
+Codex reviewed `PR #93` at review `4305610617` and opened one actionable thread:
+
+- Unsupported runtime precision values could bypass the static `ModelPrecision`
+  type because `FirstCrackConfig` is a plain dataclass. Without a fallback
+  branch, `resolve_first_crack_onnx_model(...)` could raise `UnboundLocalError`
+  instead of the documented `ArtifactResolutionError`.
+
+The fix:
+
+- converts `config.precision` to a runtime string before matching
+- raises `ArtifactResolutionError` for unsupported values before downloader use
+- adds regression coverage using `cast(ModelPrecision, "INT8")`
+
+After the fix, the review thread became outdated on GitHub. It was not manually
+resolved.
+
+## Documentation And State
+
+Updated durable project state:
+
+- `docs/state/registry.md` now marks E4-S3 complete and points next at E4-S4.
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E4-S3` complete,
+  records the FP32 selector decision, and adds validation notes.
+
+## Pull Request
+
+Opened `PR #93`: <https://github.com/syamaner/coffee-roaster-mcp/pull/93>
+
+PR branch:
+
+- `feature/34-load-fp32-onnx-by-config`
+
+Commits before this session-summary update:
+
+- `a2086da9371383a9ce362c35f6c208a1f8d2da8c` -
+  `feat: select fp32 onnx artifact`
+- `f5cca0cd2a94d219a74405551912e16dde7fbe70` -
+  `fix: handle unsupported onnx precision`
+
+PR status before this session-summary update:
+
+- state: open
+- draft: false
+- mergeable: yes
+- head: `f5cca0cd2a94d219a74405551912e16dde7fbe70`
+- GitHub Actions `Checks`: passed
+- GitHub Actions `Build Package`: passed
+
+Issue `#34` was commented with what changed and how it was tested.
+
+## Validation
+
+Before opening PR #93:
+
+- Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: `14 passed`
+- Ran `./.venv/bin/python -m pytest`: `189 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+
+After the PR review fix:
+
+- Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: `15 passed`
+- Ran `./.venv/bin/python -m pytest`: `190 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+
+GitHub Actions after the review-fix push:
+
+- `Checks`: passed
+- `Build Package`: passed
+
+## Handoff Notes
+
+After PR #93 merges:
+
+1. Sync `main`.
+2. Verify issue `#34` closes.
+3. Begin E4-S4 from updated `main`.
+4. Keep E4-S4 scoped to local offline model directory support.
+
+Do not add model training, ONNX export, Hugging Face sync, detector startup,
+audio capture, artifact validation, or MCP session integration as part of E4-S4
+unless the story scope explicitly changes.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4-S3`
-- Current target: Load FP32 ONNX by config
+- Active story: `E4-S4`
+- Current target: Support local offline model directory
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -57,6 +57,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - This repo consumes released Hugging Face artifacts only.
 - `E4-S1` adds only a narrow Hugging Face Hub artifact resolver. It resolves repository-relative released files from the configured first-crack repo and revision, uses `huggingface_hub` as a declared runtime dependency, and leaves precision-specific ONNX selection, local offline directories, artifact validation, detector startup, and session-timeline integration to later Epic 4 stories.
 - `E4-S2` resolves the configured first-crack ONNX model for default `int8` precision by selecting `onnx/int8/model_quantized.onnx` through the E4-S1 Hugging Face artifact resolver. FP32 selection, local offline directories, artifact validation, detector startup, audio capture, and session-timeline integration remain later Epic 4 work.
+- `E4-S3` resolves the configured first-crack ONNX model for `fp32` precision by selecting `onnx/fp32/model.onnx` through the E4-S1/E4-S2 resolver boundary. Local offline directories, artifact validation, detector startup, audio capture, and session-timeline integration remain later Epic 4 work.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -206,7 +207,7 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 - [x] `E4-S2` Load INT8 ONNX by default.
   - Done when `onnx/int8/model_quantized.onnx` is selected for `precision: int8`.
 
-- [ ] `E4-S3` Load FP32 ONNX by config.
+- [x] `E4-S3` Load FP32 ONNX by config.
   - Done when `onnx/fp32/model.onnx` is selected for `precision: fp32`.
 
 - [ ] `E4-S4` Support local offline model directory.
@@ -664,6 +665,16 @@ After completing a story:
   - The selector resolves `onnx/int8/model_quantized.onnx` for configured `int8` precision, including the default `FirstCrackConfig()` precision.
   - FP32 selection remains deferred to E4-S3, and model training, ONNX export, Hugging Face sync, detector startup, audio capture, local offline directories, artifact validation, and MCP/session integration remain out of scope.
   - Added mocked resolver tests for default INT8 selection, explicit INT8 selection with revision propagation, and the deferred FP32 boundary.
+  - Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: 14 passed.
+  - Ran `./.venv/bin/python -m pytest`: 189 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E4-S3:
+  - Extended `resolve_first_crack_onnx_model(...)` to select `onnx/fp32/model.onnx` when `FirstCrackConfig.precision` is `fp32`.
+  - Preserved the default `int8` selection of `onnx/int8/model_quantized.onnx` and kept repository, revision, filename validation, and download behavior delegated to the E4-S1 Hugging Face artifact resolver.
+  - Kept model training, ONNX export, Hugging Face sync, detector startup, audio capture, local offline directories, artifact validation, and MCP/session integration out of scope.
+  - Added mocked resolver coverage for configured FP32 selection with revision propagation.
   - Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: 14 passed.
   - Ran `./.venv/bin/python -m pytest`: 189 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -674,9 +674,9 @@ After completing a story:
   - Extended `resolve_first_crack_onnx_model(...)` to select `onnx/fp32/model.onnx` when `FirstCrackConfig.precision` is `fp32`.
   - Preserved the default `int8` selection of `onnx/int8/model_quantized.onnx` and kept repository, revision, filename validation, and download behavior delegated to the E4-S1 Hugging Face artifact resolver.
   - Kept model training, ONNX export, Hugging Face sync, detector startup, audio capture, local offline directories, artifact validation, and MCP/session integration out of scope.
-  - Added mocked resolver coverage for configured FP32 selection with revision propagation.
-  - Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: 14 passed.
-  - Ran `./.venv/bin/python -m pytest`: 189 passed.
+  - Added mocked resolver coverage for configured FP32 selection with revision propagation and unsupported precision domain-error handling.
+  - Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: 15 passed.
+  - Ran `./.venv/bin/python -m pytest`: 190 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -30,13 +30,14 @@ drop and emergency stop included. A follow-up 60-second stability test also held
 fan at `10%`, heat at `40%` for 30 seconds, then heat at `100%` for 30 seconds
 with continuous command streaming and no command-loop or status-read errors.
 
-E4-S2 is complete. The first-crack path now resolves the configured ONNX model
-artifact for the default `int8` precision by selecting
-`onnx/int8/model_quantized.onnx` through the Hugging Face artifact resolver. This
-does not add model training, export, sync, detector startup, audio capture, local
-offline directories, or MCP session behavior.
+E4-S3 is complete. The first-crack path now resolves the configured ONNX model
+artifact for both supported real-model precisions: `int8` selects
+`onnx/int8/model_quantized.onnx`, and `fp32` selects `onnx/fp32/model.onnx`
+through the Hugging Face artifact resolver. This does not add model training,
+export, sync, detector startup, audio capture, local offline directories, or MCP
+session behavior.
 
-The next story is E4-S3: load FP32 ONNX by config.
+The next story is E4-S4: support local offline model directory.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/artifacts.py
+++ b/src/coffee_roaster_mcp/artifacts.py
@@ -110,11 +110,17 @@ def resolve_first_crack_onnx_model(
         ArtifactResolutionError: If the configured precision is unsupported or
             the artifact cannot be resolved.
     """
-    match config.precision:
+    precision = str(config.precision)
+    match precision:
         case "int8":
             filename = INT8_ONNX_MODEL_FILENAME
         case "fp32":
             filename = FP32_ONNX_MODEL_FILENAME
+        case unsupported_precision:
+            raise ArtifactResolutionError(
+                "Unsupported first-crack ONNX precision "
+                f"{unsupported_precision!r}; expected 'int8' or 'fp32'."
+            )
 
     return resolve_hugging_face_artifact(
         config,

--- a/src/coffee_roaster_mcp/artifacts.py
+++ b/src/coffee_roaster_mcp/artifacts.py
@@ -11,6 +11,7 @@ from typing import Protocol, cast
 from coffee_roaster_mcp.config import FirstCrackConfig
 
 INT8_ONNX_MODEL_FILENAME = "onnx/int8/model_quantized.onnx"
+FP32_ONNX_MODEL_FILENAME = "onnx/fp32/model.onnx"
 
 
 class ArtifactResolutionError(RuntimeError):
@@ -106,18 +107,18 @@ def resolve_first_crack_onnx_model(
         Metadata for the resolved local ONNX model artifact path.
 
     Raises:
-        ArtifactResolutionError: If the configured precision is not supported yet
-            or the artifact cannot be resolved.
+        ArtifactResolutionError: If the configured precision is unsupported or
+            the artifact cannot be resolved.
     """
-    if config.precision != "int8":
-        raise ArtifactResolutionError(
-            "Only first-crack precision 'int8' is supported for ONNX model resolution "
-            "until FP32 selection lands in E4-S3."
-        )
+    match config.precision:
+        case "int8":
+            filename = INT8_ONNX_MODEL_FILENAME
+        case "fp32":
+            filename = FP32_ONNX_MODEL_FILENAME
 
     return resolve_hugging_face_artifact(
         config,
-        INT8_ONNX_MODEL_FILENAME,
+        filename,
         downloader=downloader,
     )
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -9,7 +10,7 @@ from coffee_roaster_mcp.artifacts import (
     resolve_first_crack_onnx_model,
     resolve_hugging_face_artifact,
 )
-from coffee_roaster_mcp.config import FirstCrackConfig
+from coffee_roaster_mcp.config import FirstCrackConfig, ModelPrecision
 
 
 class RecordingDownloader:
@@ -109,6 +110,18 @@ def test_resolves_fp32_onnx_model_for_configured_precision() -> None:
             "revision": "v0.1.0",
         }
     ]
+
+
+def test_unsupported_onnx_precision_fails_before_download() -> None:
+    downloader = RecordingDownloader()
+
+    with pytest.raises(ArtifactResolutionError, match="Unsupported.*precision"):
+        resolve_first_crack_onnx_model(
+            FirstCrackConfig(precision=cast(ModelPrecision, "INT8")),
+            downloader=downloader,
+        )
+
+    assert downloader.calls == []
 
 
 def test_resolver_honors_configured_revision() -> None:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from coffee_roaster_mcp.artifacts import (
+    FP32_ONNX_MODEL_FILENAME,
     INT8_ONNX_MODEL_FILENAME,
     ArtifactResolutionError,
     resolve_first_crack_onnx_model,
@@ -90,16 +91,24 @@ def test_resolves_int8_onnx_model_for_explicit_int8_precision() -> None:
     ]
 
 
-def test_fp32_onnx_model_resolution_is_deferred_to_e4_s3() -> None:
-    downloader = RecordingDownloader()
+def test_resolves_fp32_onnx_model_for_configured_precision() -> None:
+    downloader = RecordingDownloader("/tmp/hf-cache/model.onnx")
 
-    with pytest.raises(ArtifactResolutionError, match="E4-S3"):
-        resolve_first_crack_onnx_model(
-            FirstCrackConfig(precision="fp32"),
-            downloader=downloader,
-        )
+    artifact = resolve_first_crack_onnx_model(
+        FirstCrackConfig(precision="fp32", revision="v0.1.0"),
+        downloader=downloader,
+    )
 
-    assert downloader.calls == []
+    assert artifact.filename == FP32_ONNX_MODEL_FILENAME
+    assert artifact.revision == "v0.1.0"
+    assert artifact.local_path == Path("/tmp/hf-cache/model.onnx")
+    assert downloader.calls == [
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "onnx/fp32/model.onnx",
+            "revision": "v0.1.0",
+        }
+    ]
 
 
 def test_resolver_honors_configured_revision() -> None:


### PR DESCRIPTION
## Summary
- add `FP32_ONNX_MODEL_FILENAME` for `onnx/fp32/model.onnx`
- resolve `precision: fp32` through the existing first-crack ONNX artifact selector
- preserve default INT8 selection and the Hugging Face resolver boundary
- handle unsupported runtime precision values with `ArtifactResolutionError` before downloader use
- update durable state for E4-S3 completion and E4-S4 handoff

## Validation
- `./.venv/bin/python -m pytest tests/test_artifacts.py` -> 15 passed
- `./.venv/bin/python -m pytest` -> 190 passed
- `./.venv/bin/python -m ruff check .` -> passed
- `./.venv/bin/python -m ruff format --check .` -> passed
- `./.venv/bin/python -m pyright` -> 0 errors

Closes #34