### PR TITLE
E4-S5: Validate required detector artifacts

### DIFF
--- a/docs/session-summaries/2026-05-17-e4-s5-validate-required-detector-artifacts.md
+++ b/docs/session-summaries/2026-05-17-e4-s5-validate-required-detector-artifacts.md
@@ -1,0 +1,152 @@
+# E4-S5 Validate Required Detector Artifacts Session
+
+## Scope
+
+This session resumed after `PR #94` for `E4-S4` was squashed and merged, and
+issue `#35` was closed. Work started from updated `main` on branch
+`feature/36-validate-required-detector-artifacts` for issue `#36`, `E4-S5:
+Validate required detector artifacts before detection starts`.
+
+The story goal was intentionally narrow: validate the released first-crack
+detector artifact set before audio detection begins, using the existing E4-S1
+through E4-S4 resolver boundary. The work did not add model training, ONNX
+export, Hugging Face sync, detector startup beyond validation prerequisites,
+audio capture, local directory sync behavior, artifact content validation, or
+MCP session timeline integration.
+
+## Context Usage
+
+Session usage snapshot supplied by the operator after the review-fix push:
+
+- Context window: `54% left (126K used / 258K)`
+- 5h limit: `100% left`, resets `22:35`
+- Weekly limit: `98% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `21:32`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `16:32 on 24 May`
+- Warning: limits may be stale; run `/status` again shortly.
+
+## Pre-Story Verification
+
+Before starting E4-S5:
+
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding to the E4-S4 squash
+  merge commit `afe377f5460ec8dbbbb97aa2b2d57623d5d89c7b`.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-17-e4-s4-support-local-offline-model-directory.md`,
+  and GitHub issue `#36`.
+- Confirmed issue `#36` required missing ONNX model and missing feature
+  extractor files to fail clearly before audio detection begins, with missing
+  artifact tests.
+
+## Implementation
+
+Updated:
+
+- `src/coffee_roaster_mcp/artifacts.py`
+- `tests/test_artifacts.py`
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+Behavior added:
+
+- `resolve_first_crack_detector_artifacts(...)` is now the narrow pre-audio
+  detector artifact validation entry point.
+- The detector artifact set resolves the configured ONNX model plus the
+  precision-specific feature extractor preprocessor config.
+- INT8 validation resolves:
+  - `onnx/int8/model_quantized.onnx`
+  - `onnx/int8/preprocessor_config.json`
+- FP32 validation resolves:
+  - `onnx/fp32/model.onnx`
+  - `onnx/fp32/preprocessor_config.json`
+- Missing ONNX model artifacts fail before feature extractor resolution.
+- Missing feature extractor config artifacts fail with repository, revision,
+  and filename context.
+- Local offline directory behavior remains delegated to the existing resolver,
+  so local paths still resolve without Hugging Face network access.
+
+## Review Fix
+
+Copilot review on `PR #95` requested explicit coverage for a missing Hugging
+Face ONNX model through `resolve_first_crack_detector_artifacts(...)`, including
+proof that feature-extractor resolution is not attempted after the ONNX failure.
+
+Added:
+
+- `test_missing_hub_detector_onnx_model_fails_before_feature_extractor`
+
+Review-fix commit:
+
+- `da9440aa9ef29d670bdb812b016474733ab2c8b3` -
+  `test: cover missing hub detector onnx`
+
+The Copilot review thread was still marked unresolved in GitHub after the fix;
+it was not manually resolved or replied to.
+
+## Pull Request
+
+Opened `PR #95`: <https://github.com/syamaner/coffee-roaster-mcp/pull/95>
+
+PR branch:
+
+- `feature/36-validate-required-detector-artifacts`
+
+Implementation commit:
+
+- `89e5c710838aad0a807e06b27a295b1f6033180b` -
+  `feat: validate first crack detector artifacts`
+
+Review-fix commit:
+
+- `da9440aa9ef29d670bdb812b016474733ab2c8b3` -
+  `test: cover missing hub detector onnx`
+
+PR status before this context-summary update:
+
+- state: open
+- draft: false
+- mergeable: yes
+- head: `da9440aa9ef29d670bdb812b016474733ab2c8b3`
+- GitHub Actions `Build Package`: passed
+- GitHub Actions `Checks`: passed
+
+Issue `#36` was commented with what changed and how it was tested.
+
+## Validation
+
+Before opening PR #95:
+
+- Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: `24 passed`
+- Ran `./.venv/bin/python -m pytest`: `199 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+
+After the review-fix commit:
+
+- Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: `25 passed`
+- Ran `./.venv/bin/python -m pytest`: `200 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+
+GitHub Actions after the review-fix push:
+
+- `Build Package`: passed
+- `Checks`: passed
+
+## Handoff Notes
+
+After PR #95 merges:
+
+1. Sync `main`.
+2. Verify issue `#36` closes.
+3. Begin E4-S6 from updated `main`.
+4. Keep E4-S6 scoped to the audio capture pipeline.
+
+Do not add model training, ONNX export, Hugging Face sync, detector adapter
+behavior beyond what E4-S6 explicitly requires, local directory sync behavior,
+or MCP session timeline integration as part of E4-S6 unless the story scope
+explicitly changes.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4-S5`
-- Current target: Validate required detector artifacts before detection starts
+- Active story: `E4-S6`
+- Current target: Add audio capture pipeline
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -59,6 +59,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E4-S2` resolves the configured first-crack ONNX model for default `int8` precision by selecting `onnx/int8/model_quantized.onnx` through the E4-S1 Hugging Face artifact resolver. FP32 selection, local offline directories, artifact validation, detector startup, audio capture, and session-timeline integration remain later Epic 4 work.
 - `E4-S3` resolves the configured first-crack ONNX model for `fp32` precision by selecting `onnx/fp32/model.onnx` through the E4-S1/E4-S2 resolver boundary. Local offline directories, artifact validation, detector startup, audio capture, and session-timeline integration remain later Epic 4 work.
 - `E4-S4` resolves configured first-crack artifacts from `first_crack.local_model_dir` before any Hugging Face Hub download. The local path uses the same repository-relative artifact names as the released Hub layout, fails clearly when the target local file is missing, and leaves broader detector artifact validation, detector startup, audio capture, and session-timeline integration to later Epic 4 work.
+- `E4-S5` validates the required first-crack detector artifact set through the existing resolver boundary before audio detection begins. The validation resolves the configured ONNX model plus `onnx/int8/preprocessor_config.json` or `onnx/fp32/preprocessor_config.json`, depending on precision, and keeps detector startup, audio capture, artifact content validation, and session-timeline integration out of scope.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -214,7 +215,7 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 - [x] `E4-S4` Support local offline model directory.
   - Done when `local_model_dir` works without Hugging Face network access.
 
-- [ ] `E4-S5` Validate required detector artifacts before detection starts.
+- [x] `E4-S5` Validate required detector artifacts before detection starts.
   - Done when missing ONNX model or feature extractor files fail clearly before audio detection begins.
 
 - [ ] `E4-S6` Add audio capture pipeline.
@@ -687,3 +688,9 @@ After completing a story:
   - Preserved existing Hugging Face Hub behavior when `local_model_dir` is unset and kept model training, ONNX export, Hugging Face sync, detector startup, audio capture, broad artifact validation, and MCP/session integration out of scope.
   - Added offline resolver tests for default INT8 local model selection, FP32 local model selection, and missing local model failures before downloader use.
   - Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: 18 passed.
+- Validation run for E4-S5:
+  - Added `ResolvedDetectorArtifacts` and `resolve_first_crack_detector_artifacts(...)` as the narrow pre-audio detector artifact validation entry point.
+  - The detector artifact resolver validates the configured ONNX model plus the precision-specific feature extractor preprocessor config: `onnx/int8/preprocessor_config.json` for INT8 and `onnx/fp32/preprocessor_config.json` for FP32.
+  - Missing ONNX models fail before feature extractor resolution, and missing feature extractor configs fail with repository, revision, and filename context while preserving local offline directory behavior.
+  - Kept model training, ONNX export, Hugging Face sync, detector startup beyond validation prerequisites, audio capture, local directory sync behavior, artifact content validation, and MCP/session integration out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: 24 passed.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -30,18 +30,20 @@ drop and emergency stop included. A follow-up 60-second stability test also held
 fan at `10%`, heat at `40%` for 30 seconds, then heat at `100%` for 30 seconds
 with continuous command streaming and no command-loop or status-read errors.
 
-E4-S4 is complete. The first-crack path now resolves the configured ONNX model
+E4-S5 is complete. The first-crack path now resolves the configured ONNX model
 artifact for both supported real-model precisions: `int8` selects
 `onnx/int8/model_quantized.onnx`, and `fp32` selects `onnx/fp32/model.onnx`
 through the artifact resolver. When `first_crack.local_model_dir` is configured,
 the same repository-relative artifact names resolve from that local directory
 without Hugging Face network access, and missing local files fail with a clear
-artifact resolution error. This does not add model training, export, sync,
-detector startup, audio capture, broad artifact validation, or MCP session
-behavior.
+artifact resolution error. Detector artifact validation now resolves both the
+selected ONNX model and the precision-specific
+`onnx/{precision}/preprocessor_config.json` feature extractor config before
+audio detection begins. This does not add model training, export, sync, detector
+startup beyond validation prerequisites, audio capture, local directory sync, or
+MCP session behavior.
 
-The next story is E4-S5: validate required detector artifacts before detection
-starts.
+The next story is E4-S6: add audio capture pipeline.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/artifacts.py
+++ b/src/coffee_roaster_mcp/artifacts.py
@@ -12,6 +12,8 @@ from coffee_roaster_mcp.config import FirstCrackConfig
 
 INT8_ONNX_MODEL_FILENAME = "onnx/int8/model_quantized.onnx"
 FP32_ONNX_MODEL_FILENAME = "onnx/fp32/model.onnx"
+INT8_FEATURE_EXTRACTOR_FILENAME = "onnx/int8/preprocessor_config.json"
+FP32_FEATURE_EXTRACTOR_FILENAME = "onnx/fp32/preprocessor_config.json"
 
 
 class ArtifactResolutionError(RuntimeError):
@@ -47,6 +49,20 @@ class ResolvedArtifact:
     revision: str | None
     filename: str
     local_path: Path
+
+
+@dataclass(frozen=True)
+class ResolvedDetectorArtifacts:
+    """Resolved first-crack detector artifact set.
+
+    Attributes:
+        onnx_model: Resolved ONNX model artifact for the configured precision.
+        feature_extractor_config: Resolved feature extractor preprocessor config
+            artifact for the configured precision.
+    """
+
+    onnx_model: ResolvedArtifact
+    feature_extractor_config: ResolvedArtifact
 
 
 def resolve_hugging_face_artifact(
@@ -136,6 +152,51 @@ def resolve_first_crack_onnx_model(
         filename,
         downloader=downloader,
     )
+
+
+def resolve_first_crack_detector_artifacts(
+    config: FirstCrackConfig,
+    *,
+    downloader: HuggingFaceDownloader | None = None,
+) -> ResolvedDetectorArtifacts:
+    """Resolve required first-crack detector artifacts before detection starts.
+
+    Args:
+        config: First-crack configuration containing precision, repo, revision,
+            and optional local model directory.
+        downloader: Optional test double for the Hugging Face download call.
+
+    Returns:
+        Metadata for the resolved ONNX model and feature extractor artifacts.
+
+    Raises:
+        ArtifactResolutionError: If the configured precision is unsupported or
+            any required detector artifact cannot be resolved.
+    """
+    onnx_model = resolve_first_crack_onnx_model(config, downloader=downloader)
+    feature_extractor_config = resolve_hugging_face_artifact(
+        config,
+        _feature_extractor_filename_for_precision(config),
+        downloader=downloader,
+    )
+    return ResolvedDetectorArtifacts(
+        onnx_model=onnx_model,
+        feature_extractor_config=feature_extractor_config,
+    )
+
+
+def _feature_extractor_filename_for_precision(config: FirstCrackConfig) -> str:
+    precision = str(config.precision)
+    match precision:
+        case "int8":
+            return INT8_FEATURE_EXTRACTOR_FILENAME
+        case "fp32":
+            return FP32_FEATURE_EXTRACTOR_FILENAME
+        case unsupported_precision:
+            raise ArtifactResolutionError(
+                "Unsupported first-crack feature extractor precision "
+                f"{unsupported_precision!r}; expected 'int8' or 'fp32'."
+            )
 
 
 def _validate_hub_filename(filename: str) -> str:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -256,6 +256,45 @@ def test_missing_local_detector_onnx_model_fails_before_feature_extractor(
     assert downloader.calls == []
 
 
+def test_missing_hub_detector_onnx_model_fails_before_feature_extractor() -> None:
+    calls: list[dict[str, str | None]] = []
+
+    def missing_onnx_downloader(
+        *,
+        repo_id: str,
+        filename: str,
+        revision: str | None,
+    ) -> str:
+        calls.append(
+            {
+                "repo_id": repo_id,
+                "filename": filename,
+                "revision": revision,
+            }
+        )
+        if filename == INT8_ONNX_MODEL_FILENAME:
+            raise RuntimeError("not found")
+        return "/tmp/hf-cache/preprocessor_config.json"
+
+    with pytest.raises(ArtifactResolutionError) as exc_info:
+        resolve_first_crack_detector_artifacts(
+            FirstCrackConfig(revision="pinned-release"),
+            downloader=missing_onnx_downloader,
+        )
+
+    message = str(exc_info.value)
+    assert "onnx/int8/model_quantized.onnx" in message
+    assert "syamaner/coffee-first-crack-detection" in message
+    assert "pinned-release" in message
+    assert calls == [
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "onnx/int8/model_quantized.onnx",
+            "revision": "pinned-release",
+        },
+    ]
+
+
 def test_missing_local_feature_extractor_fails_before_download(tmp_path: Path) -> None:
     local_model_path = tmp_path / "onnx" / "int8" / "model_quantized.onnx"
     local_model_path.parent.mkdir(parents=True)

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -4,9 +4,12 @@ from typing import cast
 import pytest
 
 from coffee_roaster_mcp.artifacts import (
+    FP32_FEATURE_EXTRACTOR_FILENAME,
     FP32_ONNX_MODEL_FILENAME,
+    INT8_FEATURE_EXTRACTOR_FILENAME,
     INT8_ONNX_MODEL_FILENAME,
     ArtifactResolutionError,
+    resolve_first_crack_detector_artifacts,
     resolve_first_crack_onnx_model,
     resolve_hugging_face_artifact,
 )
@@ -146,6 +149,76 @@ def test_resolves_fp32_onnx_model_from_local_model_dir(tmp_path: Path) -> None:
     assert downloader.calls == []
 
 
+def test_resolves_detector_artifacts_for_default_int8_precision() -> None:
+    downloader = RecordingDownloader()
+
+    artifacts = resolve_first_crack_detector_artifacts(
+        FirstCrackConfig(revision="v0.1.0"),
+        downloader=downloader,
+    )
+
+    assert artifacts.onnx_model.filename == INT8_ONNX_MODEL_FILENAME
+    assert artifacts.feature_extractor_config.filename == INT8_FEATURE_EXTRACTOR_FILENAME
+    assert artifacts.onnx_model.revision == "v0.1.0"
+    assert artifacts.feature_extractor_config.revision == "v0.1.0"
+    assert downloader.calls == [
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "onnx/int8/model_quantized.onnx",
+            "revision": "v0.1.0",
+        },
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "onnx/int8/preprocessor_config.json",
+            "revision": "v0.1.0",
+        },
+    ]
+
+
+def test_resolves_detector_artifacts_for_configured_fp32_precision() -> None:
+    downloader = RecordingDownloader()
+
+    artifacts = resolve_first_crack_detector_artifacts(
+        FirstCrackConfig(precision="fp32"),
+        downloader=downloader,
+    )
+
+    assert artifacts.onnx_model.filename == FP32_ONNX_MODEL_FILENAME
+    assert artifacts.feature_extractor_config.filename == FP32_FEATURE_EXTRACTOR_FILENAME
+    assert downloader.calls == [
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "onnx/fp32/model.onnx",
+            "revision": None,
+        },
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "onnx/fp32/preprocessor_config.json",
+            "revision": None,
+        },
+    ]
+
+
+def test_resolves_detector_artifacts_from_local_model_dir_without_download(
+    tmp_path: Path,
+) -> None:
+    local_model_path = tmp_path / "onnx" / "int8" / "model_quantized.onnx"
+    local_preprocessor_path = tmp_path / "onnx" / "int8" / "preprocessor_config.json"
+    local_model_path.parent.mkdir(parents=True)
+    local_model_path.write_bytes(b"onnx")
+    local_preprocessor_path.write_text("{}", encoding="utf-8")
+    downloader = RecordingDownloader()
+
+    artifacts = resolve_first_crack_detector_artifacts(
+        FirstCrackConfig(local_model_dir=tmp_path),
+        downloader=downloader,
+    )
+
+    assert artifacts.onnx_model.local_path == local_model_path
+    assert artifacts.feature_extractor_config.local_path == local_preprocessor_path
+    assert downloader.calls == []
+
+
 def test_missing_local_onnx_model_fails_before_download(tmp_path: Path) -> None:
     downloader = RecordingDownloader()
 
@@ -160,6 +233,90 @@ def test_missing_local_onnx_model_fails_before_download(tmp_path: Path) -> None:
     assert "onnx/int8/model_quantized.onnx" in message
     assert str(tmp_path) in message
     assert downloader.calls == []
+
+
+def test_missing_local_detector_onnx_model_fails_before_feature_extractor(
+    tmp_path: Path,
+) -> None:
+    local_preprocessor_path = tmp_path / "onnx" / "int8" / "preprocessor_config.json"
+    local_preprocessor_path.parent.mkdir(parents=True)
+    local_preprocessor_path.write_text("{}", encoding="utf-8")
+    downloader = RecordingDownloader()
+
+    with pytest.raises(ArtifactResolutionError) as exc_info:
+        resolve_first_crack_detector_artifacts(
+            FirstCrackConfig(local_model_dir=tmp_path),
+            downloader=downloader,
+        )
+
+    message = str(exc_info.value)
+    assert "local first-crack artifact" in message
+    assert "onnx/int8/model_quantized.onnx" in message
+    assert "preprocessor_config.json" not in message
+    assert downloader.calls == []
+
+
+def test_missing_local_feature_extractor_fails_before_download(tmp_path: Path) -> None:
+    local_model_path = tmp_path / "onnx" / "int8" / "model_quantized.onnx"
+    local_model_path.parent.mkdir(parents=True)
+    local_model_path.write_bytes(b"onnx")
+    downloader = RecordingDownloader()
+
+    with pytest.raises(ArtifactResolutionError) as exc_info:
+        resolve_first_crack_detector_artifacts(
+            FirstCrackConfig(local_model_dir=tmp_path),
+            downloader=downloader,
+        )
+
+    message = str(exc_info.value)
+    assert "local first-crack artifact" in message
+    assert "onnx/int8/preprocessor_config.json" in message
+    assert str(tmp_path) in message
+    assert downloader.calls == []
+
+
+def test_missing_hub_feature_extractor_includes_artifact_context() -> None:
+    calls: list[dict[str, str | None]] = []
+
+    def missing_feature_extractor_downloader(
+        *,
+        repo_id: str,
+        filename: str,
+        revision: str | None,
+    ) -> str:
+        calls.append(
+            {
+                "repo_id": repo_id,
+                "filename": filename,
+                "revision": revision,
+            }
+        )
+        if filename == INT8_FEATURE_EXTRACTOR_FILENAME:
+            raise RuntimeError("not found")
+        return "/tmp/hf-cache/model_quantized.onnx"
+
+    with pytest.raises(ArtifactResolutionError) as exc_info:
+        resolve_first_crack_detector_artifacts(
+            FirstCrackConfig(revision="pinned-release"),
+            downloader=missing_feature_extractor_downloader,
+        )
+
+    message = str(exc_info.value)
+    assert "onnx/int8/preprocessor_config.json" in message
+    assert "syamaner/coffee-first-crack-detection" in message
+    assert "pinned-release" in message
+    assert calls == [
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "onnx/int8/model_quantized.onnx",
+            "revision": "pinned-release",
+        },
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "onnx/int8/preprocessor_config.json",
+            "revision": "pinned-release",
+        },
+    ]
 
 
 def test_unsupported_onnx_precision_fails_before_download() -> None:


### PR DESCRIPTION
## Summary
- add a detector-level artifact resolver that validates the configured ONNX model and precision-specific feature extractor config before audio detection starts
- resolve INT8 artifacts from `onnx/int8/model_quantized.onnx` and `onnx/int8/preprocessor_config.json`, and FP32 artifacts from `onnx/fp32/model.onnx` and `onnx/fp32/preprocessor_config.json`
- cover missing ONNX and missing feature extractor failures for local and Hugging Face resolver paths
- update durable state docs to mark E4-S5 complete and advance to E4-S6

## Review Fix
- add coverage for a missing Hugging Face ONNX model through `resolve_first_crack_detector_artifacts(...)`, proving feature-extractor resolution is not attempted after the ONNX failure

## Scope Notes
- preserves the existing E4-S1 through E4-S4 resolver boundary
- does not add model training, ONNX export, Hugging Face sync, detector startup beyond validation prerequisites, audio capture, local directory sync behavior, artifact content validation, or session timeline integration
- preserves the Epic 2 one-session store boundary, MCP semantics, mock-safe defaults, coverage workflow, and Epic 3 Hottop safety/validation boundary

## Validation
- `./.venv/bin/python -m pytest tests/test_artifacts.py`: 25 passed
- `./.venv/bin/python -m pytest`: 200 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: passed
- `./.venv/bin/python -m pyright`: 0 errors
- GitHub Actions `Build Package`: passed
- GitHub Actions `Checks`: passed

Closes #36
