### PR TITLE
E4-S7: Add detector adapter

### DIFF
--- a/docs/session-summaries/2026-05-17-e4-s7-add-detector-adapter.md
+++ b/docs/session-summaries/2026-05-17-e4-s7-add-detector-adapter.md
@@ -1,0 +1,189 @@
+# E4-S7 Add Detector Adapter Session
+
+## Scope
+
+This session resumed after `PR #96` for `E4-S6` was squashed and merged, and
+issue `#37` was closed. Work started from updated `main` on branch
+`feature/38-add-detector-adapter` for issue `#38`, `E4-S7: Add detector
+adapter`.
+
+The story goal was intentionally narrow: add the detector adapter only, using
+the E4-S1 through E4-S6 resolver, artifact-validation, and audio-window
+boundaries. The work preserved the Epic 2 one-session store boundary, MCP
+semantics, mock-safe defaults, coverage workflow, Epic 3 Hottop
+safety/validation boundary, and released-artifact boundary.
+
+The work did not add model training, ONNX export, Hugging Face sync, concrete
+microphone or WAV input adapters, local directory sync behavior, first-crack
+session timeline integration, live Hottop control changes, detector startup, or
+real ONNX runtime inference.
+
+## Context Usage
+
+Session usage snapshot supplied by the operator after the E4-S10 planning
+update:
+
+- Context window: `50% left (135K used / 258K)`
+- 5h limit: `96% left`, resets `22:35`
+- Weekly limit: `97% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `23:57`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `18:57 on 24 May`
+
+## Pre-Story Verification
+
+Before starting E4-S7:
+
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding through the E4-S6 merge
+  to `fb51b02d15e40be3ff1dcb85a06a869fedf73b0b`.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-17-e4-s6-add-audio-capture-pipeline.md`,
+  and GitHub issue `#38`.
+- Confirmed issue `#38` required detector output to map to a confirmed
+  first-crack event with timestamp, precision, revision, and optional
+  confidence, with mocked detector adapter tests.
+
+## Implementation
+
+Updated:
+
+- `src/coffee_roaster_mcp/detector.py`
+- `tests/test_detector.py`
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+Behavior added:
+
+- `FirstCrackDetectorBackend` protocol defines the injected detector backend
+  boundary.
+- `FirstCrackDetectorOutput` represents raw backend output for one E4-S6
+  `AudioWindow`.
+- `FirstCrackDetectionEvent` represents the confirmed first-crack event
+  candidate for later session-timeline integration.
+- `FirstCrackDetectorAdapter.process_window(...)` ignores unconfirmed outputs
+  and maps confirmed outputs to `first_crack_detected` event candidates.
+- Confirmed event candidates include monotonic timestamp, configured precision,
+  configured revision, repo id, resolved ONNX artifact filename, resolved
+  feature-extractor filename, source audio window sequence number, and optional
+  confidence.
+- When a backend does not provide a detection timestamp, the adapter uses the
+  end of the audio window.
+- Invalid confidence and non-finite detection timestamps fail clearly.
+
+Tests added:
+
+- Unconfirmed detector output returns no event candidate.
+- Confirmed detector output maps precision, revision, artifacts, timestamp,
+  confidence, repo id, and window sequence metadata.
+- Missing detector timestamp falls back to the audio-window end timestamp.
+- Invalid confidence values are rejected.
+- Non-finite detector timestamps are rejected.
+- Non-boolean confirmation values are rejected.
+
+## Planning Update
+
+After reviewing coverage, the project now has a closing Epic 4 coverage story:
+
+- Created GitHub issue `#99`: `E4-S10: Harden first-crack and MCP coverage
+  before next epic`.
+- Updated GitHub Epic `#4` to include `#99`.
+- Updated `docs/state/github-issues.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`, and
+  `docs/state/registry.md`.
+
+E4-S10 is placed after E4-S9. It is intended to close Epic 4 with targeted
+automated coverage for the assembled first-crack path, MCP-facing behavior,
+current export surfaces, duplicate/no-confirmation/error cases,
+disabled/manual modes, missing artifacts, and coverage gaps in `mcp_server.py`,
+`exports.py`, and the Epic 4 modules.
+
+Manual real microphone validation is explicitly optional and gated. It must be
+skipped by default and must not be required for normal CI.
+
+## Coverage Snapshot
+
+Local coverage was checked after E4-S7:
+
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json`
+- Result: `218 passed`
+- Total package coverage: `87%`
+
+Notable module coverage:
+
+- `artifacts.py`: `94%`
+- `audio.py`: `96%`
+- `detector.py`: complete enough to be skipped from the missing-lines report
+- `drivers.py`: `95%`
+- `hottop_validation.py`: `94%`
+- `session.py`: `88%`
+- `config.py`: `83%`
+- `mcp_server.py`: `55%`
+- `exports.py`: `43%`
+
+The main remaining coverage risks are `mcp_server.py`, `exports.py`, and some
+configuration edge paths. E4-S10 was added to address these after E4-S9 makes
+the assembled first-crack path available.
+
+## Pull Request
+
+Opened `PR #98`: <https://github.com/syamaner/coffee-roaster-mcp/pull/98>
+
+PR branch:
+
+- `feature/38-add-detector-adapter`
+
+Commits on the branch before this summary:
+
+- `ba647c090071cb1e385463dc295725bb3301b32d` -
+  `feat: add first crack detector adapter`
+- `3e2a5bc14840e496003b1c4e6b1acd10475083c8` -
+  `docs: add e4 s10 coverage hardening story`
+
+PR status when this summary was written:
+
+- state: open
+- draft: false
+- mergeable: true
+- head: `3e2a5bc14840e496003b1c4e6b1acd10475083c8`
+- GitHub Actions `Build Package`: passed
+- GitHub Actions `Checks`: passed
+
+Issue `#38` remains open and should close when PR #98 is merged through
+`Closes #38`.
+
+## Validation
+
+E4-S7 implementation:
+
+- Ran `./.venv/bin/python -m pytest tests/test_detector.py`: `8 passed`
+- Ran `./.venv/bin/python -m pytest`: `218 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+
+After the E4-S10 docs planning update:
+
+- Targeted Markdown `ruff check` reported no Python files, as expected.
+- Targeted Markdown `ruff format --check` was not applicable because Ruff
+  Markdown formatting is experimental and requires preview mode.
+- GitHub Actions on PR #98 passed after the planning commit.
+
+## Handoff Notes
+
+After PR #98 merges:
+
+1. Sync `main`.
+2. Verify issue `#38` closes.
+3. Begin E4-S8 from updated `main`.
+4. Keep E4-S8 scoped to concrete microphone and WAV audio input adapters behind
+   the E4-S6 `AudioInput` boundary.
+5. Do not add session timeline integration in E4-S8; that remains E4-S9.
+6. Do not perform broad coverage hardening in E4-S8 or E4-S9 unless required by
+   those issues; E4-S10 owns the final Epic 4 coverage hardening pass.
+
+Suggested restart prompt after PR #98 is merged:
+
+```text
+Resume in /Users/sertanyamaner/git/coffee-roaster-mcp. PR #98 for E4-S7 was squashed and merged, and issue #38 is closed. First run git checkout main and git pull --ff-only origin main. Then read AGENTS.md, docs/state/registry.md, docs/state/epics/coffee-roaster-mcp-v0.1.md, docs/session-summaries/2026-05-17-e4-s7-add-detector-adapter.md, and GitHub issue #97. Begin E4-S8 from updated main on branch feature/97-add-microphone-and-wav-audio-input-adapters. Keep scope to concrete microphone and WAV audio input adapters behind the E4-S6 AudioInput boundary. Preserve the Epic 2 one-session store boundary, MCP semantics, mock-safe defaults, coverage workflow, Epic 3 Hottop safety/validation boundary, and the E4-S1 through E4-S7 released-artifact, audio-pipeline, and detector-adapter boundaries. Do not add model training, ONNX export, Hugging Face sync, local directory sync behavior, first-crack session timeline integration, broad coverage hardening, or live Hottop control changes unless issue #97 explicitly requires it. Real microphone validation must be optional and explicitly gated so normal CI remains mock-safe.
+```

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4-S7`
-- Current target: Add detector adapter
+- Active story: `E4-S8`
+- Current target: Add microphone and WAV audio input adapters
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -61,6 +61,13 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E4-S4` resolves configured first-crack artifacts from `first_crack.local_model_dir` before any Hugging Face Hub download. The local path uses the same repository-relative artifact names as the released Hub layout, fails clearly when the target local file is missing, and leaves broader detector artifact validation, detector startup, audio capture, and session-timeline integration to later Epic 4 work.
 - `E4-S5` validates the required first-crack detector artifact set through the existing resolver boundary before audio detection begins. The validation resolves the configured ONNX model plus `onnx/int8/preprocessor_config.json` or `onnx/fp32/preprocessor_config.json`, depending on precision, and keeps detector startup, audio capture, artifact content validation, and session-timeline integration out of scope.
 - `E4-S6` adds an injectable audio capture pipeline that builds its source from `AudioConfig`, reads on a background worker, frames complete one-second mono detector windows at the configured sample rate, and hands windows to a bounded non-blocking queue for the future detector adapter. Live audio backend selection, detector adapter behavior, model inference, and session-timeline integration remain later work.
+- `E4-S7` adds a narrow detector adapter boundary. Injected detector backends
+  process E4-S6 `AudioWindow` instances and confirmed outputs become
+  first-crack event candidates with monotonic timestamp, configured precision,
+  revision, resolved artifact filenames, repository id, source window sequence,
+  and optional confidence. The adapter does not start audio capture, perform
+  ONNX inference by itself, or write to the authoritative session timeline;
+  E4-S9 owns timeline integration.
 - `E4-S8` is inserted after the detector adapter story to add concrete microphone and WAV audio input adapters behind the E4-S6 `AudioInput` boundary. This keeps Linux/Raspberry Pi microphone behavior and recorded-session replay explicit before first-crack events are wired into the session timeline in `E4-S9`.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
@@ -223,7 +230,7 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 - [x] `E4-S6` Add audio capture pipeline.
   - Done when configured audio input can feed detector windows without blocking roaster telemetry.
 
-- [ ] `E4-S7` Add detector adapter.
+- [x] `E4-S7` Add detector adapter.
   - Done when detector output maps to a confirmed first-crack event with timestamp, precision, revision, and confidence when available.
 
 - [ ] `E4-S8` Add microphone and WAV audio input adapters.
@@ -724,3 +731,13 @@ After completing a story:
   - Inserted `E4-S8` / issue `#97` for concrete microphone and recorded WAV audio input adapters after the detector adapter story and before session timeline integration.
   - Renamed the previous timeline integration issue `#39` to `E4-S9` so Raspberry Pi/Linux microphone behavior and recorded-session replay are captured explicitly before detector results are wired into the authoritative session timeline.
   - Updated Epic 4 acceptance criteria to include configured microphone and WAV sources feeding the detector window pipeline.
+- Validation run for E4-S7:
+  - Added `src/coffee_roaster_mcp/detector.py` with the narrow first-crack detector adapter boundary.
+  - The adapter accepts E4-S6 `AudioWindow` instances and an injected backend, ignores unconfirmed detector outputs, and maps confirmed outputs to `first_crack_detected` event candidates with monotonic timestamp, configured precision, revision, repository id, resolved artifact filenames, source window sequence number, and optional confidence.
+  - The adapter falls back to the audio-window end timestamp when the backend does not provide a detection timestamp and validates detector confidence plus finite timestamps.
+  - Kept ONNX runtime inference, model training, ONNX export, Hugging Face sync, concrete microphone/WAV adapters, local directory sync behavior, MCP tool behavior, and authoritative session timeline writes out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_detector.py`: 8 passed.
+  - Ran `./.venv/bin/python -m pytest`: 218 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -69,6 +69,11 @@ The first implementation milestone is a mock vertical slice that requires no roa
   ONNX inference by itself, or write to the authoritative session timeline;
   E4-S9 owns timeline integration.
 - `E4-S8` is inserted after the detector adapter story to add concrete microphone and WAV audio input adapters behind the E4-S6 `AudioInput` boundary. This keeps Linux/Raspberry Pi microphone behavior and recorded-session replay explicit before first-crack events are wired into the session timeline in `E4-S9`.
+- `E4-S10` closes Epic 4 with targeted test hardening before the next epic.
+  It should reduce coverage gaps around the assembled first-crack path,
+  MCP-facing behavior, current export surfaces, and mock-safe failure modes.
+  Real microphone validation can be added only as an explicit opt-in manual path
+  that is skipped by default and never required for normal CI.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -239,6 +244,10 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 - [ ] `E4-S9` Integrate first crack with session timeline.
   - Done when mocked detector output creates exactly one `first_crack_detected` event.
 
+- [ ] `E4-S10` Harden first-crack and MCP coverage before next epic.
+  - Done when automated tests cover the assembled first-crack path, MCP-facing behavior, current export surfaces, duplicate/no-confirmation/error cases, disabled/manual modes, missing artifacts, and materially reduce `mcp_server.py`, `exports.py`, and Epic 4 coverage gaps.
+  - Manual real-microphone validation may be added only behind an explicit opt-in gate and must be skipped by default unless a microphone is configured and ready.
+
 ### Epic Acceptance Criteria
 
 - INT8 resolver selects `onnx/int8/model_quantized.onnx`.
@@ -246,6 +255,10 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 - Offline local directory works without HF network access.
 - Configured microphone and WAV audio sources can feed the detector window pipeline.
 - Mocked detector output creates exactly one `first_crack_detected` event.
+- Epic 4 closes with targeted automated coverage for first-crack integration,
+  MCP-facing behavior, current export surfaces, and mock-safe failure modes.
+- Real microphone validation is optional, explicitly gated, and never required
+  for normal CI.
 
 ## Epic 5: Roast Metrics And Log Export
 

--- a/docs/state/github-issues.md
+++ b/docs/state/github-issues.md
@@ -59,6 +59,7 @@ Milestone: `v0.1`
 - #38 E4-S7: Add detector adapter
 - #97 E4-S8: Add microphone and WAV audio input adapters
 - #39 E4-S9: Integrate first crack with session timeline
+- #99 E4-S10: Harden first-crack and MCP coverage before next epic
 
 ## Epic 5 Stories
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -52,7 +52,11 @@ inference, or MCP session behavior.
 The next story is E4-S8: add microphone and WAV audio input adapters.
 Epic 4 now includes a new E4-S8 story for concrete microphone and WAV audio
 input adapters before session timeline integration. The previous timeline
-integration story is now E4-S9.
+integration story is now E4-S9. Epic 4 also now includes E4-S10 as a closing
+test-hardening story before the next epic, focused on first-crack integration,
+MCP-facing behavior, export assertions, mock-safe failure modes, and coverage
+gaps. Real microphone validation is optional and must remain explicitly gated so
+normal CI does not require audio hardware.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -30,7 +30,7 @@ drop and emergency stop included. A follow-up 60-second stability test also held
 fan at `10%`, heat at `40%` for 30 seconds, then heat at `100%` for 30 seconds
 with continuous command streaming and no command-loop or status-read errors.
 
-E4-S6 is complete. The first-crack path now resolves the configured ONNX model
+E4-S7 is complete. The first-crack path now resolves the configured ONNX model
 artifact for both supported real-model precisions: `int8` selects
 `onnx/int8/model_quantized.onnx`, and `fp32` selects `onnx/fp32/model.onnx`
 through the artifact resolver. When `first_crack.local_model_dir` is configured,
@@ -42,11 +42,14 @@ selected ONNX model and the precision-specific
 audio detection begins. The audio capture path now has an injectable background
 pipeline that reads from the configured audio input, frames complete one-second
 mono detector windows at the configured sample rate, and hands windows to a
-bounded non-blocking queue for the future detector adapter. This does not add
-model training, export, sync, detector adapter behavior, local directory sync,
-or MCP session behavior.
+bounded non-blocking queue for the detector adapter. The detector adapter now
+turns injected backend decisions into confirmed first-crack event candidates
+with monotonic timestamp, precision, revision, artifact, and optional confidence
+metadata for later session integration. This does not add model training,
+export, sync, concrete audio input adapters, local directory sync, ONNX runtime
+inference, or MCP session behavior.
 
-The next story is E4-S7: add detector adapter.
+The next story is E4-S8: add microphone and WAV audio input adapters.
 Epic 4 now includes a new E4-S8 story for concrete microphone and WAV audio
 input adapters before session timeline integration. The previous timeline
 integration story is now E4-S9.

--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -1,0 +1,156 @@
+"""Detector adapter boundary for first-crack audio windows."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from coffee_roaster_mcp.artifacts import ResolvedDetectorArtifacts
+from coffee_roaster_mcp.audio import AudioWindow
+from coffee_roaster_mcp.config import FirstCrackConfig, ModelPrecision
+
+FirstCrackDetectorEventKind = Literal["first_crack_detected"]
+
+
+class FirstCrackDetectorError(RuntimeError):
+    """Raised when first-crack detector output cannot be adapted."""
+
+
+class FirstCrackDetectorBackend(Protocol):
+    """Inference backend for first-crack detector windows."""
+
+    def detect(self, window: AudioWindow) -> FirstCrackDetectorOutput:
+        """Run detection for one audio window."""
+        ...
+
+
+@dataclass(frozen=True)
+class FirstCrackDetectorOutput:
+    """Raw detector decision for one audio window.
+
+    Attributes:
+        confirmed: Whether the detector confirmed first crack for the window.
+        confidence: Optional model confidence for confirmed detections.
+        detected_at_monotonic_seconds: Optional monotonic timestamp for the
+            detection. When omitted, the adapter uses the end of the audio window.
+    """
+
+    confirmed: bool
+    confidence: float | None = None
+    detected_at_monotonic_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class FirstCrackDetectionEvent:
+    """Confirmed first-crack detector event candidate.
+
+    This is intentionally not written to the roast-session timeline here. E4-S9
+    owns session integration; this story only adapts detector output into the
+    event metadata needed by that later boundary.
+
+    Attributes:
+        kind: Event kind intended for the session timeline.
+        detected_at_monotonic_seconds: Monotonic timestamp for first crack.
+        precision: Configured ONNX model precision.
+        revision: Configured model repository revision.
+        confidence: Optional detector confidence.
+        repo_id: Configured model repository id.
+        onnx_model_filename: Repository-relative ONNX model artifact.
+        feature_extractor_filename: Repository-relative feature extractor artifact.
+        window_sequence_number: Source audio window sequence number.
+    """
+
+    kind: FirstCrackDetectorEventKind
+    detected_at_monotonic_seconds: float
+    precision: ModelPrecision
+    revision: str | None
+    confidence: float | None
+    repo_id: str
+    onnx_model_filename: str
+    feature_extractor_filename: str
+    window_sequence_number: int
+
+    def payload(self) -> dict[str, str | int | float | None]:
+        """Return session-event payload metadata for this confirmed detection."""
+        payload: dict[str, str | int | float | None] = {
+            "source": "first_crack_detector",
+            "detected_at_monotonic_seconds": self.detected_at_monotonic_seconds,
+            "precision": self.precision,
+            "revision": self.revision,
+            "repo_id": self.repo_id,
+            "onnx_model_filename": self.onnx_model_filename,
+            "feature_extractor_filename": self.feature_extractor_filename,
+            "window_sequence_number": self.window_sequence_number,
+        }
+        if self.confidence is not None:
+            payload["confidence"] = self.confidence
+        return payload
+
+
+@dataclass(frozen=True)
+class FirstCrackDetectorAdapter:
+    """Adapt detector backend outputs into confirmed first-crack event candidates."""
+
+    config: FirstCrackConfig
+    artifacts: ResolvedDetectorArtifacts
+    backend: FirstCrackDetectorBackend
+
+    def process_window(self, window: AudioWindow) -> FirstCrackDetectionEvent | None:
+        """Process one audio window and return a confirmed event candidate if present."""
+        output = self.backend.detect(window)
+        if type(output.confirmed) is not bool:
+            raise FirstCrackDetectorError("detector output confirmed must be a boolean.")
+        if not output.confirmed:
+            return None
+
+        confidence = _validate_optional_confidence(output.confidence)
+        detected_at_monotonic_seconds = _detection_timestamp(window, output)
+        return FirstCrackDetectionEvent(
+            kind="first_crack_detected",
+            detected_at_monotonic_seconds=detected_at_monotonic_seconds,
+            precision=self.config.precision,
+            revision=self.config.revision,
+            confidence=confidence,
+            repo_id=self.config.repo_id,
+            onnx_model_filename=self.artifacts.onnx_model.filename,
+            feature_extractor_filename=self.artifacts.feature_extractor_config.filename,
+            window_sequence_number=window.sequence_number,
+        )
+
+
+def build_first_crack_detector_adapter(
+    config: FirstCrackConfig,
+    artifacts: ResolvedDetectorArtifacts,
+    backend: FirstCrackDetectorBackend,
+) -> FirstCrackDetectorAdapter:
+    """Build the first-crack detector adapter from resolved detector dependencies."""
+    return FirstCrackDetectorAdapter(
+        config=config,
+        artifacts=artifacts,
+        backend=backend,
+    )
+
+
+def _detection_timestamp(
+    window: AudioWindow,
+    output: FirstCrackDetectorOutput,
+) -> float:
+    if output.detected_at_monotonic_seconds is None:
+        detected_at = window.started_at_monotonic_seconds + window.duration_seconds
+    else:
+        detected_at = float(output.detected_at_monotonic_seconds)
+    if not math.isfinite(detected_at):
+        raise FirstCrackDetectorError(
+            "detector output detected_at_monotonic_seconds must be finite."
+        )
+    return round(detected_at, 6)
+
+
+def _validate_optional_confidence(confidence: float | None) -> float | None:
+    if confidence is None:
+        return None
+    normalized = float(confidence)
+    if not math.isfinite(normalized) or not 0.0 <= normalized <= 1.0:
+        raise FirstCrackDetectorError("detector output confidence must be between 0 and 1.")
+    return normalized

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,0 +1,202 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from coffee_roaster_mcp.artifacts import ResolvedArtifact, ResolvedDetectorArtifacts
+from coffee_roaster_mcp.audio import AudioWindow
+from coffee_roaster_mcp.config import FirstCrackConfig
+from coffee_roaster_mcp.detector import (
+    FirstCrackDetectorAdapter,
+    FirstCrackDetectorError,
+    FirstCrackDetectorOutput,
+    build_first_crack_detector_adapter,
+)
+
+
+class MockDetectorBackend:
+    def __init__(self, outputs: tuple[FirstCrackDetectorOutput, ...]) -> None:
+        self._outputs = list(outputs)
+        self.windows: list[AudioWindow] = []
+
+    def detect(self, window: AudioWindow) -> FirstCrackDetectorOutput:
+        self.windows.append(window)
+        return self._outputs.pop(0)
+
+
+class BadConfirmationBackend:
+    def detect(self, window: AudioWindow) -> FirstCrackDetectorOutput:
+        return cast(
+            FirstCrackDetectorOutput,
+            SimpleNamespace(
+                confirmed=1,
+                confidence=None,
+                detected_at_monotonic_seconds=None,
+            ),
+        )
+
+
+def test_detector_adapter_ignores_unconfirmed_detector_output() -> None:
+    window = _audio_window()
+    backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=False),))
+    adapter = build_first_crack_detector_adapter(
+        FirstCrackConfig(revision="v0.1.0"),
+        _resolved_detector_artifacts(),
+        backend,
+    )
+
+    event = adapter.process_window(window)
+
+    assert event is None
+    assert backend.windows == [window]
+
+
+def test_detector_adapter_maps_confirmed_output_to_first_crack_event() -> None:
+    window = _audio_window(sequence_number=7, started_at_monotonic_seconds=120.0)
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(
+                confirmed=True,
+                confidence=0.87,
+                detected_at_monotonic_seconds=120.42,
+            ),
+        )
+    )
+    config = FirstCrackConfig(
+        repo_id="syamaner/custom-first-crack",
+        revision="v0.2.0",
+        precision="fp32",
+    )
+    artifacts = _resolved_detector_artifacts(
+        repo_id="syamaner/custom-first-crack",
+        revision="v0.2.0",
+        onnx_filename="onnx/fp32/model.onnx",
+        feature_extractor_filename="onnx/fp32/preprocessor_config.json",
+    )
+    adapter = FirstCrackDetectorAdapter(
+        config=config,
+        artifacts=artifacts,
+        backend=backend,
+    )
+
+    event = adapter.process_window(window)
+
+    assert event is not None
+    assert event.kind == "first_crack_detected"
+    assert event.detected_at_monotonic_seconds == 120.42
+    assert event.precision == "fp32"
+    assert event.revision == "v0.2.0"
+    assert event.confidence == 0.87
+    assert event.repo_id == "syamaner/custom-first-crack"
+    assert event.onnx_model_filename == "onnx/fp32/model.onnx"
+    assert event.feature_extractor_filename == "onnx/fp32/preprocessor_config.json"
+    assert event.window_sequence_number == 7
+    assert event.payload() == {
+        "source": "first_crack_detector",
+        "detected_at_monotonic_seconds": 120.42,
+        "precision": "fp32",
+        "revision": "v0.2.0",
+        "repo_id": "syamaner/custom-first-crack",
+        "onnx_model_filename": "onnx/fp32/model.onnx",
+        "feature_extractor_filename": "onnx/fp32/preprocessor_config.json",
+        "window_sequence_number": 7,
+        "confidence": 0.87,
+    }
+
+
+def test_detector_adapter_uses_window_end_timestamp_when_output_has_no_timestamp() -> None:
+    window = _audio_window(started_at_monotonic_seconds=55.25, duration_seconds=1.0)
+    backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=True),))
+    adapter = build_first_crack_detector_adapter(
+        FirstCrackConfig(),
+        _resolved_detector_artifacts(),
+        backend,
+    )
+
+    event = adapter.process_window(window)
+
+    assert event is not None
+    assert event.detected_at_monotonic_seconds == 56.25
+    assert event.confidence is None
+    assert "confidence" not in event.payload()
+
+
+@pytest.mark.parametrize("confidence", (-0.01, 1.01, float("nan")))
+def test_detector_adapter_rejects_invalid_confidence(confidence: float) -> None:
+    adapter = build_first_crack_detector_adapter(
+        FirstCrackConfig(),
+        _resolved_detector_artifacts(),
+        MockDetectorBackend((FirstCrackDetectorOutput(confirmed=True, confidence=confidence),)),
+    )
+
+    with pytest.raises(FirstCrackDetectorError, match="confidence"):
+        adapter.process_window(_audio_window())
+
+
+def test_detector_adapter_rejects_non_finite_detection_timestamp() -> None:
+    adapter = build_first_crack_detector_adapter(
+        FirstCrackConfig(),
+        _resolved_detector_artifacts(),
+        MockDetectorBackend(
+            (
+                FirstCrackDetectorOutput(
+                    confirmed=True,
+                    detected_at_monotonic_seconds=float("inf"),
+                ),
+            )
+        ),
+    )
+
+    with pytest.raises(FirstCrackDetectorError, match="detected_at_monotonic_seconds"):
+        adapter.process_window(_audio_window())
+
+
+def test_detector_adapter_rejects_non_boolean_confirmation() -> None:
+    adapter = build_first_crack_detector_adapter(
+        FirstCrackConfig(),
+        _resolved_detector_artifacts(),
+        BadConfirmationBackend(),
+    )
+
+    with pytest.raises(FirstCrackDetectorError, match="confirmed"):
+        adapter.process_window(_audio_window())
+
+
+def _audio_window(
+    *,
+    sequence_number: int = 3,
+    started_at_monotonic_seconds: float = 10.0,
+    duration_seconds: float = 1.0,
+) -> AudioWindow:
+    return AudioWindow(
+        sequence_number=sequence_number,
+        input_device="mock-audio",
+        sample_rate=4,
+        started_at_monotonic_seconds=started_at_monotonic_seconds,
+        duration_seconds=duration_seconds,
+        samples=(0.1, 0.2, 0.3, 0.4),
+    )
+
+
+def _resolved_detector_artifacts(
+    *,
+    repo_id: str = "syamaner/coffee-first-crack-detection",
+    revision: str | None = None,
+    onnx_filename: str = "onnx/int8/model_quantized.onnx",
+    feature_extractor_filename: str = "onnx/int8/preprocessor_config.json",
+) -> ResolvedDetectorArtifacts:
+    return ResolvedDetectorArtifacts(
+        onnx_model=ResolvedArtifact(
+            repo_id=repo_id,
+            revision=revision,
+            filename=onnx_filename,
+            local_path=Path("/tmp/model.onnx"),
+        ),
+        feature_extractor_config=ResolvedArtifact(
+            repo_id=repo_id,
+            revision=revision,
+            filename=feature_extractor_filename,
+            local_path=Path("/tmp/preprocessor_config.json"),
+        ),
+    )


### PR DESCRIPTION
## Summary
- Add a narrow first-crack detector adapter boundary over E4-S6 `AudioWindow` inputs and injected detector backends.
- Map confirmed detector outputs to `first_crack_detected` event candidates with monotonic timestamp, configured precision, revision, repo id, resolved artifact filenames, source window sequence, and optional confidence.
- Update durable state docs to mark E4-S7 complete and keep E4-S8 as the next story.
- Add E4-S10 / issue #99 as the Epic 4 closing test-hardening story for first-crack integration, MCP-facing behavior, export assertions, mock-safe failure modes, and optional gated real microphone validation.
- Add `docs/session-summaries/2026-05-17-e4-s7-add-detector-adapter.md` for restart/handoff context.

## Scope
- No ONNX runtime inference, model training/export, Hugging Face sync, concrete microphone/WAV adapters, local directory sync behavior, MCP tool changes, or authoritative session timeline writes.
- E4-S10 is planning/state only in this PR; implementation remains a later story after E4-S9.

## Validation
- `./.venv/bin/python -m pytest tests/test_detector.py`: 8 passed
- `./.venv/bin/python -m pytest`: 218 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: passed
- `./.venv/bin/python -m pyright`: 0 errors
- Targeted Markdown `ruff check` reported no Python files, as expected.

Closes #38