### PR TITLE
E4-S9: Integrate first crack with session timeline

### DIFF
--- a/docs/session-summaries/2026-05-17-e4-s9-integrate-first-crack-with-session-timeline.md
+++ b/docs/session-summaries/2026-05-17-e4-s9-integrate-first-crack-with-session-timeline.md
@@ -34,11 +34,12 @@ Quality versus context consumption note:
 - The PR review loop consumed substantial context, but the Codex review comments
   were high quality. Each comment identified a real integration edge case in the
   first-crack timeline boundary rather than style churn.
-- The comments improved correctness in four important places: preserving the
+- The comments improved correctness in five important places: preserving the
   detector timestamp as authoritative timing, accepting adapter-inferred default
   window-end timestamps without breaking the common backend path, ignoring
   pre-beans false positives, and restricting future-timestamp tolerance to
-  inferred timestamps only.
+  inferred timestamps only, and ignoring late detector confirmations after the
+  session leaves active `roasting`.
 - The fixes stayed inside E4-S9 scope. They did not expand into detector
   startup, audio capture startup, ONNX runtime inference, MCP tool wiring, or
   broad coverage hardening.
@@ -145,6 +146,25 @@ Fix applied:
 - Added regression coverage proving explicit future detector timestamps are
   rejected.
 
+Codex review `4306250152` found a late lifecycle issue:
+
+- The integration guard only checked `beans_added_at_utc`, so confirmed detector
+  output could still reach the session store after the session had moved to
+  `dropped`, `cooling`, `complete`, `fault`, or stopped states when first crack
+  had not been recorded.
+- In those states, `first_crack_detected` is not a valid transition and the
+  store would raise `SessionLifecycleError`, potentially crashing a long-running
+  detector loop on late confirmations.
+
+Fix applied:
+
+- `integrate_first_crack_window_with_session(...)` now processes detector output
+  only while the session is active and still in `roasting`.
+- Late confirmations after first crack, manual first crack, drop, cooling,
+  completion, fault, or stop are ignored before calling the backend or store.
+- Added regression coverage proving confirmed detector output after bean drop is
+  ignored without mutating the timeline or invoking the backend.
+
 ## Pull Request
 
 Opened `PR #101`: <https://github.com/syamaner/coffee-roaster-mcp/pull/101>
@@ -165,17 +185,23 @@ Commits on the branch before this summary:
   `fix: ignore detector confirmations before beans`
 - `afbd65ea67d4fbc7221441279751f4cfaff43da2` -
   `fix: restrict inferred timestamp tolerance`
+- `7a26c04816f0e655027abb686c95e80cb17b225a` -
+  `docs: add e4 s9 session summary`
+- latest local commit -
+  `fix: ignore detector output outside roasting`
 
 PR status when this summary was written:
 
 - state: open
 - draft: false
 - mergeable: true
-- head: `afbd65ea67d4fbc7221441279751f4cfaff43da2`
+- head: latest local commit after the post-roasting lifecycle fix
 - GitHub Actions `Build Package`: passed
 - GitHub Actions `Checks`: passed
 - Thread-aware refresh after the latest fix showed the newest review thread
   outdated; prior actionable threads were resolved.
+- A later Codex review on `afbd65ea67` found the post-roasting lifecycle gap;
+  the latest local commit addresses it and is ready for CI after push.
 
 Issue `#39` remains open and should close when PR #101 is merged through
 `Closes #39`.
@@ -231,6 +257,15 @@ After restricting tolerance to inferred timestamps:
 - Ran `./.venv/bin/python -m ruff format --check .`: passed
 - Ran `./.venv/bin/python -m pyright`: `0 errors`
 - GitHub Actions on PR #101 passed.
+
+After ignoring detector output outside active `roasting`:
+
+- Ran `./.venv/bin/python -m pytest tests/test_first_crack_integration.py tests/test_detector.py tests/test_session.py`:
+  `55 passed`
+- Ran `./.venv/bin/python -m pytest`: `238 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
 
 ## Handoff Notes
 

--- a/docs/session-summaries/2026-05-17-e4-s9-integrate-first-crack-with-session-timeline.md
+++ b/docs/session-summaries/2026-05-17-e4-s9-integrate-first-crack-with-session-timeline.md
@@ -1,0 +1,248 @@
+# E4-S9 Integrate First Crack With Session Timeline Session
+
+## Scope
+
+This session resumed after `PR #100` for `E4-S8` was squashed and merged, and
+issue `#97` was closed. Work started from updated `main` on branch
+`feature/39-integrate-first-crack-with-session-timeline` for issue `#39`,
+`E4-S9: Integrate first crack with session timeline`.
+
+The story goal was to map confirmed detector output into the authoritative
+one-session timeline exactly once, using the existing E4-S1 through E4-S8
+released-artifact resolver, validation, audio-source, audio-pipeline, and
+detector-adapter boundaries.
+
+The work preserved the Epic 2 one-session store boundary, MCP semantics,
+mock-safe defaults, coverage workflow, Epic 3 Hottop safety/validation boundary,
+and optional/gated real microphone validation. It did not add model training,
+ONNX export, Hugging Face sync, local directory sync behavior, broad coverage
+hardening, detector startup, audio capture startup, or live Hottop control
+changes.
+
+## Context Usage
+
+Session usage snapshot supplied by the operator after the E4-S9 review loop:
+
+- Context window: `18% left (214K used / 258K)`
+- 5h limit: `90% left`, resets `22:35`
+- Weekly limit: `96% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `02:11 on 18 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `21:11 on 24 May`
+
+Quality versus context consumption note:
+
+- The PR review loop consumed substantial context, but the Codex review comments
+  were high quality. Each comment identified a real integration edge case in the
+  first-crack timeline boundary rather than style churn.
+- The comments improved correctness in four important places: preserving the
+  detector timestamp as authoritative timing, accepting adapter-inferred default
+  window-end timestamps without breaking the common backend path, ignoring
+  pre-beans false positives, and restricting future-timestamp tolerance to
+  inferred timestamps only.
+- The fixes stayed inside E4-S9 scope. They did not expand into detector
+  startup, audio capture startup, ONNX runtime inference, MCP tool wiring, or
+  broad coverage hardening.
+
+## Pre-Story Verification
+
+Before starting E4-S9:
+
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding through the E4-S8 merge
+  to `b0f56f4`.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-17-e4-s8-add-microphone-and-wav-audio-input-adapters.md`,
+  and GitHub issue `#39`.
+- Confirmed issue `#39` required mocked detector output to create exactly one
+  `first_crack_detected` event and required manual override behavior to keep
+  following config.
+
+## Implementation
+
+Updated:
+
+- `src/coffee_roaster_mcp/detector.py`
+- `src/coffee_roaster_mcp/session.py`
+- `tests/test_detector.py`
+- `tests/test_first_crack_integration.py`
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+Behavior added:
+
+- Added `integrate_first_crack_window_with_session(...)` as the explicit E4-S9
+  detector-to-session integration helper.
+- The helper is gated to `first_crack.mode: audio`; disabled and manual modes do
+  not call the detector adapter or mutate the session timeline.
+- Confirmed detector output is recorded through `RoastSessionStore` as an
+  authoritative `first_crack_detected` event.
+- Detector metadata is stored in the event payload, including source, detected
+  monotonic timestamp, precision, revision, repo id, selected ONNX artifact,
+  feature-extractor artifact, window sequence number, and optional confidence.
+- Repeated detector confirmations return the existing singleton
+  `first_crack_detected` event without appending duplicate timeline rows.
+- Automatic detection remains independent of manual override permission, so
+  `allow_manual_override: false` only disables the manual MCP override path.
+
+## Review Fixes
+
+Codex review `4306194507` found an actionable timing issue:
+
+- The first implementation stored `detection_event.detected_at_monotonic_seconds`
+  only in payload metadata, while the authoritative `RoastEvent` timestamp came
+  from the later integration time.
+- This would skew `session.first_crack_monotonic_seconds` and downstream
+  development metrics when detector inference or queue processing was delayed.
+
+Fix applied:
+
+- Added `RoastSessionStore.record_first_crack_detection_snapshot(...)`.
+- Automatic detector integration now records the authoritative first-crack event
+  at the detector-provided monotonic timestamp.
+- Added regression coverage proving `compute_roast_metrics(...)` uses the
+  detector timestamp rather than the later integration time.
+
+Codex review `4306204446` found a default timestamp edge case:
+
+- The detector adapter falls back to `window.started_at_monotonic_seconds +
+  window.duration_seconds` when a backend omits an explicit timestamp.
+- Because audio windows are emitted around capture time, that inferred window-end
+  timestamp can be slightly ahead of the integration clock and was rejected as a
+  future timestamp.
+
+Fix applied:
+
+- Added a bounded future-timestamp tolerance for inferred window-end timestamps.
+- `integrate_first_crack_window_with_session(...)` passes the active
+  `window.duration_seconds` as that tolerance.
+- Added regression coverage for the common backend path where no explicit
+  detector timestamp is provided.
+
+Codex review `4306216288` found an early false-positive issue:
+
+- Confirmed detector output before `beans_added` could raise a lifecycle error
+  from the session store and break the detection loop.
+
+Fix applied:
+
+- `integrate_first_crack_window_with_session(...)` now ignores detector output
+  before beans are added and does not call the backend in that state.
+- Added regression coverage proving a confirmed pre-roast detector output leaves
+  the timeline empty and keeps the session in `pre_roast`.
+
+Codex review `4306239859` found that tolerance was too broad:
+
+- The future-timestamp tolerance also applied to explicit backend timestamps,
+  which could hide backend clock or timestamp bugs by clamping them.
+
+Fix applied:
+
+- Added `detected_at_inferred` to `FirstCrackDetectionEvent`.
+- Future tolerance is now applied only when the adapter inferred the timestamp
+  from the window end.
+- Explicit future timestamps from detector backends fail fast.
+- Added regression coverage proving explicit future detector timestamps are
+  rejected.
+
+## Pull Request
+
+Opened `PR #101`: <https://github.com/syamaner/coffee-roaster-mcp/pull/101>
+
+PR branch:
+
+- `feature/39-integrate-first-crack-with-session-timeline`
+
+Commits on the branch before this summary:
+
+- `28bfc8ab7867b516ae4fddbc17332a4f7b8843b5` -
+  `feat: integrate first crack with session timeline`
+- `2e902191dadfb45a779cc714521706c95090ecd8` -
+  `fix: preserve detected first crack timestamp`
+- `118bfe7bbb304c6bf0d819fcdd77a87c18ecdb59` -
+  `fix: allow inferred detector window timestamp`
+- `b0fdd1bd7a5d4bfbafc32a0268ff54314856ace2` -
+  `fix: ignore detector confirmations before beans`
+- `afbd65ea67d4fbc7221441279751f4cfaff43da2` -
+  `fix: restrict inferred timestamp tolerance`
+
+PR status when this summary was written:
+
+- state: open
+- draft: false
+- mergeable: true
+- head: `afbd65ea67d4fbc7221441279751f4cfaff43da2`
+- GitHub Actions `Build Package`: passed
+- GitHub Actions `Checks`: passed
+- Thread-aware refresh after the latest fix showed the newest review thread
+  outdated; prior actionable threads were resolved.
+
+Issue `#39` remains open and should close when PR #101 is merged through
+`Closes #39`.
+
+## Validation
+
+Initial E4-S9 implementation:
+
+- Ran `./.venv/bin/python -m pytest tests/test_first_crack_integration.py tests/test_detector.py`:
+  `13 passed`
+- Ran `./.venv/bin/python -m pytest`: `234 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+- GitHub Actions on PR #101 passed.
+
+After preserving detector-provided authoritative timing:
+
+- Ran `./.venv/bin/python -m pytest tests/test_first_crack_integration.py tests/test_detector.py tests/test_session.py`:
+  `51 passed`
+- Ran `./.venv/bin/python -m pytest`: `234 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+- GitHub Actions on PR #101 passed.
+
+After accepting inferred window-end timestamps:
+
+- Ran `./.venv/bin/python -m pytest tests/test_first_crack_integration.py tests/test_detector.py tests/test_session.py`:
+  `52 passed`
+- Ran `./.venv/bin/python -m pytest`: `235 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+- GitHub Actions on PR #101 passed.
+
+After ignoring pre-beans detector confirmations:
+
+- Ran `./.venv/bin/python -m pytest tests/test_first_crack_integration.py tests/test_detector.py tests/test_session.py`:
+  `53 passed`
+- Ran `./.venv/bin/python -m pytest`: `236 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+- GitHub Actions on PR #101 passed.
+
+After restricting tolerance to inferred timestamps:
+
+- Ran `./.venv/bin/python -m pytest tests/test_first_crack_integration.py tests/test_detector.py tests/test_session.py`:
+  `54 passed`
+- Ran `./.venv/bin/python -m pytest`: `237 passed`
+- Ran `./.venv/bin/python -m ruff check .`: passed
+- Ran `./.venv/bin/python -m ruff format --check .`: passed
+- Ran `./.venv/bin/python -m pyright`: `0 errors`
+- GitHub Actions on PR #101 passed.
+
+## Handoff Notes
+
+After PR #101 merges:
+
+1. Sync `main`.
+2. Verify PR #101 is merged and issue #39 is closed.
+3. Read `AGENTS.md`, `docs/state/registry.md`,
+   `docs/state/epics/coffee-roaster-mcp-v0.1.md`, this summary, and GitHub
+   issue `#40` if E4-S10 remains tracked there.
+4. Begin E4-S10 from updated `main` on the issue-specific branch.
+5. Keep E4-S10 scoped to targeted first-crack/MCP/export coverage hardening.
+   Do not add model training, ONNX export, Hugging Face sync, local directory
+   sync behavior, broad runtime redesign, or live Hottop control changes unless
+   the E4-S10 issue explicitly requires it.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -88,10 +88,11 @@ The first implementation milestone is a mock vertical slice that requires no roa
   writes the first-crack event at the detector-provided monotonic timestamp with
   detector metadata payload, accepts adapter-inferred default timestamps that
   land slightly ahead of the integration clock within the active detector-window
-  tolerance, leaves disabled and manual modes disconnected from detector writes,
-  allows automatic detection even when manual override is disabled, and relies
-  on the store singleton event behavior so repeated detector confirmations do
-  not append duplicate `first_crack_detected` rows.
+  tolerance, ignores confirmed detector output before beans are added, leaves
+  disabled and manual modes disconnected from detector writes, allows automatic
+  detection even when manual override is disabled, and relies on the store
+  singleton event behavior so repeated detector confirmations do not append
+  duplicate `first_crack_detected` rows.
 - `E4-S10` closes Epic 4 with targeted test hardening before the next epic.
   It should reduce coverage gaps around the assembled first-crack path,
   MCP-facing behavior, current export surfaces, and mock-safe failure modes.
@@ -826,6 +827,9 @@ After completing a story:
     that are slightly ahead of the integration clock, bounded by the detector
     window duration, so backends without explicit timestamps do not fail the
     automatic path.
+  - Another review fix ignores confirmed detector output before beans are added
+    so early false positives cannot bubble a lifecycle exception and break the
+    detection loop before roasting starts.
   - Automatic detector integration remains independent of manual override
     permission, so `allow_manual_override: false` only disables the manual MCP
     override path.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4-S9`
-- Current target: Integrate first crack with session timeline
+- Active story: `E4-S10`
+- Current target: Harden first-crack and MCP coverage before next epic
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -82,6 +82,14 @@ The first implementation milestone is a mock vertical slice that requires no roa
   sample rate to match `audio.sample_rate`, converts multi-channel files to
   mono, and returns the same mono float sample contract as live microphone
   capture.
+- `E4-S9` integrates confirmed detector output with the authoritative session
+  timeline through an explicit helper that keeps mutation behind
+  `RoastSessionStore`. The integration is gated to `first_crack.mode: audio`,
+  writes detector metadata as the first-crack event payload, leaves disabled and
+  manual modes disconnected from detector writes, allows automatic detection even
+  when manual override is disabled, and relies on the store singleton event
+  behavior so repeated detector confirmations do not append duplicate
+  `first_crack_detected` rows.
 - `E4-S10` closes Epic 4 with targeted test hardening before the next epic.
   It should reduce coverage gaps around the assembled first-crack path,
   MCP-facing behavior, current export surfaces, and mock-safe failure modes.
@@ -254,7 +262,7 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 - [x] `E4-S8` Add microphone and WAV audio input adapters.
   - Done when configured microphone and recorded WAV inputs can feed the detector window pipeline through the same audio source boundary.
 
-- [ ] `E4-S9` Integrate first crack with session timeline.
+- [x] `E4-S9` Integrate first crack with session timeline.
   - Done when mocked detector output creates exactly one `first_crack_detected` event.
 
 - [ ] `E4-S10` Harden first-crack and MCP coverage before next epic.
@@ -791,6 +799,31 @@ After completing a story:
     broad coverage hardening, and live Hottop control changes out of scope.
   - Ran `./.venv/bin/python -m pytest tests/test_audio.py tests/test_config.py`: 30 passed.
   - Ran `./.venv/bin/python -m pytest`: 226 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E4-S9:
+  - Added an explicit detector-to-session integration helper in
+    `src/coffee_roaster_mcp/detector.py` that processes one `AudioWindow` with
+    the existing detector adapter and records confirmed output as an
+    authoritative `first_crack_detected` event through `RoastSessionStore`.
+  - The integration is gated to `first_crack.mode: audio`; disabled and manual
+    modes do not call the detector adapter or mutate the timeline.
+  - Confirmed detector payloads include detector source, detected monotonic
+    timestamp, precision, revision, repository id, resolved ONNX artifact,
+    feature-extractor artifact, source window sequence number, and optional
+    confidence.
+  - Repeated detector confirmations and detector confirmations after a manual
+    first-crack event return the existing singleton first-crack event without
+    appending duplicate timeline rows.
+  - Automatic detector integration remains independent of manual override
+    permission, so `allow_manual_override: false` only disables the manual MCP
+    override path.
+  - Kept model training, ONNX export, Hugging Face sync, local directory sync,
+    detector startup, audio capture startup, broad coverage hardening, and live
+    Hottop control changes out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_first_crack_integration.py tests/test_detector.py`: 13 passed.
+  - Ran `./.venv/bin/python -m pytest`: 234 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -86,10 +86,12 @@ The first implementation milestone is a mock vertical slice that requires no roa
   timeline through an explicit helper that keeps mutation behind
   `RoastSessionStore`. The integration is gated to `first_crack.mode: audio`,
   writes the first-crack event at the detector-provided monotonic timestamp with
-  detector metadata payload, leaves disabled and manual modes disconnected from
-  detector writes, allows automatic detection even when manual override is
-  disabled, and relies on the store singleton event behavior so repeated
-  detector confirmations do not append duplicate `first_crack_detected` rows.
+  detector metadata payload, accepts adapter-inferred default timestamps that
+  land slightly ahead of the integration clock within the active detector-window
+  tolerance, leaves disabled and manual modes disconnected from detector writes,
+  allows automatic detection even when manual override is disabled, and relies
+  on the store singleton event behavior so repeated detector confirmations do
+  not append duplicate `first_crack_detected` rows.
 - `E4-S10` closes Epic 4 with targeted test hardening before the next epic.
   It should reduce coverage gaps around the assembled first-crack path,
   MCP-facing behavior, current export surfaces, and mock-safe failure modes.
@@ -820,6 +822,10 @@ After completing a story:
     `RoastSessionStore.record_first_crack_detection_snapshot(...)` path so the
     authoritative event timestamp and downstream development metrics use the
     detector-provided monotonic timestamp rather than the later integration time.
+  - A follow-up review fix allows adapter-inferred default window-end timestamps
+    that are slightly ahead of the integration clock, bounded by the detector
+    window duration, so backends without explicit timestamps do not fail the
+    automatic path.
   - Automatic detector integration remains independent of manual override
     permission, so `allow_manual_override: false` only disables the manual MCP
     override path.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -85,11 +85,11 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E4-S9` integrates confirmed detector output with the authoritative session
   timeline through an explicit helper that keeps mutation behind
   `RoastSessionStore`. The integration is gated to `first_crack.mode: audio`,
-  writes detector metadata as the first-crack event payload, leaves disabled and
-  manual modes disconnected from detector writes, allows automatic detection even
-  when manual override is disabled, and relies on the store singleton event
-  behavior so repeated detector confirmations do not append duplicate
-  `first_crack_detected` rows.
+  writes the first-crack event at the detector-provided monotonic timestamp with
+  detector metadata payload, leaves disabled and manual modes disconnected from
+  detector writes, allows automatic detection even when manual override is
+  disabled, and relies on the store singleton event behavior so repeated
+  detector confirmations do not append duplicate `first_crack_detected` rows.
 - `E4-S10` closes Epic 4 with targeted test hardening before the next epic.
   It should reduce coverage gaps around the assembled first-crack path,
   MCP-facing behavior, current export surfaces, and mock-safe failure modes.
@@ -816,6 +816,10 @@ After completing a story:
   - Repeated detector confirmations and detector confirmations after a manual
     first-crack event return the existing singleton first-crack event without
     appending duplicate timeline rows.
+  - PR review hardening moved automatic first-crack recording onto a dedicated
+    `RoastSessionStore.record_first_crack_detection_snapshot(...)` path so the
+    authoritative event timestamp and downstream development metrics use the
+    detector-provided monotonic timestamp rather than the later integration time.
   - Automatic detector integration remains independent of manual override
     permission, so `allow_manual_override: false` only disables the manual MCP
     override path.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -88,11 +88,12 @@ The first implementation milestone is a mock vertical slice that requires no roa
   writes the first-crack event at the detector-provided monotonic timestamp with
   detector metadata payload, accepts adapter-inferred default timestamps that
   land slightly ahead of the integration clock within the active detector-window
-  tolerance, ignores confirmed detector output before beans are added, leaves
-  disabled and manual modes disconnected from detector writes, allows automatic
-  detection even when manual override is disabled, and relies on the store
-  singleton event behavior so repeated detector confirmations do not append
-  duplicate `first_crack_detected` rows.
+  tolerance while still rejecting explicit future detector timestamps, ignores
+  confirmed detector output before beans are added, leaves disabled and manual
+  modes disconnected from detector writes, allows automatic detection even when
+  manual override is disabled, and relies on the store singleton event behavior
+  so repeated detector confirmations do not append duplicate
+  `first_crack_detected` rows.
 - `E4-S10` closes Epic 4 with targeted test hardening before the next epic.
   It should reduce coverage gaps around the assembled first-crack path,
   MCP-facing behavior, current export surfaces, and mock-safe failure modes.
@@ -830,6 +831,10 @@ After completing a story:
   - Another review fix ignores confirmed detector output before beans are added
     so early false positives cannot bubble a lifecycle exception and break the
     detection loop before roasting starts.
+  - A final review fix restricts future-timestamp tolerance to adapter-inferred
+    window-end timestamps only; explicit future timestamps from detector
+    backends still fail fast so backend clock or timestamp bugs are not silently
+    clamped.
   - Automatic detector integration remains independent of manual override
     permission, so `allow_manual_override: false` only disables the manual MCP
     override path.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -89,11 +89,10 @@ The first implementation milestone is a mock vertical slice that requires no roa
   detector metadata payload, accepts adapter-inferred default timestamps that
   land slightly ahead of the integration clock within the active detector-window
   tolerance while still rejecting explicit future detector timestamps, ignores
-  confirmed detector output before beans are added, leaves disabled and manual
-  modes disconnected from detector writes, allows automatic detection even when
-  manual override is disabled, and relies on the store singleton event behavior
-  so repeated detector confirmations do not append duplicate
-  `first_crack_detected` rows.
+  confirmed detector output before beans are added, ignores detector output once
+  the session leaves active `roasting`, leaves disabled and manual modes
+  disconnected from detector writes, and allows automatic detection even when
+  manual override is disabled.
 - `E4-S10` closes Epic 4 with targeted test hardening before the next epic.
   It should reduce coverage gaps around the assembled first-crack path,
   MCP-facing behavior, current export surfaces, and mock-safe failure modes.
@@ -818,8 +817,8 @@ After completing a story:
     feature-extractor artifact, source window sequence number, and optional
     confidence.
   - Repeated detector confirmations and detector confirmations after a manual
-    first-crack event return the existing singleton first-crack event without
-    appending duplicate timeline rows.
+    first-crack event are ignored after the session leaves active `roasting`, so
+    late detector output does not append duplicate timeline rows.
   - PR review hardening moved automatic first-crack recording onto a dedicated
     `RoastSessionStore.record_first_crack_detection_snapshot(...)` path so the
     authoritative event timestamp and downstream development metrics use the
@@ -835,6 +834,10 @@ After completing a story:
     window-end timestamps only; explicit future timestamps from detector
     backends still fail fast so backend clock or timestamp bugs are not silently
     clamped.
+  - The latest review fix also ignores detector output after the session leaves
+    active `roasting`, covering late confirmations after first crack, drop,
+    cooling, completion, fault, or stop without relying on store-level lifecycle
+    exceptions.
   - Automatic detector integration remains independent of manual override
     permission, so `allow_manual_override: false` only disables the manual MCP
     override path.
@@ -846,3 +849,10 @@ After completing a story:
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Final review-fix validation ran
+    `./.venv/bin/python -m pytest tests/test_first_crack_integration.py tests/test_detector.py tests/test_session.py`:
+    55 passed.
+  - Final full validation ran `./.venv/bin/python -m pytest`: 238 passed,
+    `./.venv/bin/python -m ruff check .`: passed,
+    `./.venv/bin/python -m ruff format --check .`: passed, and
+    `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -61,10 +61,12 @@ of the integration clock are accepted within the active detector-window
 tolerance and recorded at the current elapsed time instead of failing the
 automatic path, while explicit future detector timestamps still fail fast.
 Confirmed detector output before beans are added is ignored so early false
-positives cannot break the detection loop. Disabled and manual modes do not let
-detector output mutate the session, automatic detection does not require manual
-override permission, and repeated detector confirmations return the original
-first-crack singleton event instead of appending duplicates.
+positives cannot break the detection loop. Detector output is also ignored once
+the session leaves active `roasting`, including after first crack, drop,
+cooling, completion, fault, or stop, so late confirmations cannot raise session
+lifecycle errors. Disabled and manual modes do not let detector output mutate
+the session, and automatic detection does not require manual override
+permission.
 
 The next story is E4-S10: harden first-crack and MCP coverage before the next epic.
 Epic 4 includes E4-S10 as a closing test-hardening story before the next epic,

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -59,11 +59,12 @@ timeline at the detector-provided monotonic timestamp with detector metadata
 payload. Adapter-inferred default detector timestamps that land slightly ahead
 of the integration clock are accepted within the active detector-window
 tolerance and recorded at the current elapsed time instead of failing the
-automatic path. Confirmed detector output before beans are added is ignored so
-early false positives cannot break the detection loop. Disabled and manual modes
-do not let detector output mutate the session, automatic detection does not
-require manual override permission, and repeated detector confirmations return
-the original first-crack singleton event instead of appending duplicates.
+automatic path, while explicit future detector timestamps still fail fast.
+Confirmed detector output before beans are added is ignored so early false
+positives cannot break the detection loop. Disabled and manual modes do not let
+detector output mutate the session, automatic detection does not require manual
+override permission, and repeated detector confirmations return the original
+first-crack singleton event instead of appending duplicates.
 
 The next story is E4-S10: harden first-crack and MCP coverage before the next epic.
 Epic 4 includes E4-S10 as a closing test-hardening story before the next epic,

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -55,10 +55,11 @@ sample contract as live capture. Real microphone validation remains optional
 and gated; normal CI uses mocked microphone backends and generated WAV fixtures.
 Confirmed detector output in `first_crack.mode: audio` now writes one
 `first_crack_detected` event into the authoritative `RoastSessionStore`
-timeline with detector metadata payload. Disabled and manual modes do not let
-detector output mutate the session, automatic detection does not require manual
-override permission, and repeated detector confirmations return the original
-first-crack singleton event instead of appending duplicates.
+timeline at the detector-provided monotonic timestamp with detector metadata
+payload. Disabled and manual modes do not let detector output mutate the
+session, automatic detection does not require manual override permission, and
+repeated detector confirmations return the original first-crack singleton event
+instead of appending duplicates.
 
 The next story is E4-S10: harden first-crack and MCP coverage before the next epic.
 Epic 4 includes E4-S10 as a closing test-hardening story before the next epic,

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -59,10 +59,11 @@ timeline at the detector-provided monotonic timestamp with detector metadata
 payload. Adapter-inferred default detector timestamps that land slightly ahead
 of the integration clock are accepted within the active detector-window
 tolerance and recorded at the current elapsed time instead of failing the
-automatic path. Disabled and manual modes do not let detector output mutate the
-session, automatic detection does not require manual override permission, and
-repeated detector confirmations return the original first-crack singleton event
-instead of appending duplicates.
+automatic path. Confirmed detector output before beans are added is ignored so
+early false positives cannot break the detection loop. Disabled and manual modes
+do not let detector output mutate the session, automatic detection does not
+require manual override permission, and repeated detector confirmations return
+the original first-crack singleton event instead of appending duplicates.
 
 The next story is E4-S10: harden first-crack and MCP coverage before the next epic.
 Epic 4 includes E4-S10 as a closing test-hardening story before the next epic,

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -30,7 +30,7 @@ drop and emergency stop included. A follow-up 60-second stability test also held
 fan at `10%`, heat at `40%` for 30 seconds, then heat at `100%` for 30 seconds
 with continuous command streaming and no command-loop or status-read errors.
 
-E4-S8 is complete. The first-crack path now resolves the configured ONNX model
+E4-S9 is complete. The first-crack path now resolves the configured ONNX model
 artifact for both supported real-model precisions: `int8` selects
 `onnx/int8/model_quantized.onnx`, and `fp32` selects `onnx/fp32/model.onnx`
 through the artifact resolver. When `first_crack.local_model_dir` is configured,
@@ -53,8 +53,14 @@ E4-S6 `AudioInput` boundary: microphone capture uses a lazy PortAudio-backed
 uses stdlib PCM decoding, channel-to-mono conversion, and the same mono float
 sample contract as live capture. Real microphone validation remains optional
 and gated; normal CI uses mocked microphone backends and generated WAV fixtures.
+Confirmed detector output in `first_crack.mode: audio` now writes one
+`first_crack_detected` event into the authoritative `RoastSessionStore`
+timeline with detector metadata payload. Disabled and manual modes do not let
+detector output mutate the session, automatic detection does not require manual
+override permission, and repeated detector confirmations return the original
+first-crack singleton event instead of appending duplicates.
 
-The next story is E4-S9: integrate first crack with the session timeline.
+The next story is E4-S10: harden first-crack and MCP coverage before the next epic.
 Epic 4 includes E4-S10 as a closing test-hardening story before the next epic,
 focused on first-crack integration, MCP-facing behavior, export assertions,
 mock-safe failure modes, and coverage gaps. Real microphone validation is

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -56,7 +56,10 @@ and gated; normal CI uses mocked microphone backends and generated WAV fixtures.
 Confirmed detector output in `first_crack.mode: audio` now writes one
 `first_crack_detected` event into the authoritative `RoastSessionStore`
 timeline at the detector-provided monotonic timestamp with detector metadata
-payload. Disabled and manual modes do not let detector output mutate the
+payload. Adapter-inferred default detector timestamps that land slightly ahead
+of the integration clock are accepted within the active detector-window
+tolerance and recorded at the current elapsed time instead of failing the
+automatic path. Disabled and manual modes do not let detector output mutate the
 session, automatic detection does not require manual override permission, and
 repeated detector confirmations return the original first-crack singleton event
 instead of appending duplicates.

--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -176,6 +176,8 @@ def integrate_first_crack_window_with_session(
     """
     if config.mode != "audio":
         return None
+    if session.beans_added_at_utc is None:
+        return None
 
     detection_event = adapter.process_window(window)
     if detection_event is None:

--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -181,9 +181,9 @@ def integrate_first_crack_window_with_session(
     if detection_event is None:
         return None
 
-    event, snapshot = session_store.record_event_snapshot(
+    event, snapshot = session_store.record_first_crack_detection_snapshot(
         session,
-        detection_event.kind,
+        detected_at_monotonic_seconds=detection_event.detected_at_monotonic_seconds,
         payload=detection_event.payload(),
     )
     return FirstCrackTimelineIntegrationResult(event=event, session=snapshot)

--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -60,6 +60,8 @@ class FirstCrackDetectionEvent:
         onnx_model_filename: Repository-relative ONNX model artifact.
         feature_extractor_filename: Repository-relative feature extractor artifact.
         window_sequence_number: Source audio window sequence number.
+        detected_at_inferred: Whether the detection timestamp was inferred from
+            the source window end because the backend omitted an explicit timestamp.
     """
 
     kind: FirstCrackDetectorEventKind
@@ -71,6 +73,7 @@ class FirstCrackDetectionEvent:
     onnx_model_filename: str
     feature_extractor_filename: str
     window_sequence_number: int
+    detected_at_inferred: bool
 
     def payload(self) -> dict[str, str | int | float | None]:
         """Return session-event payload metadata for this confirmed detection."""
@@ -117,6 +120,7 @@ class FirstCrackDetectorAdapter:
             onnx_model_filename=self.artifacts.onnx_model.filename,
             feature_extractor_filename=self.artifacts.feature_extractor_config.filename,
             window_sequence_number=window.sequence_number,
+            detected_at_inferred=output.detected_at_monotonic_seconds is None,
         )
 
 
@@ -186,7 +190,7 @@ def integrate_first_crack_window_with_session(
     event, snapshot = session_store.record_first_crack_detection_snapshot(
         session,
         detected_at_monotonic_seconds=detection_event.detected_at_monotonic_seconds,
-        max_future_seconds=window.duration_seconds,
+        max_future_seconds=window.duration_seconds if detection_event.detected_at_inferred else 0.0,
         payload=detection_event.payload(),
     )
     return FirstCrackTimelineIntegrationResult(event=event, session=snapshot)

--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -184,6 +184,7 @@ def integrate_first_crack_window_with_session(
     event, snapshot = session_store.record_first_crack_detection_snapshot(
         session,
         detected_at_monotonic_seconds=detection_event.detected_at_monotonic_seconds,
+        max_future_seconds=window.duration_seconds,
         payload=detection_event.payload(),
     )
     return FirstCrackTimelineIntegrationResult(event=event, session=snapshot)

--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -180,7 +180,7 @@ def integrate_first_crack_window_with_session(
     """
     if config.mode != "audio":
         return None
-    if session.beans_added_at_utc is None:
+    if not session.active or session.phase != "roasting":
         return None
 
     detection_event = adapter.process_window(window)

--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -9,6 +9,7 @@ from typing import Literal, Protocol
 from coffee_roaster_mcp.artifacts import ResolvedDetectorArtifacts
 from coffee_roaster_mcp.audio import AudioWindow
 from coffee_roaster_mcp.config import FirstCrackConfig, ModelPrecision
+from coffee_roaster_mcp.session import RoastEvent, RoastSession, RoastSessionStore
 
 FirstCrackDetectorEventKind = Literal["first_crack_detected"]
 
@@ -45,9 +46,9 @@ class FirstCrackDetectorOutput:
 class FirstCrackDetectionEvent:
     """Confirmed first-crack detector event candidate.
 
-    This is intentionally not written to the roast-session timeline here. E4-S9
-    owns session integration; this story only adapts detector output into the
-    event metadata needed by that later boundary.
+    The detector adapter returns this as metadata only. Session integration is
+    handled by the explicit E4-S9 integration helper so timeline writes stay
+    visible and preserve the `RoastSessionStore` mutation boundary.
 
     Attributes:
         kind: Event kind intended for the session timeline.
@@ -119,6 +120,20 @@ class FirstCrackDetectorAdapter:
         )
 
 
+@dataclass(frozen=True)
+class FirstCrackTimelineIntegrationResult:
+    """Result of applying one confirmed detector event to the session timeline.
+
+    Attributes:
+        event: Authoritative session event. Repeated confirmations return the
+            original first-crack event instead of adding another timeline row.
+        session: Snapshot of the authoritative session after integration.
+    """
+
+    event: RoastEvent
+    session: RoastSession
+
+
 def build_first_crack_detector_adapter(
     config: FirstCrackConfig,
     artifacts: ResolvedDetectorArtifacts,
@@ -130,6 +145,48 @@ def build_first_crack_detector_adapter(
         artifacts=artifacts,
         backend=backend,
     )
+
+
+def integrate_first_crack_window_with_session(
+    *,
+    config: FirstCrackConfig,
+    adapter: FirstCrackDetectorAdapter,
+    session_store: RoastSessionStore,
+    session: RoastSession,
+    window: AudioWindow,
+) -> FirstCrackTimelineIntegrationResult | None:
+    """Process one detector window and write one first-crack event if confirmed.
+
+    The integration is intentionally gated to `first_crack.mode: audio`; manual
+    and disabled modes leave detector output disconnected from the authoritative
+    timeline. Session mutation stays behind `RoastSessionStore`, so duplicate
+    detector confirmations return the original singleton `first_crack_detected`
+    event without appending another row.
+
+    Args:
+        config: First-crack runtime configuration.
+        adapter: Detector adapter that turns backend output into event metadata.
+        session_store: Authoritative one-session mutation boundary.
+        session: Active roast session to update.
+        window: Audio window to process.
+
+    Returns:
+        Timeline integration result for confirmed output, or `None` when the
+        mode is not audio or the detector did not confirm first crack.
+    """
+    if config.mode != "audio":
+        return None
+
+    detection_event = adapter.process_window(window)
+    if detection_event is None:
+        return None
+
+    event, snapshot = session_store.record_event_snapshot(
+        session,
+        detection_event.kind,
+        payload=detection_event.payload(),
+    )
+    return FirstCrackTimelineIntegrationResult(event=event, session=snapshot)
 
 
 def _detection_timestamp(

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -596,6 +596,7 @@ class RoastSessionStore:
         session: RoastSession,
         *,
         detected_at_monotonic_seconds: float,
+        max_future_seconds: float = 0.0,
         payload: dict[str, EventPayloadValue] | None = None,
     ) -> tuple[RoastEvent, RoastSession]:
         """Record automatic first crack at the detector-provided monotonic time.
@@ -604,6 +605,10 @@ class RoastSessionStore:
             session: Session to mutate.
             detected_at_monotonic_seconds: Absolute monotonic timestamp reported
                 by the detector for the first-crack event.
+            max_future_seconds: Allowed future timestamp tolerance. This lets
+                adapter-inferred window-end defaults record when the capture
+                window has just been emitted but its inferred end timestamp is
+                slightly ahead of the integration clock.
             payload: Optional structured event details.
 
         Returns:
@@ -631,6 +636,7 @@ class RoastSessionStore:
                 session,
                 detected_at_monotonic_seconds=detected_at_monotonic_seconds,
                 current_elapsed_seconds=session.elapsed_monotonic_seconds(self._monotonic_now),
+                max_future_seconds=max_future_seconds,
             )
             event = RoastEvent(
                 kind="first_crack_detected",
@@ -842,7 +848,10 @@ def _detected_elapsed_seconds(
     *,
     detected_at_monotonic_seconds: float,
     current_elapsed_seconds: float,
+    max_future_seconds: float,
 ) -> float:
+    if max_future_seconds < 0:
+        raise SessionLifecycleError("Detected first-crack future tolerance must be >= 0.")
     detected_elapsed_seconds = round(
         float(detected_at_monotonic_seconds) - session.monotonic_start,
         6,
@@ -854,7 +863,10 @@ def _detected_elapsed_seconds(
             "Detected first-crack timestamp cannot be before session start."
         )
     if detected_elapsed_seconds > current_elapsed_seconds:
-        raise SessionLifecycleError("Detected first-crack timestamp cannot be in the future.")
+        future_delta_seconds = detected_elapsed_seconds - current_elapsed_seconds
+        if future_delta_seconds > max_future_seconds:
+            raise SessionLifecycleError("Detected first-crack timestamp cannot be in the future.")
+        detected_elapsed_seconds = current_elapsed_seconds
     if (
         session.beans_added_monotonic_seconds is not None
         and detected_elapsed_seconds < session.beans_added_monotonic_seconds

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import math
 from collections import deque
 from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from threading import RLock
 from typing import Literal
@@ -590,6 +591,58 @@ class RoastSessionStore:
             event = self.record_event(session, kind, payload=payload)
             return event, _copy_session_for_read(session)
 
+    def record_first_crack_detection_snapshot(
+        self,
+        session: RoastSession,
+        *,
+        detected_at_monotonic_seconds: float,
+        payload: dict[str, EventPayloadValue] | None = None,
+    ) -> tuple[RoastEvent, RoastSession]:
+        """Record automatic first crack at the detector-provided monotonic time.
+
+        Args:
+            session: Session to mutate.
+            detected_at_monotonic_seconds: Absolute monotonic timestamp reported
+                by the detector for the first-crack event.
+            payload: Optional structured event details.
+
+        Returns:
+            The event plus an atomic lightweight snapshot. Repeated calls return
+            the already-recorded first-crack singleton event.
+
+        Raises:
+            SessionLifecycleError: If the session transition is invalid or the
+                detector timestamp is outside the active roast interval.
+        """
+        with self._lock:
+            self._assert_latest_active_session(session)
+            if session.faulted_at_utc is not None:
+                raise SessionLifecycleError("No non-fault events can be recorded after a fault.")
+
+            existing_event = self._get_existing_singleton_event(
+                session,
+                "first_crack_detected",
+            )
+            if existing_event is not None:
+                return existing_event, _copy_session_for_read(session)
+            _validate_event_transition(session, "first_crack_detected")
+
+            detected_elapsed_seconds = _detected_elapsed_seconds(
+                session,
+                detected_at_monotonic_seconds=detected_at_monotonic_seconds,
+                current_elapsed_seconds=session.elapsed_monotonic_seconds(self._monotonic_now),
+            )
+            event = RoastEvent(
+                kind="first_crack_detected",
+                recorded_at_utc=session.created_at_utc
+                + timedelta(seconds=detected_elapsed_seconds),
+                monotonic_seconds=detected_elapsed_seconds,
+                payload={} if payload is None else dict(payload),
+            )
+            session.event_timeline.append(event)
+            _apply_event_timestamp(session, event)
+            return event, _copy_session_for_read(session)
+
     def emergency_stop(
         self,
         session: RoastSession,
@@ -782,6 +835,32 @@ def _apply_event_timestamp(session: RoastSession, event: RoastEvent) -> None:
         session.phase = "fault"
         session.faulted_at_utc = event.recorded_at_utc
         session.faulted_monotonic_seconds = event.monotonic_seconds
+
+
+def _detected_elapsed_seconds(
+    session: RoastSession,
+    *,
+    detected_at_monotonic_seconds: float,
+    current_elapsed_seconds: float,
+) -> float:
+    detected_elapsed_seconds = round(
+        float(detected_at_monotonic_seconds) - session.monotonic_start,
+        6,
+    )
+    if not math.isfinite(detected_elapsed_seconds):
+        raise SessionLifecycleError("Detected first-crack timestamp must be finite.")
+    if detected_elapsed_seconds < 0:
+        raise SessionLifecycleError(
+            "Detected first-crack timestamp cannot be before session start."
+        )
+    if detected_elapsed_seconds > current_elapsed_seconds:
+        raise SessionLifecycleError("Detected first-crack timestamp cannot be in the future.")
+    if (
+        session.beans_added_monotonic_seconds is not None
+        and detected_elapsed_seconds < session.beans_added_monotonic_seconds
+    ):
+        raise SessionLifecycleError("Detected first crack cannot be before beans are added.")
+    return detected_elapsed_seconds
 
 
 def _validate_event_transition(session: RoastSession, kind: RoastEventKind) -> None:

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -92,6 +92,7 @@ def test_detector_adapter_maps_confirmed_output_to_first_crack_event() -> None:
     assert event.onnx_model_filename == "onnx/fp32/model.onnx"
     assert event.feature_extractor_filename == "onnx/fp32/preprocessor_config.json"
     assert event.window_sequence_number == 7
+    assert event.detected_at_inferred is False
     assert event.payload() == {
         "source": "first_crack_detector",
         "detected_at_monotonic_seconds": 120.42,
@@ -119,6 +120,7 @@ def test_detector_adapter_uses_window_end_timestamp_when_output_has_no_timestamp
     assert event is not None
     assert event.detected_at_monotonic_seconds == 56.25
     assert event.confidence is None
+    assert event.detected_at_inferred is True
     assert "confidence" not in event.payload()
 
 

--- a/tests/test_first_crack_integration.py
+++ b/tests/test_first_crack_integration.py
@@ -63,6 +63,28 @@ def test_integrator_ignores_detector_output_outside_audio_mode() -> None:
     assert session.phase == "roasting"
 
 
+def test_integrator_ignores_confirmed_detector_output_before_beans_are_added() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=True),))
+    config = FirstCrackConfig(mode="audio")
+    adapter = build_first_crack_detector_adapter(config, _resolved_detector_artifacts(), backend)
+
+    result = integrate_first_crack_window_with_session(
+        config=config,
+        adapter=adapter,
+        session_store=store,
+        session=session,
+        window=_audio_window(),
+    )
+
+    assert result is None
+    assert backend.windows == []
+    assert session.event_timeline == []
+    assert session.phase == "pre_roast"
+
+
 def test_integrator_ignores_unconfirmed_detector_output() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)

--- a/tests/test_first_crack_integration.py
+++ b/tests/test_first_crack_integration.py
@@ -91,6 +91,33 @@ def test_integrator_ignores_confirmed_detector_output_before_beans_are_added() -
     assert session.phase == "pre_roast"
 
 
+def test_integrator_ignores_confirmed_detector_output_after_roasting_phase() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    store.record_event(session, "beans_dropped")
+    backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=True),))
+    config = FirstCrackConfig(mode="audio")
+    adapter = build_first_crack_detector_adapter(config, _resolved_detector_artifacts(), backend)
+
+    result = integrate_first_crack_window_with_session(
+        config=config,
+        adapter=adapter,
+        session_store=store,
+        session=session,
+        window=_audio_window(),
+    )
+
+    assert result is None
+    assert backend.windows == []
+    assert [event.kind for event in session.event_timeline] == [
+        "beans_added",
+        "beans_dropped",
+    ]
+    assert session.phase == "dropped"
+
+
 def test_integrator_ignores_unconfirmed_detector_output() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
@@ -155,8 +182,7 @@ def test_confirmed_detector_output_records_first_crack_event_once() -> None:
     )
 
     assert first_result is not None
-    assert second_result is not None
-    assert first_result.event == second_result.event
+    assert second_result is None
     assert [event.kind for event in session.event_timeline] == [
         "beans_added",
         "first_crack_detected",
@@ -186,7 +212,7 @@ def test_confirmed_detector_output_records_first_crack_event_once() -> None:
         "confidence": 0.91,
     }
     assert len(first_result.session.event_timeline) == 2
-    assert len(second_result.session.event_timeline) == 2
+    assert [window.sequence_number for window in backend.windows] == [11]
     metrics = compute_roast_metrics(session, monotonic_now=clock.monotonic_now)
     assert metrics.development_time_seconds == 2.75
 
@@ -289,21 +315,18 @@ def test_manual_first_crack_event_takes_precedence_over_later_detector_confirmat
     store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
     session = store.start_session()
     store.record_event(session, "beans_added")
-    manual_event = store.record_event(session, "first_crack_detected")
+    store.record_event(session, "first_crack_detected")
     config = FirstCrackConfig(mode="audio")
-    adapter = build_first_crack_detector_adapter(
-        config,
-        _resolved_detector_artifacts(),
-        MockDetectorBackend(
-            (
-                FirstCrackDetectorOutput(
-                    confirmed=True,
-                    confidence=0.7,
-                    detected_at_monotonic_seconds=502.0,
-                ),
-            )
-        ),
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(
+                confirmed=True,
+                confidence=0.7,
+                detected_at_monotonic_seconds=502.0,
+            ),
+        )
     )
+    adapter = build_first_crack_detector_adapter(config, _resolved_detector_artifacts(), backend)
 
     result = integrate_first_crack_window_with_session(
         config=config,
@@ -313,13 +336,13 @@ def test_manual_first_crack_event_takes_precedence_over_later_detector_confirmat
         window=_audio_window(),
     )
 
-    assert result is not None
-    assert result.event == manual_event
+    assert result is None
     assert [event.kind for event in session.event_timeline] == [
         "beans_added",
         "first_crack_detected",
     ]
     assert session.event_timeline[-1].payload == {}
+    assert backend.windows == []
 
 
 def _audio_window(

--- a/tests/test_first_crack_integration.py
+++ b/tests/test_first_crack_integration.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from coffee_roaster_mcp.artifacts import ResolvedArtifact, ResolvedDetectorArtifacts
+from coffee_roaster_mcp.audio import AudioWindow
+from coffee_roaster_mcp.config import FirstCrackConfig
+from coffee_roaster_mcp.detector import (
+    FirstCrackDetectorOutput,
+    build_first_crack_detector_adapter,
+    integrate_first_crack_window_with_session,
+)
+from coffee_roaster_mcp.session import RoastSessionStore
+
+
+class ClockHarness:
+    """Deterministic wall-clock and monotonic clock supplier for integration tests."""
+
+    def __init__(self) -> None:
+        self.utc_value = datetime(2026, 5, 17, 14, 0, tzinfo=UTC)
+        self.monotonic_value = 500.0
+
+    def utc_now(self) -> datetime:
+        return self.utc_value
+
+    def monotonic_now(self) -> float:
+        return self.monotonic_value
+
+
+class MockDetectorBackend:
+    """Detector backend with deterministic queued outputs."""
+
+    def __init__(self, outputs: tuple[FirstCrackDetectorOutput, ...]) -> None:
+        self._outputs = list(outputs)
+        self.windows: list[AudioWindow] = []
+
+    def detect(self, window: AudioWindow) -> FirstCrackDetectorOutput:
+        self.windows.append(window)
+        return self._outputs.pop(0)
+
+
+def test_integrator_ignores_detector_output_outside_audio_mode() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=True),))
+    config = FirstCrackConfig(mode="manual")
+    adapter = build_first_crack_detector_adapter(config, _resolved_detector_artifacts(), backend)
+
+    result = integrate_first_crack_window_with_session(
+        config=config,
+        adapter=adapter,
+        session_store=store,
+        session=session,
+        window=_audio_window(),
+    )
+
+    assert result is None
+    assert backend.windows == []
+    assert [event.kind for event in session.event_timeline] == ["beans_added"]
+    assert session.phase == "roasting"
+
+
+def test_integrator_ignores_unconfirmed_detector_output() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=False),))
+    config = FirstCrackConfig(mode="audio")
+    adapter = build_first_crack_detector_adapter(config, _resolved_detector_artifacts(), backend)
+
+    result = integrate_first_crack_window_with_session(
+        config=config,
+        adapter=adapter,
+        session_store=store,
+        session=session,
+        window=_audio_window(sequence_number=4),
+    )
+
+    assert result is None
+    assert [window.sequence_number for window in backend.windows] == [4]
+    assert [event.kind for event in session.event_timeline] == ["beans_added"]
+    assert session.first_crack_at_utc is None
+
+
+def test_confirmed_detector_output_records_first_crack_event_once() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    clock.monotonic_value = 505.0
+    store.record_event(session, "beans_added")
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(
+                confirmed=True,
+                confidence=0.91,
+                detected_at_monotonic_seconds=537.25,
+            ),
+            FirstCrackDetectorOutput(
+                confirmed=True,
+                confidence=0.99,
+                detected_at_monotonic_seconds=538.0,
+            ),
+        )
+    )
+    config = FirstCrackConfig(mode="audio", revision="v0.1.0")
+    adapter = build_first_crack_detector_adapter(config, _resolved_detector_artifacts(), backend)
+
+    clock.utc_value = datetime(2026, 5, 17, 14, 6, tzinfo=UTC)
+    clock.monotonic_value = 540.0
+    first_result = integrate_first_crack_window_with_session(
+        config=config,
+        adapter=adapter,
+        session_store=store,
+        session=session,
+        window=_audio_window(sequence_number=11, started_at_monotonic_seconds=536.5),
+    )
+    second_result = integrate_first_crack_window_with_session(
+        config=config,
+        adapter=adapter,
+        session_store=store,
+        session=session,
+        window=_audio_window(sequence_number=12, started_at_monotonic_seconds=537.5),
+    )
+
+    assert first_result is not None
+    assert second_result is not None
+    assert first_result.event == second_result.event
+    assert [event.kind for event in session.event_timeline] == [
+        "beans_added",
+        "first_crack_detected",
+    ]
+    assert session.phase == "development"
+    assert session.first_crack_at_utc == datetime(2026, 5, 17, 14, 6, tzinfo=UTC)
+    assert session.first_crack_monotonic_seconds == 40.0
+    assert first_result.event.payload == {
+        "source": "first_crack_detector",
+        "detected_at_monotonic_seconds": 537.25,
+        "precision": "int8",
+        "revision": "v0.1.0",
+        "repo_id": "syamaner/coffee-first-crack-detection",
+        "onnx_model_filename": "onnx/int8/model_quantized.onnx",
+        "feature_extractor_filename": "onnx/int8/preprocessor_config.json",
+        "window_sequence_number": 11,
+        "confidence": 0.91,
+    }
+    assert len(first_result.session.event_timeline) == 2
+    assert len(second_result.session.event_timeline) == 2
+
+
+def test_automatic_detection_does_not_require_manual_override_permission() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    config = FirstCrackConfig(mode="audio", allow_manual_override=False)
+    adapter = build_first_crack_detector_adapter(
+        config,
+        _resolved_detector_artifacts(),
+        MockDetectorBackend((FirstCrackDetectorOutput(confirmed=True),)),
+    )
+
+    result = integrate_first_crack_window_with_session(
+        config=config,
+        adapter=adapter,
+        session_store=store,
+        session=session,
+        window=_audio_window(),
+    )
+
+    assert result is not None
+    assert result.event.kind == "first_crack_detected"
+    assert session.phase == "development"
+
+
+def test_manual_first_crack_event_takes_precedence_over_later_detector_confirmation() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    manual_event = store.record_event(session, "first_crack_detected")
+    config = FirstCrackConfig(mode="audio")
+    adapter = build_first_crack_detector_adapter(
+        config,
+        _resolved_detector_artifacts(),
+        MockDetectorBackend(
+            (
+                FirstCrackDetectorOutput(
+                    confirmed=True,
+                    confidence=0.7,
+                    detected_at_monotonic_seconds=502.0,
+                ),
+            )
+        ),
+    )
+
+    result = integrate_first_crack_window_with_session(
+        config=config,
+        adapter=adapter,
+        session_store=store,
+        session=session,
+        window=_audio_window(),
+    )
+
+    assert result is not None
+    assert result.event == manual_event
+    assert [event.kind for event in session.event_timeline] == [
+        "beans_added",
+        "first_crack_detected",
+    ]
+    assert session.event_timeline[-1].payload == {}
+
+
+def _audio_window(
+    *,
+    sequence_number: int = 3,
+    started_at_monotonic_seconds: float = 10.0,
+) -> AudioWindow:
+    return AudioWindow(
+        sequence_number=sequence_number,
+        input_device="mock-audio",
+        sample_rate=4,
+        started_at_monotonic_seconds=started_at_monotonic_seconds,
+        duration_seconds=1.0,
+        samples=(0.1, 0.2, 0.3, 0.4),
+    )
+
+
+def _resolved_detector_artifacts() -> ResolvedDetectorArtifacts:
+    return ResolvedDetectorArtifacts(
+        onnx_model=ResolvedArtifact(
+            repo_id="syamaner/coffee-first-crack-detection",
+            revision=None,
+            filename="onnx/int8/model_quantized.onnx",
+            local_path=Path("/tmp/model.onnx"),
+        ),
+        feature_extractor_config=ResolvedArtifact(
+            repo_id="syamaner/coffee-first-crack-detection",
+            revision=None,
+            filename="onnx/int8/preprocessor_config.json",
+            local_path=Path("/tmp/preprocessor_config.json"),
+        ),
+    )

--- a/tests/test_first_crack_integration.py
+++ b/tests/test_first_crack_integration.py
@@ -11,7 +11,7 @@ from coffee_roaster_mcp.detector import (
     build_first_crack_detector_adapter,
     integrate_first_crack_window_with_session,
 )
-from coffee_roaster_mcp.session import RoastSessionStore
+from coffee_roaster_mcp.session import RoastSessionStore, compute_roast_metrics
 
 
 class ClockHarness:
@@ -134,8 +134,18 @@ def test_confirmed_detector_output_records_first_crack_event_once() -> None:
         "first_crack_detected",
     ]
     assert session.phase == "development"
-    assert session.first_crack_at_utc == datetime(2026, 5, 17, 14, 6, tzinfo=UTC)
-    assert session.first_crack_monotonic_seconds == 40.0
+    assert session.first_crack_at_utc == datetime(
+        2026,
+        5,
+        17,
+        14,
+        0,
+        37,
+        250000,
+        tzinfo=UTC,
+    )
+    assert session.first_crack_monotonic_seconds == 37.25
+    assert first_result.event.monotonic_seconds == 37.25
     assert first_result.event.payload == {
         "source": "first_crack_detector",
         "detected_at_monotonic_seconds": 537.25,
@@ -149,6 +159,8 @@ def test_confirmed_detector_output_records_first_crack_event_once() -> None:
     }
     assert len(first_result.session.event_timeline) == 2
     assert len(second_result.session.event_timeline) == 2
+    metrics = compute_roast_metrics(session, monotonic_now=clock.monotonic_now)
+    assert metrics.development_time_seconds == 2.75
 
 
 def test_automatic_detection_does_not_require_manual_override_permission() -> None:
@@ -156,6 +168,7 @@ def test_automatic_detection_does_not_require_manual_override_permission() -> No
     store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
     session = store.start_session()
     store.record_event(session, "beans_added")
+    clock.monotonic_value = 502.0
     config = FirstCrackConfig(mode="audio", allow_manual_override=False)
     adapter = build_first_crack_detector_adapter(
         config,
@@ -217,7 +230,7 @@ def test_manual_first_crack_event_takes_precedence_over_later_detector_confirmat
 def _audio_window(
     *,
     sequence_number: int = 3,
-    started_at_monotonic_seconds: float = 10.0,
+    started_at_monotonic_seconds: float = 500.5,
 ) -> AudioWindow:
     return AudioWindow(
         sequence_number=sequence_number,

--- a/tests/test_first_crack_integration.py
+++ b/tests/test_first_crack_integration.py
@@ -189,6 +189,37 @@ def test_automatic_detection_does_not_require_manual_override_permission() -> No
     assert session.phase == "development"
 
 
+def test_adapter_default_timestamp_records_when_window_end_is_slightly_ahead() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 501.25
+    config = FirstCrackConfig(mode="audio")
+    adapter = build_first_crack_detector_adapter(
+        config,
+        _resolved_detector_artifacts(),
+        MockDetectorBackend((FirstCrackDetectorOutput(confirmed=True),)),
+    )
+
+    result = integrate_first_crack_window_with_session(
+        config=config,
+        adapter=adapter,
+        session_store=store,
+        session=session,
+        window=_audio_window(
+            started_at_monotonic_seconds=501.0,
+            duration_seconds=1.0,
+        ),
+    )
+
+    assert result is not None
+    assert result.event.kind == "first_crack_detected"
+    assert result.event.monotonic_seconds == 1.25
+    assert result.event.payload["detected_at_monotonic_seconds"] == 502.0
+    assert session.first_crack_monotonic_seconds == 1.25
+
+
 def test_manual_first_crack_event_takes_precedence_over_later_detector_confirmation() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
@@ -231,13 +262,14 @@ def _audio_window(
     *,
     sequence_number: int = 3,
     started_at_monotonic_seconds: float = 500.5,
+    duration_seconds: float = 1.0,
 ) -> AudioWindow:
     return AudioWindow(
         sequence_number=sequence_number,
         input_device="mock-audio",
         sample_rate=4,
         started_at_monotonic_seconds=started_at_monotonic_seconds,
-        duration_seconds=1.0,
+        duration_seconds=duration_seconds,
         samples=(0.1, 0.2, 0.3, 0.4),
     )
 

--- a/tests/test_first_crack_integration.py
+++ b/tests/test_first_crack_integration.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 from coffee_roaster_mcp.artifacts import ResolvedArtifact, ResolvedDetectorArtifacts
 from coffee_roaster_mcp.audio import AudioWindow
 from coffee_roaster_mcp.config import FirstCrackConfig
@@ -11,7 +13,11 @@ from coffee_roaster_mcp.detector import (
     build_first_crack_detector_adapter,
     integrate_first_crack_window_with_session,
 )
-from coffee_roaster_mcp.session import RoastSessionStore, compute_roast_metrics
+from coffee_roaster_mcp.session import (
+    RoastSessionStore,
+    SessionLifecycleError,
+    compute_roast_metrics,
+)
 
 
 class ClockHarness:
@@ -240,6 +246,42 @@ def test_adapter_default_timestamp_records_when_window_end_is_slightly_ahead() -
     assert result.event.monotonic_seconds == 1.25
     assert result.event.payload["detected_at_monotonic_seconds"] == 502.0
     assert session.first_crack_monotonic_seconds == 1.25
+
+
+def test_explicit_future_detector_timestamp_is_rejected() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 501.25
+    config = FirstCrackConfig(mode="audio")
+    adapter = build_first_crack_detector_adapter(
+        config,
+        _resolved_detector_artifacts(),
+        MockDetectorBackend(
+            (
+                FirstCrackDetectorOutput(
+                    confirmed=True,
+                    detected_at_monotonic_seconds=502.0,
+                ),
+            )
+        ),
+    )
+
+    with pytest.raises(SessionLifecycleError, match="cannot be in the future"):
+        integrate_first_crack_window_with_session(
+            config=config,
+            adapter=adapter,
+            session_store=store,
+            session=session,
+            window=_audio_window(
+                started_at_monotonic_seconds=501.0,
+                duration_seconds=1.0,
+            ),
+        )
+
+    assert [event.kind for event in session.event_timeline] == ["beans_added"]
+    assert session.phase == "roasting"
 
 
 def test_manual_first_crack_event_takes_precedence_over_later_detector_confirmation() -> None:


### PR DESCRIPTION
## Summary
- Add the E4-S9 detector-to-session integration helper that records confirmed detector output through the authoritative `RoastSessionStore` timeline.
- Gate detector timeline writes to `first_crack.mode: audio` while preserving manual and disabled mode behavior.
- Preserve detector-provided first-crack timing as the authoritative event timestamp so downstream development metrics are not shifted by detector/integration latency.
- Accept adapter-inferred default window-end timestamps within the detector-window tolerance so backends without explicit timestamps do not fail the automatic path, while explicit future backend timestamps still fail fast.
- Ignore detector confirmations before beans are added and after the session leaves active `roasting`, so false positives and late confirmations do not break the detector loop with session lifecycle errors.
- Add focused tests for unconfirmed output, mode gating, duplicate/late detector confirmations, manual-first precedence, automatic detection with manual override disabled, inferred timestamp tolerance, explicit future timestamp rejection, pre-beans confirmed output, and post-roasting confirmed output.
- Update durable state so E4-S9 is complete and E4-S10 is the next active story.

Closes #39

## Validation
- `./.venv/bin/python -m pytest tests/test_first_crack_integration.py tests/test_detector.py tests/test_session.py` -> 55 passed
- `./.venv/bin/python -m pytest` -> 238 passed
- `./.venv/bin/python -m ruff check .` -> passed
- `./.venv/bin/python -m ruff format --check .` -> passed
- `./.venv/bin/python -m pyright` -> 0 errors