### PR TITLE
E4-S8: Add microphone and WAV audio input adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,10 @@ first_crack:
   allow_manual_override: true
 
 audio:
+  source: microphone
   input_device: null
   sample_rate: 16000
+  wav_path: null
 
 logging:
   log_dir: ./logs
@@ -224,9 +226,19 @@ Supported environment overrides:
 - `COFFEE_FIRST_CRACK_PRECISION`
 - `COFFEE_FIRST_CRACK_LOCAL_MODEL_DIR`
 - `COFFEE_FIRST_CRACK_ONNX_THREADS`
+- `COFFEE_AUDIO_SOURCE`
 - `COFFEE_AUDIO_INPUT_DEVICE`
+- `COFFEE_AUDIO_SAMPLE_RATE`
+- `COFFEE_AUDIO_WAV_PATH`
 - `COFFEE_ROAST_LOG_DIR`
 - `HF_HOME`
+
+`audio.source` can be `microphone` or `wav`. Microphone capture uses a
+PortAudio-backed `sounddevice` stream and keeps the configured device identifier
+behind the audio-input boundary for macOS, Linux, and Raspberry Pi hosts. WAV
+replay uses PCM `.wav` files, converts channels to the same mono float sample
+contract as microphone capture, and requires the file sample rate to match
+`audio.sample_rate`.
 
 `HF_HOME` is consumed by Hugging Face tooling directly rather than copied into the RoastPilot config object.
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,16 @@ replay uses PCM `.wav` files, converts channels to the same mono float sample
 contract as microphone capture, and requires the file sample rate to match
 `audio.sample_rate`.
 
+For microphone capture, `audio.input_device: null` uses the system default input
+device. To pin a specific microphone, set `audio.input_device` to a
+PortAudio-resolvable device name or platform device identifier. On Linux and
+Raspberry Pi, use `arecord -l` and `arecord -L` to inspect ALSA devices; values
+such as `plughw:1,0` are often more forgiving than raw `hw:1,0` because ALSA can
+perform format conversion. On macOS, use the system sound settings or a
+`sounddevice` device listing during manual validation. Real microphone checks
+are optional and should be run only when `first_crack.mode: audio` and
+`audio.source: microphone` are deliberately configured.
+
 `HF_HOME` is consumed by Hugging Face tooling directly rather than copied into the RoastPilot config object.
 
 ## Hugging Face Model Boundary

--- a/docs/session-summaries/2026-05-17-e4-s8-add-microphone-and-wav-audio-input-adapters.md
+++ b/docs/session-summaries/2026-05-17-e4-s8-add-microphone-and-wav-audio-input-adapters.md
@@ -43,6 +43,15 @@ Quality versus context consumption note:
   stop. Both fixes improve Raspberry Pi/Linux and macOS operator behavior while
   staying within E4-S8 scope and preserving mock-safe CI.
 
+Final snapshot after the recent PR fixes:
+
+- Context window: `30% left (183K used / 258K)`
+- 5h limit: `93% left`, resets `22:35`
+- Weekly limit: `97% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `00:46 on 18 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `19:46 on 24 May`
+- Warning: limits may be stale; run `/status` again shortly.
+
 ## Pre-Story Verification
 
 Before starting E4-S8:
@@ -143,6 +152,27 @@ Fixes applied:
 - Thread-aware review refresh after the fix showed all `PR #100` review threads
   resolved.
 
+Final Codex review on `PR #100` found two more actionable startup-failure
+normalization issues:
+
+- `_load_sounddevice()` only caught `ImportError`, but `sounddevice` can raise
+  `OSError` when the Python package is installed and the PortAudio runtime is
+  missing.
+- `_ensure_stream()` cached `self._stream` before `start()` succeeded and closed
+  it on failure without clearing the cached reference, so a transient startup
+  failure could leave the input unable to retry without rebuilding the object.
+
+Fixes applied:
+
+- `_load_sounddevice()` now normalizes both `ImportError` and `OSError` to
+  `AudioCaptureError`.
+- `_ensure_stream()` now clears `self._stream` when startup fails so a later
+  read can retry with a fresh stream.
+- Added mocked regression coverage for missing PortAudio runtime normalization
+  and retry after a transient microphone startup failure.
+- Thread-aware review refresh after the fix showed all `PR #100` review threads
+  resolved.
+
 ## Pull Request
 
 Opened `PR #100`: <https://github.com/syamaner/coffee-roaster-mcp/pull/100>
@@ -163,13 +193,17 @@ Commits on the branch before this summary:
   `docs: add e4 s8 session summary`
 - `64f6060e56d1b8f9c5b117d4ed78a8b42383c455` -
   `fix: align microphone stream lifecycle with capture`
+- `61bc7e5e13acfead84c3672dda77520443bca3c4` -
+  `docs: update e4 s8 review summary`
+- `847672ec43390e3fc8975e53d611e18e777597b2` -
+  `fix: normalize microphone startup failures`
 
 PR status when this summary was written:
 
 - state: open
 - draft: false
 - mergeable: true
-- head: `64f6060e56d1b8f9c5b117d4ed78a8b42383c455`
+- head: `847672ec43390e3fc8975e53d611e18e777597b2`
 - GitHub Actions `Build Package`: passed
 - GitHub Actions `Checks`: passed
 
@@ -209,6 +243,15 @@ After latest lifecycle review fix:
 - Ran `./.venv/bin/python -m ruff format --check .`: passed
 - Ran `./.venv/bin/python -m pyright`: `0 errors`
 - GitHub Actions on PR #100 passed after the latest review-fix commit.
+
+After final startup-failure review fix:
+
+- Ran `./.venv/bin/python -m pytest tests/test_audio.py`: `20 passed`
+- Ran `./.venv/bin/python -m pytest`: `229 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+- GitHub Actions on PR #100 passed after the final review-fix commit.
 
 ## Handoff Notes
 

--- a/docs/session-summaries/2026-05-17-e4-s8-add-microphone-and-wav-audio-input-adapters.md
+++ b/docs/session-summaries/2026-05-17-e4-s8-add-microphone-and-wav-audio-input-adapters.md
@@ -19,13 +19,29 @@ integration, broad coverage hardening, or live Hottop control changes.
 
 ## Context Usage
 
-Session usage snapshot supplied by the operator after the E4-S8 review fix:
+Session usage snapshot supplied by the operator after the first E4-S8 review fix:
 
 - Context window: `51% left (133K used / 258K)`
 - 5h limit: `95% left`, resets `22:35`
 - Weekly limit: `97% left`, resets `12:12 on 24 May`
 - GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `00:18 on 18 May`
 - GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `19:18 on 24 May`
+
+Updated snapshot after the latest Codex PR review fix:
+
+- Context window: `40% left (161K used / 258K)`
+- 5h limit: `94% left`, resets `22:35`
+- Weekly limit: `97% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `00:28 on 18 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `19:28 on 24 May`
+
+Quality versus context consumption note:
+
+- The latest Codex PR review consumed meaningful context but caught two
+  lifecycle issues that matter for real microphone reliability: starting the
+  PortAudio stream too early and failing to release audio resources on pipeline
+  stop. Both fixes improve Raspberry Pi/Linux and macOS operator behavior while
+  staying within E4-S8 scope and preserving mock-safe CI.
 
 ## Pre-Story Verification
 
@@ -89,9 +105,9 @@ Tests added:
 - WAV and microphone sources feed detector windows through the same
   `AudioCapturePipeline` contract.
 
-## Review Fix
+## Review Fixes
 
-Codex review on `PR #100` found one actionable issue:
+First Codex review on `PR #100` found one actionable issue:
 
 - If `sounddevice.RawInputStream(...)` succeeded but `start()` failed, the
   partially initialized stream was not closed before raising `AudioCaptureError`.
@@ -101,6 +117,31 @@ Fix applied:
 - `MicrophoneAudioInput` now tracks the created stream during startup and closes
   it in the failure path before re-raising.
 - Added a mocked regression test proving a stream is closed when `start()` raises.
+
+Latest Codex review on `PR #100` found two additional actionable lifecycle
+issues:
+
+- `MicrophoneAudioInput` started the PortAudio stream in its constructor, before
+  `AudioCapturePipeline.start()` began reading. A delay between construction and
+  capture start could let the backend buffer overflow before the first detector
+  window was emitted.
+- `AudioCapturePipeline.stop()` signalled and joined the worker but did not
+  release the underlying audio input, leaving microphone streams running and
+  device handles reserved unless callers remembered to call `close()`.
+
+Fixes applied:
+
+- `MicrophoneAudioInput` now opens the PortAudio stream lazily on first
+  `read_samples()` instead of during construction.
+- `AudioCapturePipeline.stop()` now closes audio inputs that expose `close()`.
+- `MicrophoneAudioInput.close()` resets its stream reference so a later
+  `read_samples()` reopens a fresh stream.
+- `WavAudioInput` is reopen-safe after stop-time closure and preserves its WAV
+  frame position across close/reopen.
+- Added mocked regression coverage for lazy microphone startup, start-failure
+  cleanup, overflow behavior, and stop-time stream release.
+- Thread-aware review refresh after the fix showed all `PR #100` review threads
+  resolved.
 
 ## Pull Request
 
@@ -118,13 +159,17 @@ Commits on the branch before this summary:
   `docs: document microphone selection`
 - `8c8e0f9e84cbb2470414c536db6d7fe44d765f97` -
   `fix: close microphone stream on startup failure`
+- `2f47e8c63386c3ddc6992429ecd24938e3a63e1b` -
+  `docs: add e4 s8 session summary`
+- `64f6060e56d1b8f9c5b117d4ed78a8b42383c455` -
+  `fix: align microphone stream lifecycle with capture`
 
 PR status when this summary was written:
 
 - state: open
 - draft: false
 - mergeable: true
-- head: `8c8e0f9e84cbb2470414c536db6d7fe44d765f97`
+- head: `64f6060e56d1b8f9c5b117d4ed78a8b42383c455`
 - GitHub Actions `Build Package`: passed
 - GitHub Actions `Checks`: passed
 
@@ -155,6 +200,15 @@ After review fix:
 - Ran `./.venv/bin/python -m ruff format --check .`: passed
 - Ran `./.venv/bin/python -m pyright`: `0 errors`
 - GitHub Actions on PR #100 passed after the review-fix commit.
+
+After latest lifecycle review fix:
+
+- Ran `./.venv/bin/python -m pytest tests/test_audio.py`: `18 passed`
+- Ran `./.venv/bin/python -m pytest`: `227 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+- GitHub Actions on PR #100 passed after the latest review-fix commit.
 
 ## Handoff Notes
 

--- a/docs/session-summaries/2026-05-17-e4-s8-add-microphone-and-wav-audio-input-adapters.md
+++ b/docs/session-summaries/2026-05-17-e4-s8-add-microphone-and-wav-audio-input-adapters.md
@@ -1,0 +1,176 @@
+# E4-S8 Add Microphone And WAV Audio Input Adapters Session
+
+## Scope
+
+This session resumed after `PR #98` for `E4-S7` was squashed and merged, and
+issue `#38` was closed. Work started from updated `main` on branch
+`feature/97-add-microphone-and-wav-audio-input-adapters` for issue `#97`,
+`E4-S8: Add microphone and WAV audio input adapters`.
+
+The story goal was to add concrete microphone and recorded WAV audio input
+adapters behind the E4-S6 `AudioInput` boundary. The work preserved the Epic 2
+one-session store boundary, MCP semantics, mock-safe defaults, coverage
+workflow, Epic 3 Hottop safety/validation boundary, and the E4-S1 through E4-S7
+released-artifact, audio-pipeline, and detector-adapter boundaries.
+
+The work did not add detector inference, ONNX export, model training, Hugging
+Face sync, local directory sync behavior, first-crack session timeline
+integration, broad coverage hardening, or live Hottop control changes.
+
+## Context Usage
+
+Session usage snapshot supplied by the operator after the E4-S8 review fix:
+
+- Context window: `51% left (133K used / 258K)`
+- 5h limit: `95% left`, resets `22:35`
+- Weekly limit: `97% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `00:18 on 18 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `19:18 on 24 May`
+
+## Pre-Story Verification
+
+Before starting E4-S8:
+
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding through the E4-S7 merge
+  to `aa42939`.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-17-e4-s7-add-detector-adapter.md`, and GitHub
+  issue `#97`.
+- Confirmed issue `#97` required microphone and recorded WAV source selection,
+  WAV replay through the same mono float sample contract, mocked microphone
+  tests, and Linux/Raspberry Pi suitability without real audio hardware in CI.
+
+## Implementation
+
+Updated:
+
+- `src/coffee_roaster_mcp/config.py`
+- `src/coffee_roaster_mcp/audio.py`
+- `tests/test_config.py`
+- `tests/test_audio.py`
+- `pyproject.toml`
+- `README.md`
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+Behavior added:
+
+- `AudioConfig` now includes `source: microphone|wav` and `wav_path`.
+- Environment overrides now include `COFFEE_AUDIO_SOURCE`,
+  `COFFEE_AUDIO_SAMPLE_RATE`, and `COFFEE_AUDIO_WAV_PATH`.
+- `build_audio_capture_pipeline(...)` can use a default
+  `build_configured_audio_input(...)` factory while preserving injected factories
+  for tests.
+- `WavAudioInput` reads PCM WAV files through Python stdlib `wave`, supports
+  8/16/24/32-bit PCM sample widths, converts multi-channel WAV frames to mono,
+  emits normalized float samples, and fails clearly when the file sample rate
+  differs from configured `audio.sample_rate`.
+- `MicrophoneAudioInput` opens a lazy PortAudio-backed
+  `sounddevice.RawInputStream` with configured device and sample rate, reads
+  mono float32 samples, and maps backend open/read/overflow failures to
+  `AudioCaptureError`.
+- `sounddevice>=0.5,<1` was added as a declared runtime dependency.
+- README now documents `audio.source`, WAV replay behavior, microphone device
+  selection, Linux/Raspberry Pi `arecord -l` / `arecord -L`, and why
+  `plughw:...` identifiers are often more forgiving than raw `hw:...` devices.
+
+Tests added:
+
+- Config defaults and YAML/env overrides cover audio source, sample rate, and
+  WAV path.
+- Invalid audio source values fail with config context.
+- Generated PCM WAV fixtures prove WAV source construction, mono sample output,
+  stereo-to-mono conversion, EOF behavior, and sample-rate mismatch failures.
+- Mocked microphone backend tests prove the configured device/sample-rate values
+  are passed to the PortAudio stream without touching real audio hardware.
+- Microphone overflow is reported as `AudioCaptureError`.
+- WAV and microphone sources feed detector windows through the same
+  `AudioCapturePipeline` contract.
+
+## Review Fix
+
+Codex review on `PR #100` found one actionable issue:
+
+- If `sounddevice.RawInputStream(...)` succeeded but `start()` failed, the
+  partially initialized stream was not closed before raising `AudioCaptureError`.
+
+Fix applied:
+
+- `MicrophoneAudioInput` now tracks the created stream during startup and closes
+  it in the failure path before re-raising.
+- Added a mocked regression test proving a stream is closed when `start()` raises.
+
+## Pull Request
+
+Opened `PR #100`: <https://github.com/syamaner/coffee-roaster-mcp/pull/100>
+
+PR branch:
+
+- `feature/97-add-microphone-and-wav-audio-input-adapters`
+
+Commits on the branch before this summary:
+
+- `1597bff663596c0e46ba5ddc0aeb5347e71d48f1` -
+  `feat: add microphone and wav audio inputs`
+- `deb1e44c92584efca184dd8b37eab06a86e5106b` -
+  `docs: document microphone selection`
+- `8c8e0f9e84cbb2470414c536db6d7fe44d765f97` -
+  `fix: close microphone stream on startup failure`
+
+PR status when this summary was written:
+
+- state: open
+- draft: false
+- mergeable: true
+- head: `8c8e0f9e84cbb2470414c536db6d7fe44d765f97`
+- GitHub Actions `Build Package`: passed
+- GitHub Actions `Checks`: passed
+
+Issue `#97` remains open and should close when PR #100 is merged through
+`Closes #97`.
+
+## Validation
+
+Initial E4-S8 implementation:
+
+- Ran `./.venv/bin/python -m pytest tests/test_audio.py tests/test_config.py`:
+  `30 passed`
+- Ran `./.venv/bin/python -m pytest`: `226 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+
+After microphone selection documentation:
+
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+
+After review fix:
+
+- Ran `./.venv/bin/python -m pytest tests/test_audio.py`: `18 passed`
+- Ran `./.venv/bin/python -m pytest`: `227 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+- GitHub Actions on PR #100 passed after the review-fix commit.
+
+## Handoff Notes
+
+After PR #100 merges:
+
+1. Sync `main`.
+2. Verify issue `#97` closes.
+3. Begin E4-S9 from updated `main`.
+4. Keep E4-S9 scoped to integrating confirmed detector output into the
+   authoritative session timeline.
+5. Do not add broader coverage hardening in E4-S9; E4-S10 owns the final Epic 4
+   coverage pass.
+6. Preserve mock-safe defaults and avoid real microphone requirements in CI.
+
+Suggested restart prompt after PR #100 is merged:
+
+```text
+Resume in /Users/sertanyamaner/git/coffee-roaster-mcp. PR #100 for E4-S8 was squashed and merged, and issue #97 is closed. First run git checkout main and git pull --ff-only origin main. Then read AGENTS.md, docs/state/registry.md, docs/state/epics/coffee-roaster-mcp-v0.1.md, docs/session-summaries/2026-05-17-e4-s8-add-microphone-and-wav-audio-input-adapters.md, and GitHub issue #39. Begin E4-S9 from updated main on branch feature/39-integrate-first-crack-with-session-timeline. Keep scope to integrating confirmed detector output into the authoritative session timeline exactly once, using the existing E4-S1 through E4-S8 resolver, validation, audio-source, audio-pipeline, and detector-adapter boundaries. Preserve the Epic 2 one-session store boundary, MCP semantics, mock-safe defaults, coverage workflow, Epic 3 Hottop safety/validation boundary, and optional/gated real microphone validation. Do not add model training, ONNX export, Hugging Face sync, local directory sync behavior, broad coverage hardening, or live Hottop control changes unless issue #39 explicitly requires it.
+```

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4-S8`
-- Current target: Add microphone and WAV audio input adapters
+- Active story: `E4-S9`
+- Current target: Integrate first crack with session timeline
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -69,6 +69,14 @@ The first implementation milestone is a mock vertical slice that requires no roa
   ONNX inference by itself, or write to the authoritative session timeline;
   E4-S9 owns timeline integration.
 - `E4-S8` is inserted after the detector adapter story to add concrete microphone and WAV audio input adapters behind the E4-S6 `AudioInput` boundary. This keeps Linux/Raspberry Pi microphone behavior and recorded-session replay explicit before first-crack events are wired into the session timeline in `E4-S9`.
+- `E4-S8` adds configured concrete audio sources behind the existing E4-S6
+  `AudioInput` boundary. `audio.source: microphone` opens a lazy
+  PortAudio-backed `sounddevice` raw input stream with configured device and
+  sample rate, keeping platform-specific macOS/Linux/Raspberry Pi behavior
+  behind the adapter. `audio.source: wav` reads PCM WAV files with stdlib
+  decoding, requires the WAV sample rate to match `audio.sample_rate`, converts
+  multi-channel files to mono, and returns the same mono float sample contract
+  as live microphone capture.
 - `E4-S10` closes Epic 4 with targeted test hardening before the next epic.
   It should reduce coverage gaps around the assembled first-crack path,
   MCP-facing behavior, current export surfaces, and mock-safe failure modes.
@@ -238,7 +246,7 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 - [x] `E4-S7` Add detector adapter.
   - Done when detector output maps to a confirmed first-crack event with timestamp, precision, revision, and confidence when available.
 
-- [ ] `E4-S8` Add microphone and WAV audio input adapters.
+- [x] `E4-S8` Add microphone and WAV audio input adapters.
   - Done when configured microphone and recorded WAV inputs can feed the detector window pipeline through the same audio source boundary.
 
 - [ ] `E4-S9` Integrate first crack with session timeline.
@@ -751,6 +759,33 @@ After completing a story:
   - Kept ONNX runtime inference, model training, ONNX export, Hugging Face sync, concrete microphone/WAV adapters, local directory sync behavior, MCP tool behavior, and authoritative session timeline writes out of scope.
   - Ran `./.venv/bin/python -m pytest tests/test_detector.py`: 8 passed.
   - Ran `./.venv/bin/python -m pytest`: 218 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E4-S8:
+  - Added explicit audio source selection with `audio.source: microphone|wav`,
+    `audio.wav_path`, and environment overrides for source, sample rate, and WAV
+    path while preserving `first_crack.mode: disabled` as the mock-safe default.
+  - Added `WavAudioInput` behind the E4-S6 `AudioInput` boundary. It reads PCM
+    WAV files with stdlib `wave`, supports 8/16/24/32-bit PCM sample widths,
+    converts multi-channel files to mono, emits normalized finite float samples,
+    and fails clearly when the WAV sample rate differs from configured
+    `audio.sample_rate`.
+  - Added `MicrophoneAudioInput` behind the same boundary. It opens a lazy
+    PortAudio-backed `sounddevice.RawInputStream` with configured device and
+    sample rate, reads mono float32 samples, and reports backend read/open errors
+    plus overflow as `AudioCaptureError`.
+  - Added `build_configured_audio_input(...)` as the source-selection factory
+    used by `build_audio_capture_pipeline(...)` when no test factory is injected.
+  - Tests cover config/source selection, generated WAV replay, stereo-to-mono WAV
+    conversion, WAV sample-rate mismatch, mocked microphone backend selection,
+    microphone overflow handling, and pipeline compatibility proving microphone
+    and WAV sources feed identical detector-window contracts.
+  - Kept detector inference, ONNX export, model training, Hugging Face sync,
+    local directory sync behavior, first-crack session timeline integration,
+    broad coverage hardening, and live Hottop control changes out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_audio.py tests/test_config.py`: 30 passed.
+  - Ran `./.venv/bin/python -m pytest`: 226 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -73,10 +73,15 @@ The first implementation milestone is a mock vertical slice that requires no roa
   `AudioInput` boundary. `audio.source: microphone` opens a lazy
   PortAudio-backed `sounddevice` raw input stream with configured device and
   sample rate, keeping platform-specific macOS/Linux/Raspberry Pi behavior
-  behind the adapter. `audio.source: wav` reads PCM WAV files with stdlib
-  decoding, requires the WAV sample rate to match `audio.sample_rate`, converts
-  multi-channel files to mono, and returns the same mono float sample contract
-  as live microphone capture.
+  behind the adapter. Leaving `audio.input_device` as `null` uses the system
+  default input. Operators can pin a specific microphone with a
+  PortAudio-resolvable device name or platform identifier; on Linux/Raspberry Pi
+  `arecord -l` / `arecord -L` should be used during manual setup, and
+  `plughw:...` identifiers are often more forgiving than raw `hw:...` devices.
+  `audio.source: wav` reads PCM WAV files with stdlib decoding, requires the WAV
+  sample rate to match `audio.sample_rate`, converts multi-channel files to
+  mono, and returns the same mono float sample contract as live microphone
+  capture.
 - `E4-S10` closes Epic 4 with targeted test hardening before the next epic.
   It should reduce coverage gaps around the assembled first-crack path,
   MCP-facing behavior, current export surfaces, and mock-safe failure modes.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -30,7 +30,7 @@ drop and emergency stop included. A follow-up 60-second stability test also held
 fan at `10%`, heat at `40%` for 30 seconds, then heat at `100%` for 30 seconds
 with continuous command streaming and no command-loop or status-read errors.
 
-E4-S7 is complete. The first-crack path now resolves the configured ONNX model
+E4-S8 is complete. The first-crack path now resolves the configured ONNX model
 artifact for both supported real-model precisions: `int8` selects
 `onnx/int8/model_quantized.onnx`, and `fp32` selects `onnx/fp32/model.onnx`
 through the artifact resolver. When `first_crack.local_model_dir` is configured,
@@ -46,17 +46,20 @@ bounded non-blocking queue for the detector adapter. The detector adapter now
 turns injected backend decisions into confirmed first-crack event candidates
 with monotonic timestamp, precision, revision, artifact, and optional confidence
 metadata for later session integration. This does not add model training,
-export, sync, concrete audio input adapters, local directory sync, ONNX runtime
-inference, or MCP session behavior.
+export, sync, local directory sync, ONNX runtime inference, or MCP session
+behavior. Configured microphone and recorded WAV sources now feed the same
+E4-S6 `AudioInput` boundary: microphone capture uses a lazy PortAudio-backed
+`sounddevice` stream with configured device and sample rate, while WAV replay
+uses stdlib PCM decoding, channel-to-mono conversion, and the same mono float
+sample contract as live capture. Real microphone validation remains optional
+and gated; normal CI uses mocked microphone backends and generated WAV fixtures.
 
-The next story is E4-S8: add microphone and WAV audio input adapters.
-Epic 4 now includes a new E4-S8 story for concrete microphone and WAV audio
-input adapters before session timeline integration. The previous timeline
-integration story is now E4-S9. Epic 4 also now includes E4-S10 as a closing
-test-hardening story before the next epic, focused on first-crack integration,
-MCP-facing behavior, export assertions, mock-safe failure modes, and coverage
-gaps. Real microphone validation is optional and must remain explicitly gated so
-normal CI does not require audio hardware.
+The next story is E4-S9: integrate first crack with the session timeline.
+Epic 4 includes E4-S10 as a closing test-hardening story before the next epic,
+focused on first-crack integration, MCP-facing behavior, export assertions,
+mock-safe failure modes, and coverage gaps. Real microphone validation is
+optional and must remain explicitly gated so normal CI does not require audio
+hardware.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
   "huggingface_hub>=0.23,<1",
   "mcp>=1.0.0,<2",
   "pyserial>=3.5",
-  "PyYAML>=6.0.2"
+  "PyYAML>=6.0.2",
+  "sounddevice>=0.5,<1"
 ]
 
 [project.urls]

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -181,32 +181,48 @@ class WavAudioInput:
         if sample_rate <= 0:
             raise AudioCaptureError("audio.sample_rate must be > 0.")
         self._path = Path(path)
+        self._wav: Any | None = None
+        self._frame_position = 0
+        self._channel_count = 0
+        self._sample_width = 0
+        self._sample_rate = sample_rate
+        self._open_wav()
+
+    def _open_wav(self) -> None:
         try:
-            self._wav = wave.open(str(self._path), "rb")  # noqa: SIM115 - input owns the handle.
+            wav_file = wave.open(str(self._path), "rb")  # noqa: SIM115 - input owns the handle.
         except (OSError, wave.Error) as exc:
             raise AudioCaptureError(f"Could not open WAV audio source {self._path}: {exc}") from exc
 
-        self._channel_count = self._wav.getnchannels()
-        self._sample_width = self._wav.getsampwidth()
-        wav_sample_rate = self._wav.getframerate()
+        self._wav = wav_file
+        self._channel_count = wav_file.getnchannels()
+        self._sample_width = wav_file.getsampwidth()
+        wav_sample_rate = wav_file.getframerate()
         if self._channel_count < 1:
             self.close()
             raise AudioCaptureError("WAV audio source must have at least one channel.")
         if self._sample_width not in {1, 2, 3, 4}:
             self.close()
             raise AudioCaptureError("WAV audio source must use 8, 16, 24, or 32-bit PCM samples.")
-        if wav_sample_rate != sample_rate:
+        if wav_sample_rate != self._sample_rate:
             self.close()
             raise AudioCaptureError(
                 "WAV audio source sample rate "
-                f"{wav_sample_rate} does not match configured audio.sample_rate {sample_rate}."
+                f"{wav_sample_rate} does not match configured audio.sample_rate "
+                f"{self._sample_rate}."
             )
+        wav_file.setpos(self._frame_position)
 
     def read_samples(self, sample_count: int) -> Sequence[float]:
         """Read up to `sample_count` mono floating-point samples from the WAV file."""
         if sample_count <= 0:
             return ()
+        if self._wav is None:
+            self._open_wav()
+        if self._wav is None:
+            raise AudioCaptureError("WAV audio source is not open.")
         raw_frames = self._wav.readframes(sample_count)
+        self._frame_position = self._wav.tell()
         if not raw_frames:
             return ()
         return _decode_pcm_frames(
@@ -217,7 +233,12 @@ class WavAudioInput:
 
     def close(self) -> None:
         """Close the underlying WAV file."""
+        if self._wav is None:
+            return
+        with suppress(Exception):
+            self._frame_position = self._wav.tell()
         self._wav.close()
+        self._wav = None
 
     def __enter__(self) -> Self:
         """Return this WAV input as a context manager."""
@@ -242,7 +263,7 @@ class MicrophoneAudioInput:
         *,
         sounddevice_module: Any | None = None,
     ) -> None:
-        """Open a PortAudio-backed microphone stream.
+        """Configure a microphone input that opens lazily on first read.
 
         Args:
             settings: Validated audio capture settings.
@@ -250,32 +271,39 @@ class MicrophoneAudioInput:
         """
         _validate_settings(settings)
         self._settings = settings
-        sounddevice = sounddevice_module or _load_sounddevice()
+        self._sounddevice = sounddevice_module or _load_sounddevice()
+        self._stream: Any | None = None
+
+    def _ensure_stream(self) -> Any:
+        if self._stream is not None:
+            return self._stream
         stream: Any | None = None
         try:
-            stream_factory = sounddevice.RawInputStream
+            stream_factory = self._sounddevice.RawInputStream
             created_stream = stream_factory(
-                samplerate=settings.sample_rate,
-                device=settings.input_device,
+                samplerate=self._settings.sample_rate,
+                device=self._settings.input_device,
                 channels=1,
                 dtype="float32",
                 blocksize=0,
             )
             stream = created_stream
-            self._stream: Any = created_stream
+            self._stream = created_stream
             created_stream.start()
         except Exception as exc:  # noqa: BLE001 - backend exceptions vary by platform.
             if stream is not None:
                 with suppress(Exception):
                     stream.close()
             raise AudioCaptureError(f"Could not open microphone audio source: {exc}") from exc
+        return self._stream
 
     def read_samples(self, sample_count: int) -> Sequence[float]:
         """Read up to `sample_count` mono floating-point samples from the microphone."""
         if sample_count <= 0:
             return ()
+        stream = self._ensure_stream()
         try:
-            raw_data, overflowed = self._stream.read(sample_count)
+            raw_data, overflowed = stream.read(sample_count)
         except Exception as exc:  # noqa: BLE001 - backend exceptions vary by platform.
             raise AudioCaptureError(f"Could not read microphone audio source: {exc}") from exc
         if overflowed:
@@ -284,10 +312,14 @@ class MicrophoneAudioInput:
 
     def close(self) -> None:
         """Stop and close the microphone stream."""
+        stream = self._stream
+        if stream is None:
+            return
         try:
-            self._stream.stop()
+            stream.stop()
         finally:
-            self._stream.close()
+            stream.close()
+            self._stream = None
 
     def __enter__(self) -> Self:
         """Return this microphone input as a context manager."""
@@ -368,12 +400,13 @@ class AudioCapturePipeline:
         thread = self._thread
         if thread is not None:
             thread.join(timeout=timeout_seconds)
-        return self.snapshot()
+        snapshot = self.snapshot()
+        _close_audio_input_if_supported(self._audio_input)
+        return snapshot
 
     def close(self) -> None:
         """Stop capture and close the underlying audio input when supported."""
         self.stop()
-        _close_audio_input_if_supported(self._audio_input)
 
     def get_window(
         self,

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -8,6 +8,7 @@ import struct
 import time
 import wave
 from collections.abc import Callable, Sequence
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from queue import Empty, Full, Queue
@@ -250,17 +251,23 @@ class MicrophoneAudioInput:
         _validate_settings(settings)
         self._settings = settings
         sounddevice = sounddevice_module or _load_sounddevice()
+        stream: Any | None = None
         try:
             stream_factory = sounddevice.RawInputStream
-            self._stream = stream_factory(
+            created_stream = stream_factory(
                 samplerate=settings.sample_rate,
                 device=settings.input_device,
                 channels=1,
                 dtype="float32",
                 blocksize=0,
             )
-            self._stream.start()
+            stream = created_stream
+            self._stream: Any = created_stream
+            created_stream.start()
         except Exception as exc:  # noqa: BLE001 - backend exceptions vary by platform.
+            if stream is not None:
+                with suppress(Exception):
+                    stream.close()
             raise AudioCaptureError(f"Could not open microphone audio source: {exc}") from exc
 
     def read_samples(self, sample_count: int) -> Sequence[float]:

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -294,6 +294,7 @@ class MicrophoneAudioInput:
             if stream is not None:
                 with suppress(Exception):
                     stream.close()
+            self._stream = None
             raise AudioCaptureError(f"Could not open microphone audio source: {exc}") from exc
         return self._stream
 
@@ -525,7 +526,7 @@ def _normalize_sample(sample: float) -> float:
 def _load_sounddevice() -> Any:
     try:
         return importlib.import_module("sounddevice")
-    except ImportError as exc:
+    except (ImportError, OSError) as exc:
         raise AudioCaptureError(
             "Microphone audio input requires the sounddevice package and PortAudio runtime."
         ) from exc

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import importlib
 import math
+import struct
 import time
+import wave
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from queue import Empty, Full, Queue
 from threading import Event, Lock, Thread
-from typing import Protocol
+from types import TracebackType
+from typing import Any, Protocol, Self, cast
 
 from coffee_roaster_mcp.config import AudioConfig
 
@@ -44,6 +49,8 @@ class AudioCaptureSettings:
     Attributes:
         input_device: Optional configured audio input identifier.
         sample_rate: Audio sample rate in Hz.
+        source: Configured audio source type.
+        wav_path: Optional WAV source path when source is `wav`.
         window_seconds: Detector window duration in seconds.
         queue_limit: Maximum detector windows retained for downstream consumers.
         idle_sleep_seconds: Sleep duration when an input read returns no samples.
@@ -51,6 +58,8 @@ class AudioCaptureSettings:
 
     input_device: str | None
     sample_rate: int
+    source: str = "microphone"
+    wav_path: Path | None = None
     window_seconds: float = DEFAULT_AUDIO_WINDOW_SECONDS
     queue_limit: int = DEFAULT_AUDIO_WINDOW_QUEUE_LIMIT
     idle_sleep_seconds: float = DEFAULT_AUDIO_IDLE_SLEEP_SECONDS
@@ -111,7 +120,9 @@ def audio_capture_settings_from_config(
     """Build validated audio capture settings from application config."""
     settings = AudioCaptureSettings(
         input_device=config.input_device,
+        source=config.source,
         sample_rate=config.sample_rate,
+        wav_path=config.wav_path,
         window_seconds=window_seconds,
         queue_limit=queue_limit,
         idle_sleep_seconds=idle_sleep_seconds,
@@ -122,7 +133,7 @@ def audio_capture_settings_from_config(
 
 def build_audio_capture_pipeline(
     config: AudioConfig,
-    input_factory: AudioInputFactory,
+    input_factory: AudioInputFactory | None = None,
     *,
     window_seconds: float = DEFAULT_AUDIO_WINDOW_SECONDS,
     queue_limit: int = DEFAULT_AUDIO_WINDOW_QUEUE_LIMIT,
@@ -130,6 +141,7 @@ def build_audio_capture_pipeline(
     monotonic_now: Callable[[], float] | None = None,
 ) -> AudioCapturePipeline:
     """Create an audio capture pipeline from configured audio input settings."""
+    resolved_input_factory = input_factory or build_configured_audio_input
     settings = audio_capture_settings_from_config(
         config,
         window_seconds=window_seconds,
@@ -138,9 +150,150 @@ def build_audio_capture_pipeline(
     )
     return AudioCapturePipeline(
         settings=settings,
-        audio_input=input_factory(settings),
+        audio_input=resolved_input_factory(settings),
         monotonic_now=monotonic_now,
     )
+
+
+def build_configured_audio_input(settings: AudioCaptureSettings) -> AudioInput:
+    """Create the concrete configured audio input."""
+    _validate_settings(settings)
+    if settings.source == "microphone":
+        return MicrophoneAudioInput(settings)
+    if settings.source == "wav":
+        if settings.wav_path is None:
+            raise AudioCaptureError("audio.wav_path must be configured when audio.source is wav.")
+        return WavAudioInput(settings.wav_path, sample_rate=settings.sample_rate)
+    raise AudioCaptureError("audio.source must be one of: microphone, wav.")
+
+
+class WavAudioInput:
+    """Read mono float samples from a PCM WAV file."""
+
+    def __init__(self, path: str | Path, *, sample_rate: int) -> None:
+        """Open a PCM WAV file for detector replay.
+
+        Args:
+            path: Path to a WAV file.
+            sample_rate: Expected sample rate in Hz.
+        """
+        if sample_rate <= 0:
+            raise AudioCaptureError("audio.sample_rate must be > 0.")
+        self._path = Path(path)
+        try:
+            self._wav = wave.open(str(self._path), "rb")  # noqa: SIM115 - input owns the handle.
+        except (OSError, wave.Error) as exc:
+            raise AudioCaptureError(f"Could not open WAV audio source {self._path}: {exc}") from exc
+
+        self._channel_count = self._wav.getnchannels()
+        self._sample_width = self._wav.getsampwidth()
+        wav_sample_rate = self._wav.getframerate()
+        if self._channel_count < 1:
+            self.close()
+            raise AudioCaptureError("WAV audio source must have at least one channel.")
+        if self._sample_width not in {1, 2, 3, 4}:
+            self.close()
+            raise AudioCaptureError("WAV audio source must use 8, 16, 24, or 32-bit PCM samples.")
+        if wav_sample_rate != sample_rate:
+            self.close()
+            raise AudioCaptureError(
+                "WAV audio source sample rate "
+                f"{wav_sample_rate} does not match configured audio.sample_rate {sample_rate}."
+            )
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        """Read up to `sample_count` mono floating-point samples from the WAV file."""
+        if sample_count <= 0:
+            return ()
+        raw_frames = self._wav.readframes(sample_count)
+        if not raw_frames:
+            return ()
+        return _decode_pcm_frames(
+            raw_frames,
+            channel_count=self._channel_count,
+            sample_width=self._sample_width,
+        )
+
+    def close(self) -> None:
+        """Close the underlying WAV file."""
+        self._wav.close()
+
+    def __enter__(self) -> Self:
+        """Return this WAV input as a context manager."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close the WAV input when leaving a context manager."""
+        self.close()
+
+
+class MicrophoneAudioInput:
+    """Read mono float samples from the configured system microphone."""
+
+    def __init__(
+        self,
+        settings: AudioCaptureSettings,
+        *,
+        sounddevice_module: Any | None = None,
+    ) -> None:
+        """Open a PortAudio-backed microphone stream.
+
+        Args:
+            settings: Validated audio capture settings.
+            sounddevice_module: Optional injected sounddevice-compatible module for tests.
+        """
+        _validate_settings(settings)
+        self._settings = settings
+        sounddevice = sounddevice_module or _load_sounddevice()
+        try:
+            stream_factory = sounddevice.RawInputStream
+            self._stream = stream_factory(
+                samplerate=settings.sample_rate,
+                device=settings.input_device,
+                channels=1,
+                dtype="float32",
+                blocksize=0,
+            )
+            self._stream.start()
+        except Exception as exc:  # noqa: BLE001 - backend exceptions vary by platform.
+            raise AudioCaptureError(f"Could not open microphone audio source: {exc}") from exc
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        """Read up to `sample_count` mono floating-point samples from the microphone."""
+        if sample_count <= 0:
+            return ()
+        try:
+            raw_data, overflowed = self._stream.read(sample_count)
+        except Exception as exc:  # noqa: BLE001 - backend exceptions vary by platform.
+            raise AudioCaptureError(f"Could not read microphone audio source: {exc}") from exc
+        if overflowed:
+            raise AudioCaptureError("Microphone audio input overflowed.")
+        return tuple(float(sample[0]) for sample in struct.iter_unpack("f", bytes(raw_data)))
+
+    def close(self) -> None:
+        """Stop and close the microphone stream."""
+        try:
+            self._stream.stop()
+        finally:
+            self._stream.close()
+
+    def __enter__(self) -> Self:
+        """Return this microphone input as a context manager."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close the microphone input when leaving a context manager."""
+        self.close()
 
 
 class AudioCapturePipeline:
@@ -209,6 +362,11 @@ class AudioCapturePipeline:
         if thread is not None:
             thread.join(timeout=timeout_seconds)
         return self.snapshot()
+
+    def close(self) -> None:
+        """Stop capture and close the underlying audio input when supported."""
+        self.stop()
+        _close_audio_input_if_supported(self._audio_input)
 
     def get_window(
         self,
@@ -305,6 +463,8 @@ class AudioCapturePipeline:
 
 
 def _validate_settings(settings: AudioCaptureSettings) -> None:
+    if settings.source not in {"microphone", "wav"}:
+        raise AudioCaptureError("audio.source must be one of: microphone, wav.")
     if settings.sample_rate <= 0:
         raise AudioCaptureError("audio.sample_rate must be > 0.")
     if not math.isfinite(settings.window_seconds) or settings.window_seconds <= 0:
@@ -320,3 +480,63 @@ def _normalize_sample(sample: float) -> float:
     if not math.isfinite(normalized):
         raise AudioCaptureError("audio samples must be finite numbers.")
     return normalized
+
+
+def _load_sounddevice() -> Any:
+    try:
+        return importlib.import_module("sounddevice")
+    except ImportError as exc:
+        raise AudioCaptureError(
+            "Microphone audio input requires the sounddevice package and PortAudio runtime."
+        ) from exc
+
+
+def _decode_pcm_frames(
+    raw_frames: bytes,
+    *,
+    channel_count: int,
+    sample_width: int,
+) -> tuple[float, ...]:
+    sample_values = _decode_pcm_samples(raw_frames, sample_width=sample_width)
+    if channel_count == 1:
+        return sample_values
+
+    mono_samples: list[float] = []
+    frame_count = len(sample_values) // channel_count
+    for frame_index in range(frame_count):
+        frame_start = frame_index * channel_count
+        frame = sample_values[frame_start : frame_start + channel_count]
+        mono_samples.append(sum(frame) / channel_count)
+    return tuple(mono_samples)
+
+
+def _decode_pcm_samples(raw_frames: bytes, *, sample_width: int) -> tuple[float, ...]:
+    if sample_width == 1:
+        return tuple((sample - 128) / 128.0 for sample in raw_frames)
+    if sample_width == 2:
+        return tuple(sample[0] / 32768.0 for sample in struct.iter_unpack("<h", raw_frames))
+    if sample_width == 3:
+        return tuple(
+            _decode_signed_24bit(raw_frames[index : index + 3]) / 8388608.0
+            for index in range(0, len(raw_frames), 3)
+        )
+    if sample_width == 4:
+        return tuple(sample[0] / 2147483648.0 for sample in struct.iter_unpack("<i", raw_frames))
+    raise AudioCaptureError("WAV audio source must use 8, 16, 24, or 32-bit PCM samples.")
+
+
+def _decode_signed_24bit(raw_sample: bytes) -> int:
+    if len(raw_sample) != 3:
+        raise AudioCaptureError("WAV audio source contained a partial 24-bit sample.")
+    value = int.from_bytes(raw_sample, byteorder="little", signed=False)
+    if value & 0x800000:
+        value -= 0x1000000
+    return value
+
+
+def _close_audio_input_if_supported(audio_input: AudioInput) -> None:
+    close = getattr(audio_input, "close", None)
+    if close is None:
+        return
+    close_method = cast(Callable[[], None], close)
+    close_method()

--- a/src/coffee_roaster_mcp/config.py
+++ b/src/coffee_roaster_mcp/config.py
@@ -14,6 +14,7 @@ TransportType = Literal["stdio"]
 TemperatureUnit = Literal["celsius", "fahrenheit", "auto"]
 FirstCrackMode = Literal["disabled", "audio", "manual"]
 ModelPrecision = Literal["int8", "fp32"]
+AudioSource = Literal["microphone", "wav"]
 ExportFormat = Literal["jsonl", "csv", "summary"]
 
 
@@ -52,8 +53,10 @@ class FirstCrackConfig:
 class AudioConfig:
     """Audio capture configuration."""
 
+    source: AudioSource = "microphone"
     input_device: str | None = None
     sample_rate: int = 16_000
+    wav_path: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -227,8 +230,13 @@ def _first_crack_from_mapping(raw: Mapping[str, Any]) -> FirstCrackConfig:
 
 def _audio_from_mapping(raw: Mapping[str, Any]) -> AudioConfig:
     return AudioConfig(
+        source=_audio_source(
+            _string(raw, "source", "microphone", label="audio.source"),
+            label="audio.source",
+        ),
         input_device=_optional_string(raw, "input_device", label="audio.input_device"),
         sample_rate=_integer(raw, "sample_rate", 16_000, label="audio.sample_rate"),
+        wav_path=_optional_path(raw, "wav_path", label="audio.wav_path"),
     )
 
 
@@ -334,8 +342,24 @@ def _apply_env_overrides(config: AppConfig, environ: Mapping[str, str]) -> AppCo
             ),
         )
 
+    if "COFFEE_AUDIO_SOURCE" in environ:
+        audio = replace(
+            audio,
+            source=_audio_source(environ["COFFEE_AUDIO_SOURCE"], label="COFFEE_AUDIO_SOURCE"),
+        )
     if "COFFEE_AUDIO_INPUT_DEVICE" in environ:
         audio = replace(audio, input_device=_none_if_empty(environ["COFFEE_AUDIO_INPUT_DEVICE"]))
+    if "COFFEE_AUDIO_SAMPLE_RATE" in environ:
+        audio = replace(
+            audio,
+            sample_rate=_parse_integer(
+                environ["COFFEE_AUDIO_SAMPLE_RATE"],
+                "COFFEE_AUDIO_SAMPLE_RATE",
+            ),
+        )
+    if "COFFEE_AUDIO_WAV_PATH" in environ:
+        wav_path = _none_if_empty(environ["COFFEE_AUDIO_WAV_PATH"])
+        audio = replace(audio, wav_path=Path(wav_path) if wav_path is not None else None)
 
     if "COFFEE_ROAST_LOG_DIR" in environ:
         logging = replace(
@@ -462,6 +486,13 @@ def _model_precision(value: str, label: str = "first_crack.precision") -> ModelP
     if normalized not in {"int8", "fp32"}:
         raise ConfigError(f"{label} must be one of: int8, fp32.")
     return cast(ModelPrecision, normalized)
+
+
+def _audio_source(value: str, label: str = "audio.source") -> AudioSource:
+    normalized = _normalized_token(value)
+    if normalized not in {"microphone", "wav"}:
+        raise ConfigError(f"{label} must be one of: microphone, wav.")
+    return cast(AudioSource, normalized)
 
 
 def _export_formats(value: object) -> tuple[ExportFormat, ...]:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -10,6 +10,7 @@ from threading import Lock, Thread
 
 import pytest
 
+from coffee_roaster_mcp import audio as audio_module
 from coffee_roaster_mcp.audio import (
     AudioCaptureError,
     AudioCapturePipeline,
@@ -131,6 +132,10 @@ class OverflowingRawInputStream(FakeRawInputStream):
 
 class FakeSoundDeviceModule:
     RawInputStream = FakeRawInputStream
+
+
+class RecoveringSoundDeviceModule:
+    RawInputStream: type[FakeRawInputStream] = StartFailingRawInputStream
 
 
 class StartFailingSoundDeviceModule:
@@ -290,6 +295,41 @@ def test_microphone_audio_input_closes_stream_when_start_fails() -> None:
 
     stream = FakeRawInputStream.created[0]
     assert stream.closed is True
+
+
+def test_microphone_audio_input_retries_after_start_failure() -> None:
+    FakeRawInputStream.created.clear()
+    settings = audio_capture_settings_from_config(
+        AudioConfig(source="microphone", input_device="busy-once", sample_rate=4)
+    )
+    sounddevice = RecoveringSoundDeviceModule()
+    audio_input = MicrophoneAudioInput(settings, sounddevice_module=sounddevice)
+
+    with pytest.raises(AudioCaptureError, match="device busy"):
+        audio_input.read_samples(1)
+
+    sounddevice.RawInputStream = FakeRawInputStream
+    samples = audio_input.read_samples(1)
+
+    assert len(FakeRawInputStream.created) == 2
+    assert FakeRawInputStream.created[0].closed is True
+    assert FakeRawInputStream.created[1].started is True
+    assert samples == (0.25,)
+
+
+def test_microphone_audio_input_normalizes_missing_portaudio_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = audio_capture_settings_from_config(AudioConfig(source="microphone", sample_rate=4))
+
+    def fail_import(module_name: str) -> object:
+        assert module_name == "sounddevice"
+        raise OSError("PortAudio library not found")
+
+    monkeypatch.setattr(audio_module.importlib, "import_module", fail_import)
+
+    with pytest.raises(AudioCaptureError, match="PortAudio runtime"):
+        build_configured_audio_input(settings)
 
 
 def test_wav_and_microphone_sources_feed_same_window_contract(tmp_path: Path) -> None:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -109,12 +109,36 @@ class StartFailingRawInputStream(FakeRawInputStream):
         raise RuntimeError("device busy")
 
 
+class OverflowingRawInputStream(FakeRawInputStream):
+    def __init__(
+        self,
+        *,
+        samplerate: int,
+        device: str | None,
+        channels: int,
+        dtype: str,
+        blocksize: int,
+    ) -> None:
+        super().__init__(
+            samplerate=samplerate,
+            device=device,
+            channels=channels,
+            dtype=dtype,
+            blocksize=blocksize,
+        )
+        self.overflowed = True
+
+
 class FakeSoundDeviceModule:
     RawInputStream = FakeRawInputStream
 
 
 class StartFailingSoundDeviceModule:
     RawInputStream = StartFailingRawInputStream
+
+
+class OverflowingSoundDeviceModule:
+    RawInputStream = OverflowingRawInputStream
 
 
 class ClockHarness:
@@ -222,7 +246,10 @@ def test_microphone_audio_input_uses_configured_portaudio_stream() -> None:
         AudioConfig(source="microphone", input_device="hw:1,0", sample_rate=4)
     )
 
-    with MicrophoneAudioInput(settings, sounddevice_module=FakeSoundDeviceModule()) as audio_input:
+    audio_input = MicrophoneAudioInput(settings, sounddevice_module=FakeSoundDeviceModule())
+    assert FakeRawInputStream.created == []
+
+    with audio_input:
         samples = audio_input.read_samples(3)
 
     stream = FakeRawInputStream.created[0]
@@ -240,8 +267,7 @@ def test_microphone_audio_input_uses_configured_portaudio_stream() -> None:
 def test_microphone_audio_input_reports_overflow() -> None:
     FakeRawInputStream.created.clear()
     settings = audio_capture_settings_from_config(AudioConfig(source="microphone", sample_rate=4))
-    audio_input = MicrophoneAudioInput(settings, sounddevice_module=FakeSoundDeviceModule())
-    FakeRawInputStream.created[0].overflowed = True
+    audio_input = MicrophoneAudioInput(settings, sounddevice_module=OverflowingSoundDeviceModule())
 
     try:
         with pytest.raises(AudioCaptureError, match="overflowed"):
@@ -257,7 +283,10 @@ def test_microphone_audio_input_closes_stream_when_start_fails() -> None:
     )
 
     with pytest.raises(AudioCaptureError, match="device busy"):
-        MicrophoneAudioInput(settings, sounddevice_module=StartFailingSoundDeviceModule())
+        MicrophoneAudioInput(
+            settings,
+            sounddevice_module=StartFailingSoundDeviceModule(),
+        ).read_samples(1)
 
     stream = FakeRawInputStream.created[0]
     assert stream.closed is True
@@ -291,9 +320,12 @@ def test_wav_and_microphone_sources_feed_same_window_contract(tmp_path: Path) ->
 
     wav_window = wav_pipeline.drain_windows()[0]
     microphone_window = microphone_pipeline.drain_windows()[0]
+    microphone_stream = FakeRawInputStream.created[-1]
     assert wav_window.sample_rate == microphone_window.sample_rate == 4
     assert len(wav_window.samples) == len(microphone_window.samples) == 4
     assert wav_window.duration_seconds == microphone_window.duration_seconds == 1.0
+    assert microphone_stream.stopped is True
+    assert microphone_stream.closed is True
 
 
 def test_audio_capture_pipeline_feeds_detector_windows_from_mock_input() -> None:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import struct
 import time
+import wave
 from collections.abc import Callable, Sequence
+from pathlib import Path
 from queue import Queue
 from threading import Lock, Thread
 
@@ -12,8 +15,11 @@ from coffee_roaster_mcp.audio import (
     AudioCapturePipeline,
     AudioCaptureSettings,
     AudioInput,
+    MicrophoneAudioInput,
+    WavAudioInput,
     audio_capture_settings_from_config,
     build_audio_capture_pipeline,
+    build_configured_audio_input,
 )
 from coffee_roaster_mcp.config import AudioConfig
 
@@ -55,6 +61,51 @@ class MutableAudioInput:
 class FailingAudioInput:
     def read_samples(self, sample_count: int) -> Sequence[float]:
         raise RuntimeError(f"capture failed after {sample_count} requested samples")
+
+
+class FakeRawInputStream:
+    created: list[FakeRawInputStream] = []
+
+    def __init__(
+        self,
+        *,
+        samplerate: int,
+        device: str | None,
+        channels: int,
+        dtype: str,
+        blocksize: int,
+    ) -> None:
+        self.samplerate = samplerate
+        self.device = device
+        self.channels = channels
+        self.dtype = dtype
+        self.blocksize = blocksize
+        self.started = False
+        self.stopped = False
+        self.closed = False
+        self.overflowed = False
+        self._samples = [0.25, -0.5, 0.75, 1.0]
+        self.read_counts: list[int] = []
+        FakeRawInputStream.created.append(self)
+
+    def start(self) -> None:
+        self.started = True
+
+    def read(self, sample_count: int) -> tuple[bytes, bool]:
+        self.read_counts.append(sample_count)
+        samples = self._samples[:sample_count]
+        del self._samples[:sample_count]
+        return struct.pack(f"{len(samples)}f", *samples), self.overflowed
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeSoundDeviceModule:
+    RawInputStream = FakeRawInputStream
 
 
 class ClockHarness:
@@ -107,6 +158,120 @@ def test_build_audio_capture_pipeline_passes_config_to_input_factory() -> None:
     assert pipeline.settings.input_device == "configured-mic"
     assert pipeline.settings.sample_rate == 4
     assert factory_calls == [pipeline.settings]
+
+
+def test_configured_audio_input_factory_builds_wav_source(tmp_path: Path) -> None:
+    wav_path = tmp_path / "fixture.wav"
+    _write_pcm16_wav(
+        wav_path,
+        sample_rate=4,
+        channel_count=1,
+        samples=(0, 16_384, -16_384, 32_767),
+    )
+    settings = audio_capture_settings_from_config(
+        AudioConfig(source="wav", sample_rate=4, wav_path=wav_path),
+    )
+
+    audio_input = build_configured_audio_input(settings)
+
+    assert isinstance(audio_input, WavAudioInput)
+    assert audio_input.read_samples(4) == (0.0, 0.5, -0.5, 32_767 / 32_768)
+
+
+def test_configured_audio_input_factory_requires_wav_path() -> None:
+    settings = audio_capture_settings_from_config(AudioConfig(source="wav", sample_rate=4))
+
+    with pytest.raises(AudioCaptureError, match="audio.wav_path"):
+        build_configured_audio_input(settings)
+
+
+def test_wav_audio_input_averages_channels_to_mono_float_samples(tmp_path: Path) -> None:
+    wav_path = tmp_path / "stereo.wav"
+    _write_pcm16_wav(
+        wav_path,
+        sample_rate=4,
+        channel_count=2,
+        samples=(32_767, 32_767, 0, 0, -32_768, -32_768),
+    )
+
+    with WavAudioInput(wav_path, sample_rate=4) as audio_input:
+        assert audio_input.read_samples(3) == (32_767 / 32_768, 0.0, -1.0)
+        assert audio_input.read_samples(3) == ()
+
+
+def test_wav_audio_input_rejects_sample_rate_mismatch(tmp_path: Path) -> None:
+    wav_path = tmp_path / "wrong-rate.wav"
+    _write_pcm16_wav(wav_path, sample_rate=8, channel_count=1, samples=(0,))
+
+    with pytest.raises(AudioCaptureError, match="sample rate 8"):
+        WavAudioInput(wav_path, sample_rate=4)
+
+
+def test_microphone_audio_input_uses_configured_portaudio_stream() -> None:
+    FakeRawInputStream.created.clear()
+    settings = audio_capture_settings_from_config(
+        AudioConfig(source="microphone", input_device="hw:1,0", sample_rate=4)
+    )
+
+    with MicrophoneAudioInput(settings, sounddevice_module=FakeSoundDeviceModule()) as audio_input:
+        samples = audio_input.read_samples(3)
+
+    stream = FakeRawInputStream.created[0]
+    assert stream.samplerate == 4
+    assert stream.device == "hw:1,0"
+    assert stream.channels == 1
+    assert stream.dtype == "float32"
+    assert stream.started is True
+    assert stream.stopped is True
+    assert stream.closed is True
+    assert stream.read_counts == [3]
+    assert samples == (0.25, -0.5, 0.75)
+
+
+def test_microphone_audio_input_reports_overflow() -> None:
+    FakeRawInputStream.created.clear()
+    settings = audio_capture_settings_from_config(AudioConfig(source="microphone", sample_rate=4))
+    audio_input = MicrophoneAudioInput(settings, sounddevice_module=FakeSoundDeviceModule())
+    FakeRawInputStream.created[0].overflowed = True
+
+    try:
+        with pytest.raises(AudioCaptureError, match="overflowed"):
+            audio_input.read_samples(1)
+    finally:
+        audio_input.close()
+
+
+def test_wav_and_microphone_sources_feed_same_window_contract(tmp_path: Path) -> None:
+    wav_path = tmp_path / "fixture.wav"
+    _write_pcm16_wav(wav_path, sample_rate=4, channel_count=1, samples=(0, 8192, -8192, 16_384))
+    wav_pipeline = build_audio_capture_pipeline(
+        AudioConfig(source="wav", sample_rate=4, wav_path=wav_path),
+        window_seconds=1.0,
+        idle_sleep_seconds=0.001,
+    )
+
+    wav_pipeline.start()
+    _wait_for(lambda: wav_pipeline.snapshot().emitted_window_count == 1)
+    wav_pipeline.stop()
+
+    microphone_pipeline = build_audio_capture_pipeline(
+        AudioConfig(source="microphone", input_device="mock-mic", sample_rate=4),
+        lambda settings: MicrophoneAudioInput(
+            settings,
+            sounddevice_module=FakeSoundDeviceModule(),
+        ),
+        window_seconds=1.0,
+        idle_sleep_seconds=0.001,
+    )
+    microphone_pipeline.start()
+    _wait_for(lambda: microphone_pipeline.snapshot().emitted_window_count == 1)
+    microphone_pipeline.stop()
+
+    wav_window = wav_pipeline.drain_windows()[0]
+    microphone_window = microphone_pipeline.drain_windows()[0]
+    assert wav_window.sample_rate == microphone_window.sample_rate == 4
+    assert len(wav_window.samples) == len(microphone_window.samples) == 4
+    assert wav_window.duration_seconds == microphone_window.duration_seconds == 1.0
 
 
 def test_audio_capture_pipeline_feeds_detector_windows_from_mock_input() -> None:
@@ -287,3 +452,17 @@ def _wait_for(predicate: Callable[[], bool], *, timeout_seconds: float = 1.0) ->
             return
         time.sleep(0.001)
     raise AssertionError("Timed out waiting for condition.")
+
+
+def _write_pcm16_wav(
+    path: Path,
+    *,
+    sample_rate: int,
+    channel_count: int,
+    samples: Sequence[int],
+) -> None:
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(channel_count)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(struct.pack(f"<{len(samples)}h", *samples))

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -104,8 +104,17 @@ class FakeRawInputStream:
         self.closed = True
 
 
+class StartFailingRawInputStream(FakeRawInputStream):
+    def start(self) -> None:
+        raise RuntimeError("device busy")
+
+
 class FakeSoundDeviceModule:
     RawInputStream = FakeRawInputStream
+
+
+class StartFailingSoundDeviceModule:
+    RawInputStream = StartFailingRawInputStream
 
 
 class ClockHarness:
@@ -239,6 +248,19 @@ def test_microphone_audio_input_reports_overflow() -> None:
             audio_input.read_samples(1)
     finally:
         audio_input.close()
+
+
+def test_microphone_audio_input_closes_stream_when_start_fails() -> None:
+    FakeRawInputStream.created.clear()
+    settings = audio_capture_settings_from_config(
+        AudioConfig(source="microphone", input_device="busy-mic", sample_rate=4)
+    )
+
+    with pytest.raises(AudioCaptureError, match="device busy"):
+        MicrophoneAudioInput(settings, sounddevice_module=StartFailingSoundDeviceModule())
+
+    stream = FakeRawInputStream.created[0]
+    assert stream.closed is True
 
 
 def test_wav_and_microphone_sources_feed_same_window_contract(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,6 +22,8 @@ def test_default_config_allows_mock_run_without_file(
     assert config.first_crack.mode == "disabled"
     assert config.first_crack.repo_id == "syamaner/coffee-first-crack-detection"
     assert config.first_crack.precision == "int8"
+    assert config.audio.source == "microphone"
+    assert config.audio.wav_path is None
     assert config.logging.log_dir == Path("./logs")
     assert config.logging.export_formats == ("jsonl", "csv", "summary")
     assert config.session.auto_t0_detection_enabled is False
@@ -84,8 +86,10 @@ session:
     assert config.first_crack.local_model_dir == Path("./models/fp32")
     assert config.first_crack.onnx_threads == 4
     assert config.first_crack.allow_manual_override is False
+    assert config.audio.source == "microphone"
     assert config.audio.input_device == "roast-mic"
     assert config.audio.sample_rate == 48_000
+    assert config.audio.wav_path is None
     assert config.logging.log_dir == Path("./roast-logs")
     assert config.logging.sample_interval_seconds == 0.5
     assert config.logging.export_formats == ("jsonl", "summary")
@@ -104,7 +108,10 @@ first_crack:
   mode: disabled
   precision: int8
 audio:
+  source: wav
   input_device: file-mic
+  sample_rate: 8000
+  wav_path: ./fixture.wav
 logging:
   log_dir: ./file-logs
 """,
@@ -123,7 +130,10 @@ logging:
             "COFFEE_FIRST_CRACK_PRECISION": "fp32 ",
             "COFFEE_FIRST_CRACK_LOCAL_MODEL_DIR": "/models/env",
             "COFFEE_FIRST_CRACK_ONNX_THREADS": "8",
+            "COFFEE_AUDIO_SOURCE": "microphone",
             "COFFEE_AUDIO_INPUT_DEVICE": "env-mic",
+            "COFFEE_AUDIO_SAMPLE_RATE": "16000",
+            "COFFEE_AUDIO_WAV_PATH": "",
             "COFFEE_ROAST_LOG_DIR": "/tmp/roasts",
         },
     )
@@ -137,7 +147,10 @@ logging:
     assert config.first_crack.precision == "fp32"
     assert config.first_crack.local_model_dir == Path("/models/env")
     assert config.first_crack.onnx_threads == 8
+    assert config.audio.source == "microphone"
     assert config.audio.input_device == "env-mic"
+    assert config.audio.sample_rate == 16_000
+    assert config.audio.wav_path is None
     assert config.logging.log_dir == Path("/tmp/roasts")
 
 
@@ -156,6 +169,14 @@ def test_invalid_enum_value_fails(tmp_path: Path) -> None:
     config_path.write_text("first_crack:\n  precision: fp16\n", encoding="utf-8")
 
     with pytest.raises(ConfigError, match="first_crack.precision"):
+        load_config(config_path, environ={})
+
+
+def test_invalid_audio_source_fails(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("audio:\n  source: bluetooth\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="audio.source"):
         load_config(config_path, environ={})
 
 


### PR DESCRIPTION
## Summary

- Adds explicit audio source selection with `audio.source: microphone|wav`, `audio.wav_path`, and environment overrides for audio source, sample rate, and WAV path.
- Adds concrete `WavAudioInput` and `MicrophoneAudioInput` implementations behind the E4-S6 `AudioInput` boundary.
- Keeps WAV replay and microphone capture on the same mono float sample contract so both feed detector windows through the existing pipeline.
- Updates README and durable state for E4-S8 completion.

## Portability

- WAV replay uses Python stdlib `wave` parsing, supports PCM sample widths, converts multi-channel input to mono, and requires the WAV sample rate to match configured `audio.sample_rate`.
- Microphone capture uses a lazy PortAudio-backed `sounddevice.RawInputStream`, keeping macOS/Linux/Raspberry Pi device behavior behind the adapter.
- Real microphone validation remains optional and gated; CI uses generated WAV fixtures and mocked microphone backends only.

## Scope

- No detector inference, ONNX export, model training, Hugging Face sync, local directory sync behavior, first-crack session timeline integration, broad coverage hardening, or live Hottop control changes.

## Validation

- `./.venv/bin/python -m pytest tests/test_audio.py tests/test_config.py` -> 30 passed
- `./.venv/bin/python -m pytest` -> 226 passed
- `./.venv/bin/python -m ruff check .` -> passed
- `./.venv/bin/python -m ruff format --check .` -> passed
- `./.venv/bin/python -m pyright` -> 0 errors

Closes #97
