### PR TITLE
E4-S4: Support local offline model directory

### DIFF
--- a/docs/session-summaries/2026-05-17-e4-s4-support-local-offline-model-directory.md
+++ b/docs/session-summaries/2026-05-17-e4-s4-support-local-offline-model-directory.md
@@ -1,0 +1,137 @@
+# E4-S4 Support Local Offline Model Directory Session
+
+## Scope
+
+This session resumed after `PR #93` for `E4-S3` was squashed and merged, and
+issue `#34` was closed. Work started from updated `main` on branch
+`feature/35-support-local-offline-model-directory` for issue `#35`, `E4-S4:
+Support local offline model directory`.
+
+The story goal was intentionally narrow: make `first_crack.local_model_dir`
+resolve released first-crack artifacts from local storage without Hugging Face
+network access, using the existing E4-S1 through E4-S3 artifact resolver and
+ONNX filename selection boundary. The work did not add model training, ONNX
+export, Hugging Face sync, detector startup, audio capture, broad artifact
+validation, local directory sync behavior, or MCP session integration.
+
+## Context Usage
+
+Session usage snapshot supplied by the operator after PR creation:
+
+- Context window: `69% left (88.5K used / 258K)`
+- 5h limit: `93% left`, resets `17:12`
+- Weekly limit: `98% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `21:18`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `16:18 on 24 May`
+
+## Pre-Story Verification
+
+Before starting E4-S4:
+
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding to the E4-S3 squash
+  merge commit `ce4a3f91668aa90205813e3207c595ecf21c5cbc`.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-17-e4-s3-load-fp32-onnx-by-config.md`,
+  and GitHub issue `#35`.
+- Confirmed issue `#35` required `local_model_dir` to work without Hugging Face
+  network access, missing local artifacts to fail clearly, and offline local
+  directory tests.
+
+## Implementation
+
+Updated:
+
+- `src/coffee_roaster_mcp/artifacts.py`
+- `tests/test_artifacts.py`
+
+Behavior added:
+
+- `resolve_hugging_face_artifact(...)` now validates the repository-relative
+  artifact filename, then checks `FirstCrackConfig.local_model_dir`.
+- When `local_model_dir` is configured, the resolver joins the local directory
+  with the same repository-relative artifact path used for released Hub
+  artifacts.
+- Local resolution returns `ResolvedArtifact` without calling the Hugging Face
+  downloader.
+- Missing local files raise `ArtifactResolutionError` with the repository-
+  relative filename, configured local directory, and computed local path.
+- When `local_model_dir` is unset, existing Hugging Face Hub resolution behavior
+  is unchanged.
+
+The existing E4-S2/E4-S3 ONNX selector continues to choose:
+
+- `onnx/int8/model_quantized.onnx` for `precision="int8"`
+- `onnx/fp32/model.onnx` for `precision="fp32"`
+
+## Tests
+
+Added offline resolver coverage for:
+
+- default INT8 ONNX local model selection without downloader use
+- configured FP32 ONNX local model selection without downloader use
+- missing local ONNX model failure before downloader use
+
+## Documentation And State
+
+Updated durable project state:
+
+- `docs/state/registry.md` now marks E4-S4 complete and points next at E4-S5.
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E4-S4` complete,
+  records the local directory resolver decision, and adds validation notes.
+
+## Pull Request
+
+Opened `PR #94`: <https://github.com/syamaner/coffee-roaster-mcp/pull/94>
+
+PR branch:
+
+- `feature/35-support-local-offline-model-directory`
+
+Implementation commit before this session-summary update:
+
+- `c34048b8c8a1ff646f21b408049163fdb43f4f41` -
+  `feat: resolve local first crack artifacts`
+
+PR status before this session-summary update:
+
+- state: open
+- draft: false
+- mergeable: yes
+- head: `c34048b8c8a1ff646f21b408049163fdb43f4f41`
+- GitHub Actions `Checks`: passed
+- GitHub Actions `Build Package`: passed
+
+Issue `#35` was commented with what changed and how it was tested.
+
+## Validation
+
+Before opening PR #94:
+
+- Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: `18 passed`
+- Ran `./.venv/bin/python -m pytest`: `193 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+- Ran `git diff --check`: clean
+
+GitHub Actions after the implementation push:
+
+- `Checks`: passed
+- `Build Package`: passed
+
+## Handoff Notes
+
+After PR #94 merges:
+
+1. Sync `main`.
+2. Verify issue `#35` closes.
+3. Begin E4-S5 from updated `main`.
+4. Keep E4-S5 scoped to validating required detector artifacts before detection
+   starts.
+
+Do not add model training, ONNX export, Hugging Face sync, detector startup
+beyond validation prerequisites, audio capture, local directory sync behavior,
+or MCP session integration as part of E4-S5 unless the story scope explicitly
+changes.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4-S4`
-- Current target: Support local offline model directory
+- Active story: `E4-S5`
+- Current target: Validate required detector artifacts before detection starts
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -58,6 +58,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E4-S1` adds only a narrow Hugging Face Hub artifact resolver. It resolves repository-relative released files from the configured first-crack repo and revision, uses `huggingface_hub` as a declared runtime dependency, and leaves precision-specific ONNX selection, local offline directories, artifact validation, detector startup, and session-timeline integration to later Epic 4 stories.
 - `E4-S2` resolves the configured first-crack ONNX model for default `int8` precision by selecting `onnx/int8/model_quantized.onnx` through the E4-S1 Hugging Face artifact resolver. FP32 selection, local offline directories, artifact validation, detector startup, audio capture, and session-timeline integration remain later Epic 4 work.
 - `E4-S3` resolves the configured first-crack ONNX model for `fp32` precision by selecting `onnx/fp32/model.onnx` through the E4-S1/E4-S2 resolver boundary. Local offline directories, artifact validation, detector startup, audio capture, and session-timeline integration remain later Epic 4 work.
+- `E4-S4` resolves configured first-crack artifacts from `first_crack.local_model_dir` before any Hugging Face Hub download. The local path uses the same repository-relative artifact names as the released Hub layout, fails clearly when the target local file is missing, and leaves broader detector artifact validation, detector startup, audio capture, and session-timeline integration to later Epic 4 work.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -210,7 +211,7 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 - [x] `E4-S3` Load FP32 ONNX by config.
   - Done when `onnx/fp32/model.onnx` is selected for `precision: fp32`.
 
-- [ ] `E4-S4` Support local offline model directory.
+- [x] `E4-S4` Support local offline model directory.
   - Done when `local_model_dir` works without Hugging Face network access.
 
 - [ ] `E4-S5` Validate required detector artifacts before detection starts.
@@ -680,3 +681,9 @@ After completing a story:
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E4-S4:
+  - Updated the first-crack artifact resolver to prefer `FirstCrackConfig.local_model_dir` when configured, resolving the same repository-relative artifact filenames from local storage before any Hugging Face Hub download.
+  - Missing local artifacts now raise `ArtifactResolutionError` with the repository-relative filename, configured local directory, and computed local path.
+  - Preserved existing Hugging Face Hub behavior when `local_model_dir` is unset and kept model training, ONNX export, Hugging Face sync, detector startup, audio capture, broad artifact validation, and MCP/session integration out of scope.
+  - Added offline resolver tests for default INT8 local model selection, FP32 local model selection, and missing local model failures before downloader use.
+  - Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: 18 passed.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -30,14 +30,18 @@ drop and emergency stop included. A follow-up 60-second stability test also held
 fan at `10%`, heat at `40%` for 30 seconds, then heat at `100%` for 30 seconds
 with continuous command streaming and no command-loop or status-read errors.
 
-E4-S3 is complete. The first-crack path now resolves the configured ONNX model
+E4-S4 is complete. The first-crack path now resolves the configured ONNX model
 artifact for both supported real-model precisions: `int8` selects
 `onnx/int8/model_quantized.onnx`, and `fp32` selects `onnx/fp32/model.onnx`
-through the Hugging Face artifact resolver. This does not add model training,
-export, sync, detector startup, audio capture, local offline directories, or MCP
-session behavior.
+through the artifact resolver. When `first_crack.local_model_dir` is configured,
+the same repository-relative artifact names resolve from that local directory
+without Hugging Face network access, and missing local files fail with a clear
+artifact resolution error. This does not add model training, export, sync,
+detector startup, audio capture, broad artifact validation, or MCP session
+behavior.
 
-The next story is E4-S4: support local offline model directory.
+The next story is E4-S5: validate required detector artifacts before detection
+starts.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/artifacts.py
+++ b/src/coffee_roaster_mcp/artifacts.py
@@ -40,7 +40,7 @@ class ResolvedArtifact:
         repo_id: Hugging Face repository that supplied the artifact.
         revision: Configured repository revision, or `None` for the Hub default.
         filename: Repository-relative artifact path.
-        local_path: Local cache path returned by the Hugging Face Hub client.
+        local_path: Local filesystem path for the resolved artifact.
     """
 
     repo_id: str
@@ -55,10 +55,10 @@ def resolve_hugging_face_artifact(
     *,
     downloader: HuggingFaceDownloader | None = None,
 ) -> ResolvedArtifact:
-    """Resolve one released first-crack artifact from Hugging Face Hub.
+    """Resolve one released first-crack artifact from local storage or Hugging Face Hub.
 
     Args:
-        config: First-crack configuration containing the model repo and revision.
+        config: First-crack configuration containing local directory, model repo, and revision.
         filename: Repository-relative artifact path to resolve.
         downloader: Optional test double for the Hugging Face download call.
 
@@ -69,6 +69,15 @@ def resolve_hugging_face_artifact(
         ArtifactResolutionError: If the filename is invalid or the download fails.
     """
     normalized_filename = _validate_hub_filename(filename)
+    if config.local_model_dir is not None:
+        local_path = _resolve_local_artifact(config.local_model_dir, normalized_filename)
+        return ResolvedArtifact(
+            repo_id=config.repo_id,
+            revision=config.revision,
+            filename=normalized_filename,
+            local_path=local_path,
+        )
+
     download = _hf_hub_download if downloader is None else downloader
 
     try:
@@ -144,6 +153,17 @@ def _validate_hub_filename(filename: str) -> str:
             "Hugging Face artifact filename must be a repository-relative path."
         )
     return path.as_posix()
+
+
+def _resolve_local_artifact(local_model_dir: Path, filename: str) -> Path:
+    local_path = local_model_dir.joinpath(*PurePosixPath(filename).parts)
+    if not local_path.is_file():
+        raise ArtifactResolutionError(
+            "Could not resolve local first-crack artifact "
+            f"{filename!r} from local_model_dir {str(local_model_dir)!r}: "
+            f"{local_path} is not a file."
+        )
+    return local_path
 
 
 def _hf_hub_download(

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -112,6 +112,56 @@ def test_resolves_fp32_onnx_model_for_configured_precision() -> None:
     ]
 
 
+def test_resolves_onnx_model_from_local_model_dir_without_download(tmp_path: Path) -> None:
+    local_model_path = tmp_path / "onnx" / "int8" / "model_quantized.onnx"
+    local_model_path.parent.mkdir(parents=True)
+    local_model_path.write_bytes(b"onnx")
+    downloader = RecordingDownloader()
+
+    artifact = resolve_first_crack_onnx_model(
+        FirstCrackConfig(local_model_dir=tmp_path, revision="v0.1.0"),
+        downloader=downloader,
+    )
+
+    assert artifact.filename == INT8_ONNX_MODEL_FILENAME
+    assert artifact.local_path == local_model_path
+    assert artifact.repo_id == "syamaner/coffee-first-crack-detection"
+    assert artifact.revision == "v0.1.0"
+    assert downloader.calls == []
+
+
+def test_resolves_fp32_onnx_model_from_local_model_dir(tmp_path: Path) -> None:
+    local_model_path = tmp_path / "onnx" / "fp32" / "model.onnx"
+    local_model_path.parent.mkdir(parents=True)
+    local_model_path.write_bytes(b"onnx")
+    downloader = RecordingDownloader()
+
+    artifact = resolve_first_crack_onnx_model(
+        FirstCrackConfig(precision="fp32", local_model_dir=tmp_path),
+        downloader=downloader,
+    )
+
+    assert artifact.filename == FP32_ONNX_MODEL_FILENAME
+    assert artifact.local_path == local_model_path
+    assert downloader.calls == []
+
+
+def test_missing_local_onnx_model_fails_before_download(tmp_path: Path) -> None:
+    downloader = RecordingDownloader()
+
+    with pytest.raises(ArtifactResolutionError) as exc_info:
+        resolve_first_crack_onnx_model(
+            FirstCrackConfig(local_model_dir=tmp_path),
+            downloader=downloader,
+        )
+
+    message = str(exc_info.value)
+    assert "local first-crack artifact" in message
+    assert "onnx/int8/model_quantized.onnx" in message
+    assert str(tmp_path) in message
+    assert downloader.calls == []
+
+
 def test_unsupported_onnx_precision_fails_before_download() -> None:
     downloader = RecordingDownloader()
 


### PR DESCRIPTION
## Summary
- resolve configured first-crack artifacts from `first_crack.local_model_dir` before any Hugging Face Hub download
- keep INT8 and FP32 ONNX selection on the existing E4-S1 through E4-S3 repository-relative artifact boundary
- raise `ArtifactResolutionError` with clear local path context when a configured local artifact is missing
- update durable state docs for E4-S4 completion and E4-S5 handoff

## Scope Notes
- No model training, ONNX export, Hugging Face sync, detector startup, audio capture, broad artifact validation, or session timeline integration added.
- Preserves existing Hugging Face Hub behavior when `local_model_dir` is unset.

## Validation
- `./.venv/bin/python -m pytest tests/test_artifacts.py`: 18 passed
- `./.venv/bin/python -m pytest`: 193 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: passed
- `./.venv/bin/python -m pyright`: 0 errors
- `git diff --check`: clean

Closes #35