### PR TITLE
E4-S6: Add audio capture pipeline

### DIFF
--- a/docs/session-summaries/2026-05-17-e4-s6-add-audio-capture-pipeline.md
+++ b/docs/session-summaries/2026-05-17-e4-s6-add-audio-capture-pipeline.md
@@ -1,0 +1,211 @@
+# E4-S6 Add Audio Capture Pipeline Session
+
+## Scope
+
+This session resumed after `PR #95` for `E4-S5` was squashed and merged, and
+issue `#36` was closed. Work started from updated `main` on branch
+`feature/37-add-audio-capture-pipeline` for issue `#37`, `E4-S6: Add audio
+capture pipeline`.
+
+The story goal was intentionally narrow: add the audio capture pipeline only,
+so configured audio input can feed detector windows without blocking roaster
+telemetry. The work preserved the Epic 2 one-session store boundary, MCP
+semantics, mock-safe defaults, coverage workflow, Epic 3 Hottop
+safety/validation boundary, and the E4-S1 through E4-S5 released-artifact
+resolver/validation boundary.
+
+The work did not add model training, ONNX export, Hugging Face sync, detector
+adapter behavior, ONNX inference, local directory sync behavior, first-crack
+session timeline integration, live microphone backend selection, or live Hottop
+control changes.
+
+## Context Usage
+
+Session usage snapshot supplied by the operator after the review-fix push:
+
+- Context window: `37% left (168K used / 258K)`
+- 5h limit: `98% left`, resets `22:35`
+- Weekly limit: `98% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `23:13`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `18:13 on 24 May`
+- Warning: limits may be stale; run `/status` again shortly.
+
+## Pre-Story Verification
+
+Before starting E4-S6:
+
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding to the E4-S5 squash
+  merge commit `b4b07a76725dd9e3bc0a31a0cb8295562e11d853`.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-17-e4-s5-validate-required-detector-artifacts.md`,
+  and GitHub issue `#37`.
+- Confirmed issue `#37` required configured audio input to feed detector
+  windows without blocking roaster telemetry, with mocked audio pipeline tests.
+
+## Implementation
+
+Updated:
+
+- `src/coffee_roaster_mcp/audio.py`
+- `tests/test_audio.py`
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+- `docs/state/github-issues.md`
+
+Behavior added:
+
+- `AudioInput` and `AudioInputFactory` protocols define the audio-source
+  boundary for later microphone and WAV implementations.
+- `AudioCaptureSettings` builds validated capture settings from `AudioConfig`.
+- `AudioWindow` represents a complete mono detector window.
+- `AudioCapturePipeline` runs audio reads on a daemon worker thread and emits
+  one-second detector windows at the configured sample rate.
+- Detector-window handoff uses a bounded queue with `put_nowait`; if the
+  downstream detector queue is full, windows are dropped and counted instead of
+  blocking capture.
+- `build_audio_capture_pipeline(...)` constructs the pipeline from
+  configuration and an injected input factory.
+
+Tests added:
+
+- Config-driven audio source construction.
+- Invalid audio capture settings.
+- Mocked sample input windowing.
+- Bounded queue drop behavior.
+- Source error capture.
+- Double-start protection.
+- Finite sample validation.
+- Restart state reset.
+- Blocking detector consumer preservation across restart.
+
+## Planning Update
+
+During review discussion, the gap between the generic E4-S6 audio pipeline and
+concrete audio sources was made explicit:
+
+- Created GitHub issue `#97`: `E4-S8: Add microphone and WAV audio input
+  adapters`.
+- Renamed issue `#39` from `E4-S8` to `E4-S9: Integrate first crack with
+  session timeline`.
+- Updated Epic `#4` to list the sequence `E4-S7 -> E4-S8 -> E4-S9`.
+- Updated `docs/state/github-issues.md`, `docs/state/registry.md`, and
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md` with the new story ordering.
+
+The new `E4-S8` issue captures Linux/Raspberry Pi microphone behavior and WAV
+replay explicitly, keeping both behind the E4-S6 `AudioInput` boundary and out
+of E4-S7 detector-adapter scope.
+
+## Review Fixes
+
+First Codex review on `PR #96`:
+
+- Review URL:
+  <https://github.com/syamaner/coffee-roaster-mcp/pull/96#pullrequestreview-4305911152>
+- Finding: restarting a pipeline reused partial samples and sequence state from
+  the previous run.
+- Fix commit:
+  `becfd8343d59919b6be1b5fe3fe3e9068d705547` -
+  `fix: reset audio capture run state`
+- Fix: reset run-scoped state on each `AudioCapturePipeline.start()` so partial
+  samples, queued windows, sequence numbers, counters, and prior errors cannot
+  leak across stopped/restarted pipeline instances.
+- Added restart regression coverage.
+
+Second Codex review on `PR #96`:
+
+- Review URL:
+  <https://github.com/syamaner/coffee-roaster-mcp/pull/96#pullrequestreview-4305947834>
+- Finding: the first review fix replaced the queue object on restart, which
+  could strand detector consumers already blocked on the old queue.
+- Fix commit:
+  `bb790c00a7767f3c0bf2b1f1f37e1cb8c86ab750` -
+  `fix: keep audio queue stable on restart`
+- Fix: reset now drains and reuses the existing queue instead of replacing it.
+- Added blocking-consumer restart coverage proving a consumer waiting before
+  restart receives the next window after capture restarts.
+
+Both review threads were checked through thread-aware GitHub GraphQL reads and
+were marked resolved in GitHub after the fixes.
+
+## Pull Request
+
+Opened `PR #96`: <https://github.com/syamaner/coffee-roaster-mcp/pull/96>
+
+PR branch:
+
+- `feature/37-add-audio-capture-pipeline`
+
+Commits on the branch:
+
+- `c9a6a5fb9b01b3d522049d3efb5c51b7e35418c6` -
+  `feat: add audio capture pipeline`
+- `6d64d8f08a7ad3e84d1f9057aaddbf704bfeac32` -
+  `docs: insert audio input adapter story`
+- `becfd8343d59919b6be1b5fe3fe3e9068d705547` -
+  `fix: reset audio capture run state`
+- `bb790c00a7767f3c0bf2b1f1f37e1cb8c86ab750` -
+  `fix: keep audio queue stable on restart`
+
+PR status at the time this summary was written:
+
+- state: open
+- draft: false
+- mergeable: yes
+- head: `bb790c00a7767f3c0bf2b1f1f37e1cb8c86ab750`
+- GitHub Actions `Build Package`: passed
+- GitHub Actions `Checks`: passed
+
+Issue `#37` remains open and should close when PR #96 is merged through
+`Closes #37`.
+
+## Validation
+
+Initial E4-S6 implementation:
+
+- Ran `./.venv/bin/python -m pytest tests/test_audio.py`: `8 passed`
+- Ran `./.venv/bin/python -m pytest`: `208 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+
+After first review fix:
+
+- Ran `./.venv/bin/python -m pytest tests/test_audio.py`: `9 passed`
+- Ran `./.venv/bin/python -m pytest`: `209 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+
+After second review fix:
+
+- Ran `./.venv/bin/python -m pytest tests/test_audio.py`: `10 passed`
+- Ran `./.venv/bin/python -m pytest`: `210 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+
+GitHub Actions after the final review-fix push:
+
+- `Build Package`: passed
+- `Checks`: passed
+
+## Handoff Notes
+
+After PR #96 merges:
+
+1. Sync `main`.
+2. Verify issue `#37` closes.
+3. Begin E4-S7 from updated `main`.
+4. Keep E4-S7 scoped to the detector adapter only.
+
+Do not add concrete microphone/WAV adapters in E4-S7; those are now captured in
+`E4-S8` / issue `#97`. Do not add first-crack session timeline integration in
+E4-S7 or E4-S8; that remains `E4-S9` / issue `#39`.
+
+Suggested restart prompt after PR #96 is merged:
+
+```text
+Resume in /Users/sertanyamaner/git/coffee-roaster-mcp. PR #96 for E4-S6 was squashed and merged, and issue #37 is closed. First run git checkout main and git pull --ff-only origin main. Then read AGENTS.md, docs/state/registry.md, docs/state/epics/coffee-roaster-mcp-v0.1.md, docs/session-summaries/2026-05-17-e4-s6-add-audio-capture-pipeline.md, and GitHub issue #38. Begin E4-S7 from updated main on branch feature/38-add-detector-adapter. Keep scope to the detector adapter only. Preserve the Epic 2 one-session store boundary, MCP semantics, mock-safe defaults, coverage workflow, Epic 3 Hottop safety/validation boundary, and the E4-S1 through E4-S6 released-artifact and audio-pipeline boundaries. Do not add model training, ONNX export, Hugging Face sync, concrete microphone or WAV input adapters, local directory sync behavior, first-crack session timeline integration, or live Hottop control changes unless issue #38 explicitly requires it.
+```

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -710,6 +710,14 @@ After completing a story:
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- PR review fix for E4-S6:
+  - Reset audio capture run-scoped state on each `AudioCapturePipeline.start()` so partial samples, queued windows, sequence numbers, counters, and prior errors cannot leak across a stopped and restarted pipeline instance.
+  - Added a restart regression test proving leftover partial samples from the first run are not mixed into the first detector window of the next run, and sequence numbers restart from zero.
+  - Ran `./.venv/bin/python -m pytest tests/test_audio.py`: 9 passed.
+  - Ran `./.venv/bin/python -m pytest`: 209 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
 - Planning update after E4-S6:
   - Inserted `E4-S8` / issue `#97` for concrete microphone and recorded WAV audio input adapters after the detector adapter story and before session timeline integration.
   - Renamed the previous timeline integration issue `#39` to `E4-S9` so Raspberry Pi/Linux microphone behavior and recorded-session replay are captured explicitly before detector results are wired into the authoritative session timeline.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4-S6`
-- Current target: Add audio capture pipeline
+- Active story: `E4-S7`
+- Current target: Add detector adapter
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -60,6 +60,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E4-S3` resolves the configured first-crack ONNX model for `fp32` precision by selecting `onnx/fp32/model.onnx` through the E4-S1/E4-S2 resolver boundary. Local offline directories, artifact validation, detector startup, audio capture, and session-timeline integration remain later Epic 4 work.
 - `E4-S4` resolves configured first-crack artifacts from `first_crack.local_model_dir` before any Hugging Face Hub download. The local path uses the same repository-relative artifact names as the released Hub layout, fails clearly when the target local file is missing, and leaves broader detector artifact validation, detector startup, audio capture, and session-timeline integration to later Epic 4 work.
 - `E4-S5` validates the required first-crack detector artifact set through the existing resolver boundary before audio detection begins. The validation resolves the configured ONNX model plus `onnx/int8/preprocessor_config.json` or `onnx/fp32/preprocessor_config.json`, depending on precision, and keeps detector startup, audio capture, artifact content validation, and session-timeline integration out of scope.
+- `E4-S6` adds an injectable audio capture pipeline that builds its source from `AudioConfig`, reads on a background worker, frames complete one-second mono detector windows at the configured sample rate, and hands windows to a bounded non-blocking queue for the future detector adapter. Live audio backend selection, detector adapter behavior, model inference, and session-timeline integration remain later work.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -218,7 +219,7 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 - [x] `E4-S5` Validate required detector artifacts before detection starts.
   - Done when missing ONNX model or feature extractor files fail clearly before audio detection begins.
 
-- [ ] `E4-S6` Add audio capture pipeline.
+- [x] `E4-S6` Add audio capture pipeline.
   - Done when configured audio input can feed detector windows without blocking roaster telemetry.
 
 - [ ] `E4-S7` Add detector adapter.
@@ -694,3 +695,13 @@ After completing a story:
   - Missing ONNX models fail before feature extractor resolution, and missing feature extractor configs fail with repository, revision, and filename context while preserving local offline directory behavior.
   - Kept model training, ONNX export, Hugging Face sync, detector startup beyond validation prerequisites, audio capture, local directory sync behavior, artifact content validation, and MCP/session integration out of scope.
   - Ran `./.venv/bin/python -m pytest tests/test_artifacts.py`: 24 passed.
+- Validation run for E4-S6:
+  - Added `src/coffee_roaster_mcp/audio.py` with an injectable audio capture pipeline for future first-crack detector use.
+  - The pipeline builds validated capture settings from `AudioConfig`, passes the configured input device and sample rate into an injected input factory, reads samples on a daemon worker thread, and emits complete one-second mono `AudioWindow` detector windows.
+  - Detector-window handoff uses a bounded queue and `put_nowait`; when the detector side is full, windows are dropped and counted instead of blocking capture or roaster telemetry work elsewhere in the process.
+  - Kept live microphone backend selection, detector adapter behavior, ONNX inference, first-crack session timeline integration, model training, ONNX export, and Hugging Face sync out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_audio.py`: 8 passed.
+  - Ran `./.venv/bin/python -m pytest`: 208 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -61,6 +61,7 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E4-S4` resolves configured first-crack artifacts from `first_crack.local_model_dir` before any Hugging Face Hub download. The local path uses the same repository-relative artifact names as the released Hub layout, fails clearly when the target local file is missing, and leaves broader detector artifact validation, detector startup, audio capture, and session-timeline integration to later Epic 4 work.
 - `E4-S5` validates the required first-crack detector artifact set through the existing resolver boundary before audio detection begins. The validation resolves the configured ONNX model plus `onnx/int8/preprocessor_config.json` or `onnx/fp32/preprocessor_config.json`, depending on precision, and keeps detector startup, audio capture, artifact content validation, and session-timeline integration out of scope.
 - `E4-S6` adds an injectable audio capture pipeline that builds its source from `AudioConfig`, reads on a background worker, frames complete one-second mono detector windows at the configured sample rate, and hands windows to a bounded non-blocking queue for the future detector adapter. Live audio backend selection, detector adapter behavior, model inference, and session-timeline integration remain later work.
+- `E4-S8` is inserted after the detector adapter story to add concrete microphone and WAV audio input adapters behind the E4-S6 `AudioInput` boundary. This keeps Linux/Raspberry Pi microphone behavior and recorded-session replay explicit before first-crack events are wired into the session timeline in `E4-S9`.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -225,7 +226,10 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 - [ ] `E4-S7` Add detector adapter.
   - Done when detector output maps to a confirmed first-crack event with timestamp, precision, revision, and confidence when available.
 
-- [ ] `E4-S8` Integrate first crack with session timeline.
+- [ ] `E4-S8` Add microphone and WAV audio input adapters.
+  - Done when configured microphone and recorded WAV inputs can feed the detector window pipeline through the same audio source boundary.
+
+- [ ] `E4-S9` Integrate first crack with session timeline.
   - Done when mocked detector output creates exactly one `first_crack_detected` event.
 
 ### Epic Acceptance Criteria
@@ -233,6 +237,7 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 - INT8 resolver selects `onnx/int8/model_quantized.onnx`.
 - FP32 resolver selects `onnx/fp32/model.onnx`.
 - Offline local directory works without HF network access.
+- Configured microphone and WAV audio sources can feed the detector window pipeline.
 - Mocked detector output creates exactly one `first_crack_detected` event.
 
 ## Epic 5: Roast Metrics And Log Export
@@ -705,3 +710,7 @@ After completing a story:
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Planning update after E4-S6:
+  - Inserted `E4-S8` / issue `#97` for concrete microphone and recorded WAV audio input adapters after the detector adapter story and before session timeline integration.
+  - Renamed the previous timeline integration issue `#39` to `E4-S9` so Raspberry Pi/Linux microphone behavior and recorded-session replay are captured explicitly before detector results are wired into the authoritative session timeline.
+  - Updated Epic 4 acceptance criteria to include configured microphone and WAV sources feeding the detector window pipeline.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -713,8 +713,10 @@ After completing a story:
 - PR review fix for E4-S6:
   - Reset audio capture run-scoped state on each `AudioCapturePipeline.start()` so partial samples, queued windows, sequence numbers, counters, and prior errors cannot leak across a stopped and restarted pipeline instance.
   - Added a restart regression test proving leftover partial samples from the first run are not mixed into the first detector window of the next run, and sequence numbers restart from zero.
-  - Ran `./.venv/bin/python -m pytest tests/test_audio.py`: 9 passed.
-  - Ran `./.venv/bin/python -m pytest`: 209 passed.
+  - Kept the detector window queue stable across restarts by draining and reusing the existing queue instead of replacing it, so blocking detector consumers are not stranded on an old queue object.
+  - Added a blocking-consumer restart regression test proving a consumer waiting before restart receives the next window after capture restarts.
+  - Ran `./.venv/bin/python -m pytest tests/test_audio.py`: 10 passed.
+  - Ran `./.venv/bin/python -m pytest`: 210 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/github-issues.md
+++ b/docs/state/github-issues.md
@@ -57,7 +57,8 @@ Milestone: `v0.1`
 - #36 E4-S5: Validate required detector artifacts before detection starts
 - #37 E4-S6: Add audio capture pipeline
 - #38 E4-S7: Add detector adapter
-- #39 E4-S8: Integrate first crack with session timeline
+- #97 E4-S8: Add microphone and WAV audio input adapters
+- #39 E4-S9: Integrate first crack with session timeline
 
 ## Epic 5 Stories
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -47,6 +47,9 @@ model training, export, sync, detector adapter behavior, local directory sync,
 or MCP session behavior.
 
 The next story is E4-S7: add detector adapter.
+Epic 4 now includes a new E4-S8 story for concrete microphone and WAV audio
+input adapters before session timeline integration. The previous timeline
+integration story is now E4-S9.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -30,7 +30,7 @@ drop and emergency stop included. A follow-up 60-second stability test also held
 fan at `10%`, heat at `40%` for 30 seconds, then heat at `100%` for 30 seconds
 with continuous command streaming and no command-loop or status-read errors.
 
-E4-S5 is complete. The first-crack path now resolves the configured ONNX model
+E4-S6 is complete. The first-crack path now resolves the configured ONNX model
 artifact for both supported real-model precisions: `int8` selects
 `onnx/int8/model_quantized.onnx`, and `fp32` selects `onnx/fp32/model.onnx`
 through the artifact resolver. When `first_crack.local_model_dir` is configured,
@@ -39,11 +39,14 @@ without Hugging Face network access, and missing local files fail with a clear
 artifact resolution error. Detector artifact validation now resolves both the
 selected ONNX model and the precision-specific
 `onnx/{precision}/preprocessor_config.json` feature extractor config before
-audio detection begins. This does not add model training, export, sync, detector
-startup beyond validation prerequisites, audio capture, local directory sync, or
-MCP session behavior.
+audio detection begins. The audio capture path now has an injectable background
+pipeline that reads from the configured audio input, frames complete one-second
+mono detector windows at the configured sample rate, and hands windows to a
+bounded non-blocking queue for the future detector adapter. This does not add
+model training, export, sync, detector adapter behavior, local directory sync,
+or MCP session behavior.
 
-The next story is E4-S6: add audio capture pipeline.
+The next story is E4-S7: add detector adapter.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -1,0 +1,310 @@
+"""Audio capture windowing for first-crack detection."""
+
+from __future__ import annotations
+
+import math
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from queue import Empty, Full, Queue
+from threading import Event, Lock, Thread
+from typing import Protocol
+
+from coffee_roaster_mcp.config import AudioConfig
+
+DEFAULT_AUDIO_WINDOW_SECONDS = 1.0
+DEFAULT_AUDIO_WINDOW_QUEUE_LIMIT = 8
+DEFAULT_AUDIO_IDLE_SLEEP_SECONDS = 0.01
+
+
+class AudioCaptureError(RuntimeError):
+    """Raised when audio capture cannot be configured or run."""
+
+
+class AudioInput(Protocol):
+    """Readable audio input for detector-window capture."""
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        """Read up to `sample_count` mono floating-point samples."""
+        ...
+
+
+class AudioInputFactory(Protocol):
+    """Factory for configured audio inputs."""
+
+    def __call__(self, settings: AudioCaptureSettings) -> AudioInput:
+        """Create an audio input for the supplied capture settings."""
+        ...
+
+
+@dataclass(frozen=True)
+class AudioCaptureSettings:
+    """Runtime audio capture settings.
+
+    Attributes:
+        input_device: Optional configured audio input identifier.
+        sample_rate: Audio sample rate in Hz.
+        window_seconds: Detector window duration in seconds.
+        queue_limit: Maximum detector windows retained for downstream consumers.
+        idle_sleep_seconds: Sleep duration when an input read returns no samples.
+    """
+
+    input_device: str | None
+    sample_rate: int
+    window_seconds: float = DEFAULT_AUDIO_WINDOW_SECONDS
+    queue_limit: int = DEFAULT_AUDIO_WINDOW_QUEUE_LIMIT
+    idle_sleep_seconds: float = DEFAULT_AUDIO_IDLE_SLEEP_SECONDS
+
+    @property
+    def window_sample_count(self) -> int:
+        """Return the exact number of samples required for one detector window."""
+        return max(1, round(self.sample_rate * self.window_seconds))
+
+
+@dataclass(frozen=True)
+class AudioWindow:
+    """Complete mono audio window ready for detector inference.
+
+    Attributes:
+        sequence_number: Monotonic window sequence number for one pipeline run.
+        input_device: Optional configured audio input identifier.
+        sample_rate: Audio sample rate in Hz.
+        started_at_monotonic_seconds: Monotonic timestamp when the window was emitted.
+        duration_seconds: Window duration derived from sample count and sample rate.
+        samples: Mono floating-point samples.
+    """
+
+    sequence_number: int
+    input_device: str | None
+    sample_rate: int
+    started_at_monotonic_seconds: float
+    duration_seconds: float
+    samples: tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class AudioCaptureSnapshot:
+    """Current audio capture pipeline status.
+
+    Attributes:
+        running: Whether the capture worker is currently alive.
+        queued_window_count: Detector windows currently waiting for consumption.
+        emitted_window_count: Windows successfully queued for detector consumption.
+        dropped_window_count: Windows dropped because the detector queue was full.
+        latest_error: Last capture error message, if the worker stopped on error.
+    """
+
+    running: bool
+    queued_window_count: int
+    emitted_window_count: int
+    dropped_window_count: int
+    latest_error: str | None
+
+
+def audio_capture_settings_from_config(
+    config: AudioConfig,
+    *,
+    window_seconds: float = DEFAULT_AUDIO_WINDOW_SECONDS,
+    queue_limit: int = DEFAULT_AUDIO_WINDOW_QUEUE_LIMIT,
+    idle_sleep_seconds: float = DEFAULT_AUDIO_IDLE_SLEEP_SECONDS,
+) -> AudioCaptureSettings:
+    """Build validated audio capture settings from application config."""
+    settings = AudioCaptureSettings(
+        input_device=config.input_device,
+        sample_rate=config.sample_rate,
+        window_seconds=window_seconds,
+        queue_limit=queue_limit,
+        idle_sleep_seconds=idle_sleep_seconds,
+    )
+    _validate_settings(settings)
+    return settings
+
+
+def build_audio_capture_pipeline(
+    config: AudioConfig,
+    input_factory: AudioInputFactory,
+    *,
+    window_seconds: float = DEFAULT_AUDIO_WINDOW_SECONDS,
+    queue_limit: int = DEFAULT_AUDIO_WINDOW_QUEUE_LIMIT,
+    idle_sleep_seconds: float = DEFAULT_AUDIO_IDLE_SLEEP_SECONDS,
+    monotonic_now: Callable[[], float] | None = None,
+) -> AudioCapturePipeline:
+    """Create an audio capture pipeline from configured audio input settings."""
+    settings = audio_capture_settings_from_config(
+        config,
+        window_seconds=window_seconds,
+        queue_limit=queue_limit,
+        idle_sleep_seconds=idle_sleep_seconds,
+    )
+    return AudioCapturePipeline(
+        settings=settings,
+        audio_input=input_factory(settings),
+        monotonic_now=monotonic_now,
+    )
+
+
+class AudioCapturePipeline:
+    """Background audio capture pipeline that emits detector windows.
+
+    The worker thread owns potentially blocking audio reads. Complete windows
+    are offered to a bounded queue without waiting, so a slow detector consumer
+    cannot stall the capture worker or any roaster telemetry loop running
+    elsewhere in the process.
+    """
+
+    def __init__(
+        self,
+        *,
+        settings: AudioCaptureSettings,
+        audio_input: AudioInput,
+        monotonic_now: Callable[[], float] | None = None,
+    ) -> None:
+        """Initialize an audio capture pipeline.
+
+        Args:
+            settings: Validated audio capture settings.
+            audio_input: Configured readable audio source.
+            monotonic_now: Optional monotonic clock supplier for tests.
+        """
+        _validate_settings(settings)
+        self._settings = settings
+        self._audio_input = audio_input
+        self._monotonic_now = monotonic_now or time.monotonic
+        self._windows: Queue[AudioWindow] = Queue(maxsize=settings.queue_limit)
+        self._sample_buffer: list[float] = []
+        self._stop_requested = Event()
+        self._state_lock = Lock()
+        self._thread: Thread | None = None
+        self._next_sequence_number = 0
+        self._emitted_window_count = 0
+        self._dropped_window_count = 0
+        self._latest_error: str | None = None
+
+    @property
+    def settings(self) -> AudioCaptureSettings:
+        """Return the immutable capture settings."""
+        return self._settings
+
+    def start(self) -> AudioCaptureSnapshot:
+        """Start background audio capture and return the current status snapshot."""
+        with self._state_lock:
+            if self._thread is not None and self._thread.is_alive():
+                raise AudioCaptureError("Audio capture pipeline is already running.")
+            self._stop_requested.clear()
+            self._latest_error = None
+            self._thread = Thread(
+                target=self._run_capture_loop,
+                name="coffee-roaster-audio-capture",
+                daemon=True,
+            )
+            self._thread.start()
+        return self.snapshot()
+
+    def stop(self, *, timeout_seconds: float = 1.0) -> AudioCaptureSnapshot:
+        """Request capture stop and wait briefly for the worker to finish."""
+        if timeout_seconds < 0:
+            raise AudioCaptureError("timeout_seconds must be >= 0.")
+        self._stop_requested.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=timeout_seconds)
+        return self.snapshot()
+
+    def get_window(
+        self,
+        *,
+        block: bool = False,
+        timeout_seconds: float | None = None,
+    ) -> AudioWindow | None:
+        """Return one queued detector window, if available."""
+        try:
+            return self._windows.get(block=block, timeout=timeout_seconds)
+        except Empty:
+            return None
+
+    def drain_windows(self, *, max_windows: int | None = None) -> tuple[AudioWindow, ...]:
+        """Return all currently queued detector windows without blocking."""
+        if max_windows is not None and max_windows < 0:
+            raise AudioCaptureError("max_windows must be >= 0.")
+        windows: list[AudioWindow] = []
+        while max_windows is None or len(windows) < max_windows:
+            window = self.get_window()
+            if window is None:
+                break
+            windows.append(window)
+        return tuple(windows)
+
+    def snapshot(self) -> AudioCaptureSnapshot:
+        """Return a thread-safe capture status snapshot."""
+        thread = self._thread
+        with self._state_lock:
+            return AudioCaptureSnapshot(
+                running=thread is not None and thread.is_alive(),
+                queued_window_count=self._windows.qsize(),
+                emitted_window_count=self._emitted_window_count,
+                dropped_window_count=self._dropped_window_count,
+                latest_error=self._latest_error,
+            )
+
+    def _run_capture_loop(self) -> None:
+        try:
+            while not self._stop_requested.is_set():
+                samples = self._read_next_samples()
+                if not samples:
+                    time.sleep(self._settings.idle_sleep_seconds)
+                    continue
+                self._sample_buffer.extend(samples)
+                self._emit_complete_windows()
+        except Exception as exc:  # noqa: BLE001 - worker stores error for caller inspection.
+            with self._state_lock:
+                self._latest_error = str(exc)
+            self._stop_requested.set()
+
+    def _read_next_samples(self) -> tuple[float, ...]:
+        needed_samples = self._settings.window_sample_count - len(self._sample_buffer)
+        raw_samples = self._audio_input.read_samples(max(1, needed_samples))
+        return tuple(_normalize_sample(sample) for sample in raw_samples)
+
+    def _emit_complete_windows(self) -> None:
+        window_sample_count = self._settings.window_sample_count
+        while len(self._sample_buffer) >= window_sample_count:
+            window_samples = tuple(self._sample_buffer[:window_sample_count])
+            del self._sample_buffer[:window_sample_count]
+            window = AudioWindow(
+                sequence_number=self._next_sequence_number,
+                input_device=self._settings.input_device,
+                sample_rate=self._settings.sample_rate,
+                started_at_monotonic_seconds=self._monotonic_now(),
+                duration_seconds=round(window_sample_count / self._settings.sample_rate, 6),
+                samples=window_samples,
+            )
+            self._next_sequence_number += 1
+            self._publish_window(window)
+
+    def _publish_window(self, window: AudioWindow) -> None:
+        try:
+            self._windows.put_nowait(window)
+        except Full:
+            with self._state_lock:
+                self._dropped_window_count += 1
+            return
+        with self._state_lock:
+            self._emitted_window_count += 1
+
+
+def _validate_settings(settings: AudioCaptureSettings) -> None:
+    if settings.sample_rate <= 0:
+        raise AudioCaptureError("audio.sample_rate must be > 0.")
+    if not math.isfinite(settings.window_seconds) or settings.window_seconds <= 0:
+        raise AudioCaptureError("audio window_seconds must be > 0.")
+    if settings.queue_limit < 1:
+        raise AudioCaptureError("audio queue_limit must be >= 1.")
+    if not math.isfinite(settings.idle_sleep_seconds) or settings.idle_sleep_seconds < 0:
+        raise AudioCaptureError("audio idle_sleep_seconds must be >= 0.")
+
+
+def _normalize_sample(sample: float) -> float:
+    normalized = float(sample)
+    if not math.isfinite(normalized):
+        raise AudioCaptureError("audio samples must be finite numbers.")
+    return normalized

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -190,8 +190,8 @@ class AudioCapturePipeline:
         with self._state_lock:
             if self._thread is not None and self._thread.is_alive():
                 raise AudioCaptureError("Audio capture pipeline is already running.")
+            self._reset_run_state_locked()
             self._stop_requested.clear()
-            self._latest_error = None
             self._thread = Thread(
                 target=self._run_capture_loop,
                 name="coffee-roaster-audio-capture",
@@ -290,6 +290,14 @@ class AudioCapturePipeline:
             return
         with self._state_lock:
             self._emitted_window_count += 1
+
+    def _reset_run_state_locked(self) -> None:
+        self._windows = Queue(maxsize=self._settings.queue_limit)
+        self._sample_buffer.clear()
+        self._next_sequence_number = 0
+        self._emitted_window_count = 0
+        self._dropped_window_count = 0
+        self._latest_error = None
 
 
 def _validate_settings(settings: AudioCaptureSettings) -> None:

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -292,7 +292,11 @@ class AudioCapturePipeline:
             self._emitted_window_count += 1
 
     def _reset_run_state_locked(self) -> None:
-        self._windows = Queue(maxsize=self._settings.queue_limit)
+        while True:
+            try:
+                self._windows.get_nowait()
+            except Empty:
+                break
         self._sample_buffer.clear()
         self._next_sequence_number = 0
         self._emitted_window_count = 0

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Sequence
+
+import pytest
+
+from coffee_roaster_mcp.audio import (
+    AudioCaptureError,
+    AudioCapturePipeline,
+    AudioCaptureSettings,
+    AudioInput,
+    audio_capture_settings_from_config,
+    build_audio_capture_pipeline,
+)
+from coffee_roaster_mcp.config import AudioConfig
+
+
+class FiniteAudioInput:
+    def __init__(self, samples: Sequence[float]) -> None:
+        self._samples = list(samples)
+        self.read_counts: list[int] = []
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        self.read_counts.append(sample_count)
+        if not self._samples:
+            return ()
+        samples = self._samples[:sample_count]
+        del self._samples[:sample_count]
+        return tuple(samples)
+
+
+class FailingAudioInput:
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        raise RuntimeError(f"capture failed after {sample_count} requested samples")
+
+
+class ClockHarness:
+    def __init__(self) -> None:
+        self.value = 100.0
+
+    def monotonic_now(self) -> float:
+        self.value += 1.0
+        return self.value
+
+
+def test_audio_capture_settings_use_configured_audio_input() -> None:
+    settings = audio_capture_settings_from_config(
+        AudioConfig(input_device="roast-mic", sample_rate=8_000),
+        window_seconds=0.5,
+        queue_limit=3,
+    )
+
+    assert settings.input_device == "roast-mic"
+    assert settings.sample_rate == 8_000
+    assert settings.window_sample_count == 4_000
+    assert settings.queue_limit == 3
+
+
+def test_audio_capture_settings_reject_invalid_values() -> None:
+    with pytest.raises(AudioCaptureError, match="sample_rate"):
+        audio_capture_settings_from_config(AudioConfig(sample_rate=0))
+
+    with pytest.raises(AudioCaptureError, match="window_seconds"):
+        audio_capture_settings_from_config(AudioConfig(), window_seconds=0)
+
+    with pytest.raises(AudioCaptureError, match="queue_limit"):
+        audio_capture_settings_from_config(AudioConfig(), queue_limit=0)
+
+
+def test_build_audio_capture_pipeline_passes_config_to_input_factory() -> None:
+    audio_input = FiniteAudioInput(())
+    factory_calls: list[AudioCaptureSettings] = []
+
+    def input_factory(settings: AudioCaptureSettings) -> AudioInput:
+        factory_calls.append(settings)
+        return audio_input
+
+    pipeline = build_audio_capture_pipeline(
+        AudioConfig(input_device="configured-mic", sample_rate=4),
+        input_factory,
+        window_seconds=1.0,
+    )
+
+    assert pipeline.settings.input_device == "configured-mic"
+    assert pipeline.settings.sample_rate == 4
+    assert factory_calls == [pipeline.settings]
+
+
+def test_audio_capture_pipeline_feeds_detector_windows_from_mock_input() -> None:
+    clock = ClockHarness()
+    audio_input = FiniteAudioInput((0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8))
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device="mock-mic",
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+        monotonic_now=clock.monotonic_now,
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().emitted_window_count == 2)
+    pipeline.stop()
+
+    windows = pipeline.drain_windows()
+    assert [window.sequence_number for window in windows] == [0, 1]
+    assert [window.samples for window in windows] == [
+        (0.1, 0.2, 0.3, 0.4),
+        (0.5, 0.6, 0.7, 0.8),
+    ]
+    assert {window.input_device for window in windows} == {"mock-mic"}
+    assert {window.sample_rate for window in windows} == {4}
+    assert {window.duration_seconds for window in windows} == {1.0}
+    assert [window.started_at_monotonic_seconds for window in windows] == [101.0, 102.0]
+
+
+def test_audio_capture_pipeline_drops_windows_when_detector_queue_is_full() -> None:
+    audio_input = FiniteAudioInput(tuple(float(value) for value in range(12)))
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=4,
+            window_seconds=1.0,
+            queue_limit=1,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().dropped_window_count == 2)
+    snapshot = pipeline.stop()
+
+    assert snapshot.queued_window_count == 1
+    assert snapshot.emitted_window_count == 1
+    assert snapshot.dropped_window_count == 2
+    assert pipeline.drain_windows()[0].samples == (0.0, 1.0, 2.0, 3.0)
+
+
+def test_audio_capture_pipeline_records_source_errors_without_raising_on_caller() -> None:
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(input_device="bad-mic", sample_rate=4),
+        audio_input=FailingAudioInput(),
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().latest_error is not None)
+    snapshot = pipeline.stop()
+
+    assert snapshot.running is False
+    assert snapshot.latest_error == "capture failed after 4 requested samples"
+
+
+def test_audio_capture_pipeline_rejects_double_start() -> None:
+    audio_input = FiniteAudioInput(())
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=4,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+    )
+
+    pipeline.start()
+    try:
+        with pytest.raises(AudioCaptureError, match="already running"):
+            pipeline.start()
+    finally:
+        pipeline.stop()
+
+
+def test_audio_capture_pipeline_validates_finite_samples() -> None:
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(input_device=None, sample_rate=4),
+        audio_input=FiniteAudioInput((0.0, float("nan"), 0.0, 0.0)),
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().latest_error is not None)
+    snapshot = pipeline.stop()
+
+    assert snapshot.latest_error == "audio samples must be finite numbers."
+
+
+def _wait_for(predicate: Callable[[], bool], *, timeout_seconds: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.001)
+    raise AssertionError("Timed out waiting for condition.")

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable, Sequence
+from threading import Lock
 
 import pytest
 
@@ -28,6 +29,26 @@ class FiniteAudioInput:
         samples = self._samples[:sample_count]
         del self._samples[:sample_count]
         return tuple(samples)
+
+
+class MutableAudioInput:
+    def __init__(self, samples: Sequence[float]) -> None:
+        self._samples = list(samples)
+        self._lock = Lock()
+        self.read_counts: list[int] = []
+
+    def add_samples(self, samples: Sequence[float]) -> None:
+        with self._lock:
+            self._samples.extend(samples)
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        with self._lock:
+            self.read_counts.append(sample_count)
+            if not self._samples:
+                return ()
+            samples = self._samples[:sample_count]
+            del self._samples[:sample_count]
+            return tuple(samples)
 
 
 class FailingAudioInput:
@@ -138,6 +159,34 @@ def test_audio_capture_pipeline_drops_windows_when_detector_queue_is_full() -> N
     assert snapshot.emitted_window_count == 1
     assert snapshot.dropped_window_count == 2
     assert pipeline.drain_windows()[0].samples == (0.0, 1.0, 2.0, 3.0)
+
+
+def test_audio_capture_pipeline_resets_run_state_on_restart() -> None:
+    audio_input = MutableAudioInput((10.0, 11.0, 12.0, 13.0, 1.0, 2.0))
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().emitted_window_count == 1)
+    pipeline.stop()
+    assert pipeline.drain_windows()[0].samples == (10.0, 11.0, 12.0, 13.0)
+
+    audio_input.add_samples((3.0, 4.0, 5.0, 6.0))
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().emitted_window_count == 1)
+    pipeline.stop()
+
+    windows = pipeline.drain_windows()
+    assert [window.sequence_number for window in windows] == [0]
+    assert windows[0].samples == (3.0, 4.0, 5.0, 6.0)
 
 
 def test_audio_capture_pipeline_records_source_errors_without_raising_on_caller() -> None:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable, Sequence
-from threading import Lock
+from queue import Queue
+from threading import Lock, Thread
 
 import pytest
 
@@ -187,6 +188,50 @@ def test_audio_capture_pipeline_resets_run_state_on_restart() -> None:
     windows = pipeline.drain_windows()
     assert [window.sequence_number for window in windows] == [0]
     assert windows[0].samples == (3.0, 4.0, 5.0, 6.0)
+
+
+def test_audio_capture_pipeline_keeps_blocking_consumer_across_restart() -> None:
+    audio_input = MutableAudioInput((10.0, 11.0, 12.0, 13.0))
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().emitted_window_count == 1)
+    pipeline.stop()
+    assert pipeline.drain_windows()[0].samples == (10.0, 11.0, 12.0, 13.0)
+
+    received_windows: Queue[tuple[float, ...] | None] = Queue()
+    consumer = Thread(
+        target=lambda: received_windows.put(
+            None
+            if (
+                window := pipeline.get_window(
+                    block=True,
+                    timeout_seconds=1.0,
+                )
+            )
+            is None
+            else window.samples
+        )
+    )
+    consumer.start()
+    _wait_for(lambda: consumer.is_alive())
+    audio_input.add_samples((1.0, 2.0, 3.0, 4.0))
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().emitted_window_count == 1)
+    pipeline.stop()
+    consumer.join(timeout=1.0)
+
+    assert not consumer.is_alive()
+    assert received_windows.get_nowait() == (1.0, 2.0, 3.0, 4.0)
 
 
 def test_audio_capture_pipeline_records_source_errors_without_raising_on_caller() -> None:


### PR DESCRIPTION
## Summary
- Add an injectable audio capture pipeline that builds settings from configured audio input values.
- Emit complete one-second mono detector windows on a background worker.
- Use a bounded non-blocking detector-window queue so slow detector consumption drops/counts windows instead of stalling capture.
- Reset run-scoped capture state on each restart so partial samples, queued windows, sequence numbers, counters, and prior errors cannot leak across runs.
- Keep the detector-window queue object stable across restarts so blocking consumers are not stranded on an old queue.
- Update durable Epic 4 state for E4-S6 and advance the active story to E4-S7.
- Insert follow-up issue #97 as E4-S8 for concrete microphone and WAV audio input adapters, and renumber the timeline integration story #39 to E4-S9.

## Scope Notes
- No live microphone backend selection added in E4-S6.
- No detector adapter, ONNX inference, first-crack session timeline integration, model training, ONNX export, Hugging Face sync, local directory sync behavior, or live Hottop control changes added.
- The microphone/WAV adapter details are captured in #97 for implementation after E4-S7 and before E4-S9.

## Validation
- `./.venv/bin/python -m pytest tests/test_audio.py`: 10 passed
- `./.venv/bin/python -m pytest`: 210 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: passed
- `./.venv/bin/python -m pyright`: 0 errors
- `git diff --check`: passed after the docs-only story insertion

Closes #37
