### PR TITLE
E4-S10: Harden first-crack and MCP coverage

### DIFF
--- a/docs/session-summaries/2026-05-17-e4-s10-harden-first-crack-and-mcp-coverage.md
+++ b/docs/session-summaries/2026-05-17-e4-s10-harden-first-crack-and-mcp-coverage.md
@@ -1,0 +1,199 @@
+# E4-S10 Harden First-Crack And MCP Coverage Session
+
+## Scope
+
+This session resumed after `PR #101` for `E4-S9` was squashed and merged, and
+issue `#39` was closed. Work started from updated `main` on branch
+`feature/99-harden-first-crack-and-mcp-coverage-before-next-epic` for issue
+`#99`, `E4-S10: Harden first-crack and MCP coverage before next epic`.
+
+The original story goal was targeted coverage hardening before Epic 5. During
+review of the MCP interface, we identified that this was not only a coverage
+gap: the installed Claude-local operational MCP path was not yet complete.
+That produced a planning correction and a new inserted Epic 4.1 before Epic 5.
+
+## Context Usage
+
+Session usage snapshot supplied by the operator when this summary was requested:
+
+- Context window: `28% left (190K used / 258K)`
+- 5h limit: `87% left`, resets `22:35`
+- Weekly limit: `95% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `02:57 on 18 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `21:57 on 24 May`
+
+## Pre-Story Verification
+
+Before starting E4-S10:
+
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding through the E4-S9 merge.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-17-e4-s9-integrate-first-crack-with-session-timeline.md`,
+  and GitHub issue `#99`.
+- Created branch
+  `feature/99-harden-first-crack-and-mcp-coverage-before-next-epic`.
+
+## Implementation
+
+Updated:
+
+- `tests/test_exports.py`
+- `tests/test_mcp_server.py`
+- `pyproject.toml`
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+- `docs/state/github-issues.md`
+
+Coverage hardening added:
+
+- Added direct in-process FastMCP tool coverage for the registered MCP tool
+  bodies. This complements the existing stdio subprocess smoke tests, which are
+  useful end-to-end checks but do not contribute to local coverage for
+  `mcp_server.py`.
+- Covered current MCP-facing behavior for server info, runtime config, session
+  start/state, heat/fan controls, beans added, manual first crack, drop,
+  cooling, export, audio-mode bootstrap safety reporting, missing active session
+  errors, disabled manual override errors, and unknown session lookup.
+- Added snapshot export coverage proving automatic first-crack detector metadata
+  is preserved in current JSONL and CSV event exports.
+- Documented that `summary.json` currently carries first-crack timestamps and
+  metrics, while final schema completeness is deferred to Epic 5.
+- Added `fail_under = 90` to coverage configuration.
+
+Coverage result:
+
+- Before E4-S10 coverage hardening, local package coverage was `86%`.
+- After E4-S10 coverage hardening, local package coverage is `91.73%`.
+- `mcp_server.py` improved from `55%` to `97%`.
+- `exports.py` improved from `43%` to `96%`.
+
+## MCP Operational Gap Review
+
+After E4-S10 coverage was implemented, we reviewed whether installing the MCP
+server locally in Claude would allow a real operational roast:
+
+- Claude should be able to start a roast.
+- Claude should be able to adjust the configured device.
+- Claude should be able to read current device and session state.
+- Claude should be able to know whether first crack has happened.
+
+The answer was: not fully yet.
+
+Current state:
+
+- MCP heat/fan/drop/cooling tools are covered at the existing mock/session
+  boundary.
+- E3 validated the Hottop driver boundary, but normal MCP heat/fan/drop/cooling
+  tools are not yet wired to live configured driver commands.
+- E4 built released-artifact resolution, audio input, detector adapter, and
+  detector-to-session integration.
+- E4 does not yet include a released-artifact ONNX detector backend or a
+  session-owned audio/detector runtime loop.
+
+Planning correction:
+
+- Added new GitHub issue `#103`: `Epic 4.1: Operational MCP runtime for device
+  control and first-crack status`.
+- Added story issues:
+  - `#104` `E4.1-S1: Wire MCP roast-control tools to configured driver`
+  - `#105` `E4.1-S2: Expose current roaster device state through MCP`
+  - `#106` `E4.1-S3: Add released-artifact ONNX first-crack detector backend`
+  - `#107` `E4.1-S4: Start first-crack detection runtime with roast sessions`
+  - `#108` `E4.1-S5: Add MCP operational readiness tests and docs`
+- Updated `docs/state/github-issues.md`, `docs/state/registry.md`, and
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md` to insert Epic 4.1 before Epic
+  5.
+
+## MCP Tool Semantics Clarified
+
+The operator asked whether `mark_beans_added`, `mark_first_crack`, and
+`start_cooling` should be exposed if the runtime should mark those events
+internally.
+
+Decision captured in GitHub issues and local state:
+
+- `mark_beans_added` remains exposed as an explicit T0 override.
+- The primary future automatic T0 path is internal runtime detection when
+  enabled, for example a qualifying bean-temperature drop.
+- `mark_first_crack` remains exposed only as an explicit manual override when
+  configuration allows it.
+- The primary audio-mode first-crack path is internal detector confirmation.
+- `drop_beans` is the normal agent/operator command that should trigger roaster
+  drop/cooling behavior and record the relevant timeline events.
+- `start_cooling` remains exposed as an advanced/manual recovery control, not
+  the normal Claude roast flow.
+- `get_roast_state` must expose event timestamps and status for beans added,
+  first crack, bean drop, cooling started, and cooling stopped.
+
+GitHub issues updated with these semantics:
+
+- `#103` Epic 4.1 operational model
+- `#104` E4.1-S1 control semantics
+- `#105` E4.1-S2 state/timestamp/status requirements
+- `#107` E4.1-S4 detector runtime/manual override semantics
+- `#108` E4.1-S5 readiness tests/docs
+
+## Pull Request
+
+Opened `PR #102`: <https://github.com/syamaner/coffee-roaster-mcp/pull/102>
+
+PR branch:
+
+- `feature/99-harden-first-crack-and-mcp-coverage-before-next-epic`
+
+Commits on the branch before this summary:
+
+- `993ff5f` - `test: harden first crack and mcp coverage`
+- `f01dd4f` - `docs: add operational mcp epic`
+- `517f2bb` - `docs: clarify operational mcp tool semantics`
+
+PR status when this summary was written:
+
+- state: open
+- draft: false
+- mergeable: true
+- head: `517f2bbc9ae2ace3abf9cf1af8e93d1e3d31baa2`
+- GitHub Actions `Build Package`: passed
+- GitHub Actions `Checks`: passed
+
+Issue `#99` remains open and should close when PR #102 is merged through
+`Closes #99`.
+
+## Validation
+
+Local validation run:
+
+- Ran `./.venv/bin/python -m pytest tests/test_exports.py tests/test_mcp_server.py tests/test_first_crack_integration.py tests/test_package.py`:
+  `27 passed`.
+- Ran `./.venv/bin/python -m pytest`: `241 passed`.
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `241 passed`, required coverage `90.0%` reached, total coverage `91.73%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
+
+GitHub Actions validation on PR #102:
+
+- `Build Package`: passed.
+- `Checks`: passed.
+
+## Handoff Notes
+
+After PR #102 merges:
+
+1. Sync `main`.
+2. Verify PR #102 is merged and issue `#99` is closed.
+3. Read `AGENTS.md`, `docs/state/registry.md`,
+   `docs/state/epics/coffee-roaster-mcp-v0.1.md`, this summary, and GitHub
+   issue `#104`.
+4. Begin E4.1-S1 from updated `main` on branch
+   `feature/104-wire-mcp-roast-control-tools-to-configured-driver`.
+5. Keep E4.1-S1 scoped to wiring current MCP roast-control tools to the
+   configured driver boundary. Preserve mock-safe defaults, one-session store
+   semantics, fail-closed safety behavior, E3 Hottop validation boundaries, and
+   no-live-hardware CI.
+6. Do not add automatic first-crack detector startup, ONNX detector runtime,
+   rolling telemetry metrics, final log schemas, model training, ONNX export,
+   Hugging Face sync, or broad release validation in E4.1-S1.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E5-S1`
-- Current target: Implement rolling telemetry buffer
+- Active story: `E4.1-S1`
+- Current target: Wire MCP roast-control tools to configured driver
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -103,6 +103,16 @@ The first implementation milestone is a mock vertical slice that requires no roa
   Epic 5 finalizes schemas. Coverage now has a stable `90%` package floor, with
   local branch-aware coverage at `91.73%`. Normal CI remains mock-safe with no
   microphone, Hottop hardware, model download, or network requirement.
+- Epic 4.1 is inserted before Epic 5 because the installed Claude-local MCP
+  operational path is not complete yet. Current MCP heat/fan/drop/cooling tools
+  are covered at the existing mock/session boundary, but they are not yet wired
+  to the configured live driver. Current first-crack components resolve
+  artifacts, capture audio windows, adapt detector outputs, and write to the
+  session timeline, but there is not yet a released-artifact ONNX runtime
+  backend or session-owned detector loop. Epic 4.1 makes the operational MCP
+  flow explicit: Claude should be able to start a roast, adjust the configured
+  roaster, read current device/session state, and know whether first crack has
+  happened before Epic 5 adds richer telemetry metrics and final log schemas.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -110,7 +120,13 @@ The first implementation milestone is a mock vertical slice that requires no roa
 
 ## Current Risks
 
-- Normal MCP heat, fan, drop, and cooling tools are not yet wired to live Hottop driver commands; current Hottop hardware readiness applies to the driver boundary validated by E3-S9.
+- Normal MCP heat, fan, drop, and cooling tools are not yet wired to live
+  Hottop driver commands; current Hottop hardware readiness applies to the
+  driver boundary validated by E3-S9, and Epic 4.1 now tracks the normal MCP
+  operational wiring.
+- The first-crack path does not yet include a released-artifact ONNX runtime
+  backend or session-owned detector loop; Epic 4.1 now tracks this before Epic
+  5 metrics/logging work.
 - MCP Registry publishing is preview and needs verification before release.
 - First-crack event integration must preserve one authoritative session timeline.
 - Log schema changes need compatibility discipline once users start collecting roast logs.
@@ -288,6 +304,59 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
   MCP-facing behavior, current export surfaces, and mock-safe failure modes.
 - Real microphone validation is optional, explicitly gated, and never required
   for normal CI.
+
+## Epic 4.1: Operational MCP Runtime
+
+Goal: make the locally installed MCP server operational for Claude before the
+metrics/logging epic. Claude should be able to start a roast, adjust the
+configured roaster, read current device and session state, and know whether
+first crack has happened through MCP tools.
+
+### Stories
+
+- [ ] `E4.1-S1` Wire MCP roast-control tools to configured driver.
+  - Done when `start_roast_session`, `set_heat`, `set_fan`, `drop_beans`,
+    `start_cooling`, `stop_cooling`, and `emergency_stop` call the configured
+    `RoasterDriver` boundary where appropriate while preserving the mock
+    default, one-session store semantics, fail-closed safety behavior, and
+    no-live-hardware CI.
+
+- [ ] `E4.1-S2` Expose current roaster device state through MCP.
+  - Done when MCP state output includes current driver state needed for
+    operational decisions: connected status, bean/environment temperatures when
+    available, heat/fan levels, cooling state, driver id, and safe raw
+    diagnostics, without implementing Epic 5 rolling metrics.
+
+- [ ] `E4.1-S3` Add released-artifact ONNX first-crack detector backend.
+  - Done when `first_crack.mode: audio` can construct a detector backend from
+    the resolved ONNX model and feature-extractor config using the existing
+    released-artifact resolver boundary, with mock-safe tests and no training,
+    export, or Hugging Face sync behavior.
+
+- [ ] `E4.1-S4` Start first-crack detection runtime with roast sessions.
+  - Done when audio mode starts/stops the configured audio pipeline and detector
+    runtime with the roast session, records confirmed first crack exactly once,
+    exposes disabled/manual/pending/detected/faulted/unavailable status through
+    MCP, and keeps detector/audio failures from crashing normal session control.
+
+- [ ] `E4.1-S5` Add MCP operational readiness tests and docs.
+  - Done when automated MCP tests cover the local Claude-installed operational
+    flow on the mock-safe path, MCP response schemas for device state and
+    first-crack status are asserted, and optional live Hottop/real microphone
+    validation docs remain explicitly gated.
+
+### Epic Acceptance Criteria
+
+- Claude can start a roast through MCP.
+- Claude can adjust configured roaster controls through MCP while the default
+  mock path remains hardware-free.
+- Claude can read current configured-device state and authoritative session
+  state through MCP.
+- Claude can determine whether first crack is disabled, manual, pending,
+  detected, faulted, or unavailable due to configuration/artifact/audio errors.
+- Normal CI requires no Hottop hardware, microphone, model download, or network.
+- Model training, ONNX export, Hugging Face sync, final telemetry metrics, and
+  final log schemas remain out of scope for this epic.
 
 ## Epic 5: Roast Metrics And Log Export
 

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -113,6 +113,13 @@ The first implementation milestone is a mock vertical slice that requires no roa
   flow explicit: Claude should be able to start a roast, adjust the configured
   roaster, read current device/session state, and know whether first crack has
   happened before Epic 5 adds richer telemetry metrics and final log schemas.
+- `mark_beans_added` and `mark_first_crack` remain exposed as explicit
+  override tools. The primary runtime path should be internal auto-T0 detection
+  when enabled and internal first-crack detector confirmation in audio mode.
+  `drop_beans` is the normal agent/operator command that should trigger the
+  roaster drop/cooling behavior and record the relevant session events;
+  `start_cooling` remains an advanced recovery/manual tool, not the normal
+  Claude roast flow.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -319,13 +326,17 @@ first crack has happened through MCP tools.
     `start_cooling`, `stop_cooling`, and `emergency_stop` call the configured
     `RoasterDriver` boundary where appropriate while preserving the mock
     default, one-session store semantics, fail-closed safety behavior, and
-    no-live-hardware CI.
+    no-live-hardware CI. `drop_beans` is the normal MCP path for drop and
+    cooling transition; `start_cooling` remains available only as an explicit
+    advanced/manual recovery control.
 
 - [ ] `E4.1-S2` Expose current roaster device state through MCP.
   - Done when MCP state output includes current driver state needed for
     operational decisions: connected status, bean/environment temperatures when
     available, heat/fan levels, cooling state, driver id, and safe raw
-    diagnostics, without implementing Epic 5 rolling metrics.
+    diagnostics, plus authoritative event timestamps for beans added, first
+    crack, bean drop, cooling start, and cooling stop, without implementing Epic
+    5 rolling metrics.
 
 - [ ] `E4.1-S3` Add released-artifact ONNX first-crack detector backend.
   - Done when `first_crack.mode: audio` can construct a detector backend from
@@ -338,12 +349,16 @@ first crack has happened through MCP tools.
     runtime with the roast session, records confirmed first crack exactly once,
     exposes disabled/manual/pending/detected/faulted/unavailable status through
     MCP, and keeps detector/audio failures from crashing normal session control.
+    `mark_first_crack` remains only the explicit manual override path when
+    configuration allows it.
 
 - [ ] `E4.1-S5` Add MCP operational readiness tests and docs.
   - Done when automated MCP tests cover the local Claude-installed operational
     flow on the mock-safe path, MCP response schemas for device state and
-    first-crack status are asserted, and optional live Hottop/real microphone
-    validation docs remain explicitly gated.
+    first-crack status are asserted, override-tool semantics for
+    `mark_beans_added` and `mark_first_crack` are documented, `drop_beans` is
+    documented as the normal drop/cooling command, and optional live
+    Hottop/real microphone validation docs remain explicitly gated.
 
 ### Epic Acceptance Criteria
 
@@ -354,6 +369,12 @@ first crack has happened through MCP tools.
   state through MCP.
 - Claude can determine whether first crack is disabled, manual, pending,
   detected, faulted, or unavailable due to configuration/artifact/audio errors.
+- Claude can read event timestamps for beans added, first crack, bean drop,
+  cooling started, and cooling stopped from `get_roast_state`.
+- Automatic T0 and automatic first-crack detection are internal runtime paths;
+  exposed mark tools are explicit overrides.
+- `drop_beans` is the normal operational command for drop and cooling
+  transition; `start_cooling` is an advanced/manual recovery path.
 - Normal CI requires no Hottop hardware, microphone, model download, or network.
 - Model training, ONNX export, Hugging Face sync, final telemetry metrics, and
   final log schemas remain out of scope for this epic.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4-S10`
-- Current target: Harden first-crack and MCP coverage before next epic
+- Active story: `E5-S1`
+- Current target: Implement rolling telemetry buffer
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -94,10 +94,15 @@ The first implementation milestone is a mock vertical slice that requires no roa
   disconnected from detector writes, and allows automatic detection even when
   manual override is disabled.
 - `E4-S10` closes Epic 4 with targeted test hardening before the next epic.
-  It should reduce coverage gaps around the assembled first-crack path,
-  MCP-facing behavior, current export surfaces, and mock-safe failure modes.
-  Real microphone validation can be added only as an explicit opt-in manual path
-  that is skipped by default and never required for normal CI.
+  Direct in-process MCP tool tests now cover the registered FastMCP tool bodies
+  for the current mock-safe session/control surface, including manual
+  first-crack behavior, audio-mode bootstrap reporting, error propagation, and
+  export through the public tool. Export tests prove automatic first-crack
+  detector metadata is preserved in current JSONL and CSV event exports, while
+  `summary.json` remains limited to first-crack timestamps and metrics until
+  Epic 5 finalizes schemas. Coverage now has a stable `90%` package floor, with
+  local branch-aware coverage at `91.73%`. Normal CI remains mock-safe with no
+  microphone, Hottop hardware, model download, or network requirement.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -268,7 +273,7 @@ Goal: consume released Hugging Face model artifacts and feed first-crack events 
 - [x] `E4-S9` Integrate first crack with session timeline.
   - Done when mocked detector output creates exactly one `first_crack_detected` event.
 
-- [ ] `E4-S10` Harden first-crack and MCP coverage before next epic.
+- [x] `E4-S10` Harden first-crack and MCP coverage before next epic.
   - Done when automated tests cover the assembled first-crack path, MCP-facing behavior, current export surfaces, duplicate/no-confirmation/error cases, disabled/manual modes, missing artifacts, and materially reduce `mcp_server.py`, `exports.py`, and Epic 4 coverage gaps.
   - Manual real-microphone validation may be added only behind an explicit opt-in gate and must be skipped by default unless a microphone is configured and ready.
 
@@ -856,3 +861,24 @@ After completing a story:
     `./.venv/bin/python -m ruff check .`: passed,
     `./.venv/bin/python -m ruff format --check .`: passed, and
     `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E4-S10:
+  - Added direct in-process MCP tool coverage for the registered FastMCP tool
+    bodies so local coverage measures the same public tool logic already
+    exercised by stdio smoke tests.
+  - Covered current MCP-facing behavior for server info, runtime config,
+    session start/state, heat/fan controls, beans added, manual first crack,
+    drop, cooling, export, audio-mode bootstrap safety reporting, missing active
+    session errors, disabled manual override errors, and unknown session lookup.
+  - Added export coverage proving automatic first-crack detector metadata is
+    preserved in JSONL and CSV event exports while `summary.json` keeps the
+    current timestamp and metrics surface until Epic 5 finalizes log schemas.
+  - Reviewed the current MCP completion boundary: mock/session device control
+    and manual first-crack MCP behavior are covered, live Hottop command wiring
+    remains a deliberate future MCP integration story, and automatic
+    first-crack detector startup is not yet a runtime MCP loop.
+  - Added a stable `90%` package coverage floor in `pyproject.toml`; local
+    branch-aware coverage is `91.73%`.
+  - Ran `./.venv/bin/python -m pytest tests/test_exports.py tests/test_mcp_server.py tests/test_first_crack_integration.py tests/test_package.py`:
+    27 passed.
+  - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+    241 passed, required coverage `90.0%` reached, total coverage `91.73%`.

--- a/docs/state/github-issues.md
+++ b/docs/state/github-issues.md
@@ -10,6 +10,7 @@ Milestone: `v0.1`
 - #2 Epic 2: MCP Runtime And Session Core
 - #3 Epic 3: Roaster Abstraction And Hottop Driver
 - #4 Epic 4: First-Crack Detection With HF Models
+- #103 Epic 4.1: Operational MCP runtime for device control and first-crack status
 - #5 Epic 5: Roast Metrics And Log Export
 - #6 Epic 6: Distribution And MCP Registry Publishing
 - #7 Epic 7: End-To-End Validation And Release Readiness
@@ -60,6 +61,14 @@ Milestone: `v0.1`
 - #97 E4-S8: Add microphone and WAV audio input adapters
 - #39 E4-S9: Integrate first crack with session timeline
 - #99 E4-S10: Harden first-crack and MCP coverage before next epic
+
+## Epic 4.1 Stories
+
+- #104 E4.1-S1: Wire MCP roast-control tools to configured driver
+- #105 E4.1-S2: Expose current roaster device state through MCP
+- #106 E4.1-S3: Add released-artifact ONNX first-crack detector backend
+- #107 E4.1-S4: Start first-crack detection runtime with roast sessions
+- #108 E4.1-S5: Add MCP operational readiness tests and docs
 
 ## Epic 5 Stories
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -30,7 +30,7 @@ drop and emergency stop included. A follow-up 60-second stability test also held
 fan at `10%`, heat at `40%` for 30 seconds, then heat at `100%` for 30 seconds
 with continuous command streaming and no command-loop or status-read errors.
 
-E4-S9 is complete. The first-crack path now resolves the configured ONNX model
+Epic 4 is complete pending merge of E4-S10. The first-crack path now resolves the configured ONNX model
 artifact for both supported real-model precisions: `int8` selects
 `onnx/int8/model_quantized.onnx`, and `fp32` selects `onnx/fp32/model.onnx`
 through the artifact resolver. When `first_crack.local_model_dir` is configured,
@@ -68,12 +68,22 @@ lifecycle errors. Disabled and manual modes do not let detector output mutate
 the session, and automatic detection does not require manual override
 permission.
 
-The next story is E4-S10: harden first-crack and MCP coverage before the next epic.
-Epic 4 includes E4-S10 as a closing test-hardening story before the next epic,
-focused on first-crack integration, MCP-facing behavior, export assertions,
-mock-safe failure modes, and coverage gaps. Real microphone validation is
-optional and must remain explicitly gated so normal CI does not require audio
-hardware.
+E4-S10 hardened the first-crack and MCP test surface before Epic 5. Direct
+in-process MCP tool tests now exercise the current mock-safe device/session
+tool surface, manual first-crack behavior, audio-mode bootstrap reporting,
+error propagation, and snapshot export through the registered FastMCP tool
+bodies. Export tests now prove automatic first-crack detector metadata is
+preserved in the current JSONL and CSV event export surfaces; `summary.json`
+continues to expose first-crack timestamp and metrics only until Epic 5 final
+schemas land. Coverage now has a stable `90%` package floor, with local
+branch-aware coverage at `91.73%`. Real microphone validation remains optional
+and gated; normal CI requires no audio hardware, model download, Hottop
+hardware, or network access. Normal MCP heat/fan/drop/cooling tools still use
+the existing one-session mock/session boundary rather than live Hottop command
+wiring, and automatic first-crack detector startup is not yet an MCP runtime
+loop.
+
+The next story after E4-S10 merges is E5-S1: implement rolling telemetry buffer.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -83,7 +83,16 @@ the existing one-session mock/session boundary rather than live Hottop command
 wiring, and automatic first-crack detector startup is not yet an MCP runtime
 loop.
 
-The next story after E4-S10 merges is E5-S1: implement rolling telemetry buffer.
+Epic 4.1 is now inserted before Epic 5 to close operational MCP runtime gaps.
+The target user flow is: install the MCP server locally in Claude, start a
+roast, adjust the configured roaster through MCP tools, read current device and
+session state, and know whether first crack has happened. E4.1 covers
+driver-backed MCP control tools, current roaster state exposure, released ONNX
+detector backend construction, session-owned first-crack detector lifecycle, and
+operational MCP readiness tests/docs. Epic 5 remains focused on telemetry
+buffering, derived metrics, and final log/export schemas.
+
+The next story after E4-S10 merges is E4.1-S1: wire MCP roast-control tools to the configured driver.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -89,8 +89,13 @@ roast, adjust the configured roaster through MCP tools, read current device and
 session state, and know whether first crack has happened. E4.1 covers
 driver-backed MCP control tools, current roaster state exposure, released ONNX
 detector backend construction, session-owned first-crack detector lifecycle, and
-operational MCP readiness tests/docs. Epic 5 remains focused on telemetry
-buffering, derived metrics, and final log/export schemas.
+operational MCP readiness tests/docs. `mark_beans_added` and
+`mark_first_crack` remain explicit override tools, while automatic T0 and
+first-crack detection are internal runtime paths. `drop_beans` is the normal
+agent/operator command for drop and cooling transition; `start_cooling` is an
+advanced recovery/manual control rather than the normal roast flow. Epic 5
+remains focused on telemetry buffering, derived metrics, and final log/export
+schemas.
 
 The next story after E4-S10 merges is E4.1-S1: wire MCP roast-control tools to the configured driver.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ source = ["coffee_roaster_mcp"]
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
+fail_under = 90
 
 [tool.coverage.html]
 directory = "htmlcov"

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,80 @@
+"""Snapshot export coverage for first-crack metadata."""
+
+from __future__ import annotations
+
+import csv
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from coffee_roaster_mcp.exports import export_roast_snapshot
+from coffee_roaster_mcp.session import EventPayloadValue, RoastSessionStore
+
+
+class ClockHarness:
+    """Deterministic clock supplier for export tests."""
+
+    def __init__(self) -> None:
+        self.utc_value = datetime(2026, 5, 17, 14, 0, tzinfo=UTC)
+        self.monotonic_value = 100.0
+
+    def utc_now(self) -> datetime:
+        """Return the current test wall-clock timestamp."""
+        return self.utc_value
+
+    def monotonic_now(self) -> float:
+        """Return the current test monotonic timestamp."""
+        return self.monotonic_value
+
+
+def test_snapshot_export_preserves_first_crack_detector_metadata(tmp_path: Path) -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    metadata: dict[str, EventPayloadValue] = {
+        "source": "first_crack_detector",
+        "detected_at_monotonic_seconds": 137.25,
+        "precision": "int8",
+        "revision": "v0.1.0",
+        "repo_id": "syamaner/coffee-first-crack-detection",
+        "onnx_model_filename": "onnx/int8/model_quantized.onnx",
+        "feature_extractor_filename": "onnx/int8/preprocessor_config.json",
+        "window_sequence_number": 9,
+        "confidence": 0.93,
+    }
+    clock.monotonic_value = 140.0
+    store.record_first_crack_detection_snapshot(
+        session,
+        detected_at_monotonic_seconds=137.25,
+        payload=metadata,
+    )
+    clock.monotonic_value = 170.0
+    store.record_event(session, "beans_dropped")
+
+    export = export_roast_snapshot(session)
+
+    jsonl_events = [
+        json.loads(line) for line in export.jsonl_path.read_text(encoding="utf-8").splitlines()
+    ]
+    first_crack_jsonl = jsonl_events[1]
+    assert first_crack_jsonl["kind"] == "first_crack_detected"
+    assert first_crack_jsonl["monotonic_seconds"] == 37.25
+    assert first_crack_jsonl["payload"] == metadata
+
+    with export.csv_path.open(encoding="utf-8", newline="") as csv_file:
+        csv_rows = list(csv.DictReader(csv_file))
+    first_crack_csv_payload = json.loads(csv_rows[1]["payload_json"])
+    assert csv_rows[1]["kind"] == "first_crack_detected"
+    assert float(csv_rows[1]["monotonic_seconds"]) == 37.25
+    assert first_crack_csv_payload == metadata
+
+    summary = json.loads(export.summary_path.read_text(encoding="utf-8"))
+    assert summary["first_crack_at_utc"] == "2026-05-17T14:00:37.250000+00:00"
+    assert summary["metrics"]["development_time_seconds"] == 32.75
+    assert summary["metrics"]["development_percent"] == 50.385

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,127 @@
+"""In-process MCP tool coverage for RoastPilot."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from coffee_roaster_mcp.mcp_server import ServerContext, build_server_context, create_mcp_server
+
+
+def test_in_process_mcp_tools_cover_mock_roast_and_export(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    server_info = _call_tool(server, "get_server_info", ctx)
+    assert server_info.bootstrap_safe is True
+    assert "export_roast_log" in server_info.available_bootstrap_tools
+
+    runtime_config = _call_tool(server, "get_runtime_config", ctx)
+    assert runtime_config.config_source == str(config_path)
+    assert runtime_config.first_crack_mode == "disabled"
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    session_id = start_result.session.session_id
+    assert start_result.session.phase == "pre_roast"
+    assert start_result.session.log_dir is not None
+
+    heat_result = _call_tool(server, "set_heat", ctx, heat_level_percent=70)
+    fan_result = _call_tool(server, "set_fan", ctx, fan_level_percent=40)
+    assert heat_result.heat_level_percent == 70
+    assert fan_result.fan_level_percent == 40
+
+    beans_added = _call_tool(server, "mark_beans_added", ctx)
+    first_crack = _call_tool(server, "mark_first_crack", ctx)
+    drop = _call_tool(server, "drop_beans", ctx)
+    cooling = _call_tool(server, "start_cooling", ctx)
+    complete = _call_tool(server, "stop_cooling", ctx)
+    assert beans_added.event.kind == "beans_added"
+    assert first_crack.event.kind == "first_crack_detected"
+    assert drop.phase == "dropped"
+    assert cooling.phase == "cooling"
+    assert complete.phase == "complete"
+
+    state = _call_tool(server, "get_roast_state", ctx, session_id=session_id)
+    assert state.session_id == session_id
+    assert state.active is False
+    assert state.phase == "complete"
+    assert [event.kind for event in state.events] == [
+        "beans_added",
+        "first_crack_detected",
+        "beans_dropped",
+        "cooling_started",
+        "cooling_stopped",
+    ]
+    assert state.first_crack_at_utc is not None
+    assert state.development_time_seconds is not None
+
+    export = _call_tool(server, "export_roast_log", ctx, session_id=session_id)
+    assert export.ready is True
+    assert export.session_id == session_id
+    assert Path(export.jsonl_path).exists()
+    assert Path(export.csv_path).exists()
+    assert Path(export.summary_path).exists()
+
+    events = [json.loads(line) for line in Path(export.jsonl_path).read_text().splitlines()]
+    assert [event["kind"] for event in events] == [
+        "beans_added",
+        "first_crack_detected",
+        "beans_dropped",
+        "cooling_started",
+        "cooling_stopped",
+    ]
+
+
+def test_in_process_mcp_tools_surface_errors_and_audio_bootstrap_state(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "first_crack:",
+                "  mode: audio",
+                "  allow_manual_override: false",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server_context = build_server_context(config_path=config_path)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    server_info = _call_tool(server, "get_server_info", ctx)
+    runtime_config = _call_tool(server, "get_runtime_config", ctx)
+    assert server_info.first_crack_mode == "audio"
+    assert server_info.bootstrap_safe is False
+    assert runtime_config.allow_manual_override is False
+
+    with pytest.raises(ValueError, match="No active roast session"):
+        _call_tool(server, "set_heat", ctx, heat_level_percent=10)
+
+    _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "mark_beans_added", ctx)
+    with pytest.raises(ValueError, match="Manual first-crack override is disabled"):
+        _call_tool(server, "mark_first_crack", ctx)
+
+    with pytest.raises(ValueError, match="Unknown session_id"):
+        _call_tool(server, "get_roast_state", ctx, session_id="missing-session")
+
+
+def _ctx(server_context: ServerContext) -> Any:
+    """Build the minimal context shape used by FastMCP tool functions."""
+    return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=server_context))
+
+
+def _call_tool(server: FastMCP, tool_name: str, ctx: Any, **kwargs: object) -> Any:
+    """Call one registered FastMCP tool function directly."""
+    tool_manager = server._tool_manager  # pyright: ignore[reportPrivateUsage]
+    tool = tool_manager.get_tool(tool_name)
+    assert tool is not None
+    return tool.fn(ctx, **kwargs)


### PR DESCRIPTION
## Summary
- add direct in-process FastMCP tool coverage for the current mock-safe MCP session/control surface, manual first-crack behavior, audio-mode bootstrap reporting, error propagation, and export
- add export coverage proving automatic first-crack detector metadata is preserved in current JSONL and CSV event exports while `summary.json` remains timestamp/metrics-focused until Epic 5 schemas
- add a stable package coverage floor with `fail_under = 90`
- add Epic 4.1 issues/state docs for the operational MCP runtime gap before Epic 5
- clarify Epic 4.1 tool semantics: `mark_beans_added` and `mark_first_crack` are override tools, `drop_beans` is the normal drop/cooling command, and `get_roast_state` owns event timestamp/status visibility

## MCP boundary reviewed
- Current MCP heat/fan/drop/cooling and manual first-crack tools are covered for the existing one-session mock/session boundary.
- Live Hottop command wiring remains incomplete for normal MCP tools; this is now tracked by Epic 4.1 issue #103 and story #104.
- Current first-crack components resolve artifacts, capture audio windows, adapt detector outputs, and integrate confirmed output with the session timeline, but there is not yet a released-artifact ONNX runtime backend or session-owned detector loop; these are now tracked by #106 and #107.
- Epic 4.1 now defines the operational model before Epic 5: internal auto-T0/detector paths are primary when enabled, explicit mark tools are overrides, and Epic 5 remains scoped to telemetry buffers, derived metrics, and final log/export schemas.

## New Epic 4.1 issues
- #103 Epic 4.1: Operational MCP runtime for device control and first-crack status
- #104 E4.1-S1: Wire MCP roast-control tools to configured driver
- #105 E4.1-S2: Expose current roaster device state through MCP
- #106 E4.1-S3: Add released-artifact ONNX first-crack detector backend
- #107 E4.1-S4: Start first-crack detection runtime with roast sessions
- #108 E4.1-S5: Add MCP operational readiness tests and docs

## Validation
- `./.venv/bin/python -m pytest tests/test_exports.py tests/test_mcp_server.py tests/test_first_crack_integration.py tests/test_package.py` -> 27 passed
- `./.venv/bin/python -m pytest` -> 241 passed
- `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov` -> 241 passed, required coverage 90.0% reached, total coverage 91.73%
- `./.venv/bin/python -m ruff check .` -> passed
- `./.venv/bin/python -m ruff format --check .` -> passed
- `./.venv/bin/python -m pyright` -> 0 errors

Closes #99