### PR TITLE
E4.1-S1: Wire MCP controls to configured driver

### DIFF
--- a/docs/session-summaries/2026-05-18-e4-1-s1-wire-mcp-roast-control-tools.md
+++ b/docs/session-summaries/2026-05-18-e4-1-s1-wire-mcp-roast-control-tools.md
@@ -34,6 +34,15 @@ batch was fixed and before fixing the third review batch:
 - GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `19:21 on 25 May`
 - Warning from status output: limits may be stale; run `/status` again shortly.
 
+Latest context-reset usage snapshot supplied by the operator after all known PR
+review issues were fixed:
+
+- Context window: `66% left (95.6K used / 258K)`
+- 5h limit: `95% left`, resets `20:10`
+- Weekly limit: `94% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `00:37 on 19 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `19:37 on 25 May`
+
 ## Pre-Story Verification
 
 Before starting E4.1-S1:
@@ -236,11 +245,15 @@ Focused validation after these latest fixes:
 Continue on branch
 `feature/104-wire-mcp-roast-control-tools-to-configured-driver`.
 
+All known review issues from PR #109 have been fixed and pushed. The latest
+thread-aware GitHub check after commit `162e3cf` showed the three review
+threads from review `4312706674` as outdated. GitHub reported the PR as
+mergeable and clean, with no status checks currently reported on the branch.
+
 Before making more code changes or merging:
 
 1. Re-read the latest thread-aware review state for PR #109.
-2. Confirm the three review threads from review `4312706674` are outdated or
-   resolved after the latest push.
+2. Confirm no new review comments were added after commit `162e3cf`.
 3. Keep any follow-up scoped to E4.1-S1: configured-driver MCP control wiring and
    safety/idempotency around those controls.
 4. Do not add automatic first-crack detector startup, released-artifact ONNX

--- a/docs/session-summaries/2026-05-18-e4-1-s1-wire-mcp-roast-control-tools.md
+++ b/docs/session-summaries/2026-05-18-e4-1-s1-wire-mcp-roast-control-tools.md
@@ -1,0 +1,221 @@
+# E4.1-S1 Wire MCP Roast-Control Tools Session
+
+## Scope
+
+This session resumed after `PR #102` for `E4-S10` was squashed and merged, and
+issue `#99` was closed. Work started from updated `main` on branch
+`feature/104-wire-mcp-roast-control-tools-to-configured-driver` for issue
+`#104`, `E4.1-S1: Wire MCP roast-control tools to configured driver`.
+
+The story goal is to wire current MCP roast-control tools to the configured
+`RoasterDriver` boundary while preserving the mock default, Epic 2 one-session
+store boundary, MCP semantics, fail-closed safety behavior, coverage workflow,
+and Epic 3 Hottop validation boundary.
+
+## Context Usage
+
+Initial session usage snapshot supplied by the operator when this summary was
+first requested:
+
+- Context window: `39% left (161K used / 258K)`
+- 5h limit: `97% left`, resets `20:10`
+- Weekly limit: `95% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `23:06`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `18:06 on 25 May`
+- Warning from status output: limits may be stale; run `/status` again shortly.
+
+Latest session usage snapshot supplied by the operator after the second review
+batch was fixed and before fixing the third review batch:
+
+- Context window: `18% left (214K used / 258K)`
+- 5h limit: `96% left`, resets `20:10`
+- Weekly limit: `94% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `00:21 on 19 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `19:21 on 25 May`
+- Warning from status output: limits may be stale; run `/status` again shortly.
+
+## Pre-Story Verification
+
+Before starting E4.1-S1:
+
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding through the E4-S10
+  merge.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-17-e4-s10-harden-first-crack-and-mcp-coverage.md`,
+  and GitHub issue `#104`.
+- Created branch
+  `feature/104-wire-mcp-roast-control-tools-to-configured-driver`.
+
+## Implementation
+
+Updated:
+
+- `src/coffee_roaster_mcp/mcp_server.py`
+- `src/coffee_roaster_mcp/session.py`
+- `src/coffee_roaster_mcp/drivers.py`
+- `tests/test_mcp_server.py`
+- `tests/test_package.py`
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+Behavior implemented:
+
+- `start_roast_session` now calls the configured driver `connect()` before
+  creating a session, preserving the mock default and requiring explicit Hottop
+  configuration for live hardware.
+- MCP `set_heat`, `set_fan`, `drop_beans`, `start_cooling`, and `stop_cooling`
+  now call the configured `RoasterDriver` boundary and mirror the returned
+  normalized control state into the authoritative session snapshot.
+- The mock driver `drop_beans` path now matches the normal operational
+  drop/cooling transition: heat off, fan `100%`, cooling on.
+- `drop_beans` remains the normal agent/operator path for drop plus cooling
+  transition. `start_cooling` remains an explicit advanced/manual recovery
+  control and is not the normal Claude roast flow.
+- Invalid drop, cooling-start, and cooling-stop phase calls were initially
+  guarded before driver commands.
+
+## Pull Request
+
+Opened `PR #109`: <https://github.com/syamaner/coffee-roaster-mcp/pull/109>
+
+PR branch:
+
+- `feature/104-wire-mcp-roast-control-tools-to-configured-driver`
+
+Earlier commit on the branch when this summary was first requested:
+
+- `e0c063f` - `feat: wire mcp controls to roaster driver`
+
+Latest pushed commit before the third review batch is fixed:
+
+- `3f17efb` - `feat: wire mcp controls to roaster driver`
+
+PR status before the latest unresolved review items were fixed:
+
+- state: open
+- draft: false
+- mergeable: true
+- GitHub Actions after commit `e0c063f`:
+  - `Build Package`: passed
+  - `Checks`: passed
+
+Issue `#104` remains open and should close when PR #109 is merged through
+`Closes #104`.
+
+## Validation
+
+Local validation before the latest unresolved review items:
+
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `245 passed`, required coverage `90.0%` reached, total coverage `91.24%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
+
+## Review Cycle So Far
+
+First Codex review on PR #109:
+
+- Review URL:
+  <https://github.com/syamaner/coffee-roaster-mcp/pull/109#pullrequestreview-4312218975>
+- Reviewed commit: `c43f05f`.
+- Two P1 comments were actionable:
+  - Duplicate `drop_beans` calls could resend the physical drop/cooling command.
+  - Drop phase validation could race a concurrent session mutation before the
+    driver command.
+- The fix moved duplicate-drop detection and drop phase validation into a
+  store-owned drop method. After pushing commit `e0c063f`, both review threads
+  became resolved and outdated on GitHub.
+
+Second Codex review on PR #109:
+
+- Review URL:
+  <https://github.com/syamaner/coffee-roaster-mcp/pull/109#pullrequestreview-4312498491>
+- Reviewed commit: `e0c063f`.
+- Three unresolved comments were inspected, judged relevant, and fixed:
+  - P1: `set_heat` and the other driver-backed controls still use a
+    check-then-act pattern where another tool could stop or fault the session
+    between `_require_active_session()` and the driver command.
+  - P1: `record_driver_drop_snapshot()` now runs `driver_drop()` while holding
+    the session-store lock, which can block emergency stop if hardware I/O hangs.
+  - P2: repeated `start_cooling` calls resend the driver command even though
+    the cooling event is already recorded.
+
+The review-fix direction was not to run all driver I/O under the session lock.
+Instead, the session store now owns non-emergency driver command reservations.
+Tools reserve the active session under the store lock, run hardware I/O outside
+the lock, then complete only if the same reservation is still active.
+
+Review fixes added:
+
+- `set_heat`, `set_fan`, `drop_beans`, `start_cooling`, and `stop_cooling` now
+  reserve non-emergency driver commands before calling the driver.
+- `drop_beans` duplicate retries return the existing `beans_dropped` event and
+  do not call the driver again.
+- `start_cooling` duplicate retries return the existing `cooling_started` event
+  and do not call the driver again.
+- `drop_beans` driver I/O no longer runs while holding the session-store lock,
+  so emergency stop can acquire the store lock while a drop command is blocked.
+- `emergency_stop` cancels pending non-emergency driver command reservations
+  before running the fail-closed driver safety call.
+- If a non-emergency driver command finishes after its reservation was canceled,
+  the code reapplies driver emergency stop and surfaces a lifecycle error
+  instead of updating the authoritative session state.
+
+Validation after these review fixes:
+
+- Ran `./.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_package.py::test_stdio_server_supports_basic_mock_roast_tool_flow tests/test_session.py`:
+  `47 passed`.
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `247 passed`, required coverage `90.0%` reached, total coverage `90.28%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
+
+After pushing these fixes, the three review threads from review `4312498491`
+became outdated on GitHub.
+
+Third Codex review on PR #109:
+
+- Review trigger/comment URL:
+  <https://github.com/syamaner/coffee-roaster-mcp/pull/109#issuecomment-4480605392>
+- Review URL:
+  <https://github.com/syamaner/coffee-roaster-mcp/pull/109#pullrequestreview-4312706674>
+- Reviewed commit: `3f17efb`.
+- Three fresh unresolved comments were inspected and judged relevant:
+  - P2: `start_roast_session` still has a check-then-act sequence
+    (`get_active_session()`, then driver `connect()`, then
+    `start_session_snapshot()`), so concurrent starts can both invoke
+    `connect()` before one fails to own the session.
+  - P2: `stop_cooling` passes pre-command `session.cooling_on` instead of
+    `driver_state.cooling_on` when completing the reserved command. This can
+    let MCP state claim cooling stopped even if the driver reports cooling still
+    active.
+  - P1: stale-command fail-closed handling currently calls global driver
+    emergency stop without scoping it to the same active session. If session A
+    is stopped/faulted, session B starts, and A's stale command completes, this
+    can interfere with B without recording a B fault.
+
+These latest three review items have not been fixed yet. They are the next
+work items before PR #109 should merge.
+
+## Handoff Notes
+
+Continue on branch
+`feature/104-wire-mcp-roast-control-tools-to-configured-driver`.
+
+Before making more code changes:
+
+1. Re-read the latest thread-aware review state for PR #109.
+2. Focus on the three unresolved review threads from review `4312706674`.
+3. Keep any follow-up scoped to E4.1-S1: configured-driver MCP control wiring and
+   safety/idempotency around those controls.
+4. Do not add automatic first-crack detector startup, released-artifact ONNX
+   detector runtime, auto-T0 detection, rolling telemetry metrics, final log
+   schemas, model training, ONNX export, Hugging Face sync, real microphone
+   validation, or broad release validation.
+5. If additional review comments appear, rerun the normal validation suite and
+   update PR #109 plus durable state if validation counts or behavior notes
+   change.

--- a/docs/session-summaries/2026-05-18-e4-1-s1-wire-mcp-roast-control-tools.md
+++ b/docs/session-summaries/2026-05-18-e4-1-s1-wire-mcp-roast-control-tools.md
@@ -161,8 +161,9 @@ Review fixes added:
 - `emergency_stop` cancels pending non-emergency driver command reservations
   before running the fail-closed driver safety call.
 - If a non-emergency driver command finishes after its reservation was canceled,
-  the code reapplies driver emergency stop and surfaces a lifecycle error
-  instead of updating the authoritative session state.
+  the code surfaces a lifecycle error instead of updating the authoritative
+  session state. It reapplies driver emergency stop only when no newer active
+  session has replaced the command's owning session.
 
 Validation after these review fixes:
 
@@ -198,18 +199,48 @@ Third Codex review on PR #109:
     is stopped/faulted, session B starts, and A's stale command completes, this
     can interfere with B without recording a B fault.
 
-These latest three review items have not been fixed yet. They are the next
-work items before PR #109 should merge.
+These latest three review items were fixed after the context snapshot above:
+
+- `start_roast_session` now reserves session startup in `RoastSessionStore`
+  before calling driver `connect()`. A concurrent start attempt fails before
+  invoking the configured driver, and failed `connect()` clears the reservation
+  without creating a session.
+- Reserved `stop_cooling` completion now uses `driver_state.cooling_on`. If the
+  driver still reports cooling active after `stop_cooling`, the session remains
+  active in `cooling` and does not record `cooling_stopped` or complete.
+- Stale non-emergency command fail-closed handling is now scoped to the
+  reservation's session id. If a newer session has already become active, the
+  stale command surfaces a lifecycle error without sending an untracked
+  emergency stop to the newer session's hardware boundary.
+
+Regression coverage added:
+
+- Concurrent session starts call driver `connect()` only once.
+- A driver that still reports cooling active after `stop_cooling` does not mark
+  the authoritative MCP session complete.
+- A stale command from a previous session does not emergency-stop a newer active
+  session.
+
+Focused validation after these latest fixes:
+
+- Ran `./.venv/bin/python -m pytest tests/test_mcp_server.py`: `11 passed`.
+- Ran `./.venv/bin/python -m pytest tests/test_session.py`: `38 passed`.
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `250 passed`, required coverage `90.0%` reached, total coverage `90.39%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
 
 ## Handoff Notes
 
 Continue on branch
 `feature/104-wire-mcp-roast-control-tools-to-configured-driver`.
 
-Before making more code changes:
+Before making more code changes or merging:
 
 1. Re-read the latest thread-aware review state for PR #109.
-2. Focus on the three unresolved review threads from review `4312706674`.
+2. Confirm the three review threads from review `4312706674` are outdated or
+   resolved after the latest push.
 3. Keep any follow-up scoped to E4.1-S1: configured-driver MCP control wiring and
    safety/idempotency around those controls.
 4. Do not add automatic first-crack detector startup, released-artifact ONNX

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -121,6 +121,13 @@ The first implementation milestone is a mock vertical slice that requires no roa
   driver safety call fails. `drop_beans` records both `beans_dropped` and
   `cooling_started` when the driver reports cooling active, which is the normal
   Hottop compound drop/cooling path and the mock-safe default path.
+- `E4.1-S1` review hardening reserves session startup before driver `connect()`
+  so concurrent starts cannot both reach the configured driver. Reserved
+  `stop_cooling` completion trusts the driver's returned cooling state and does
+  not mark the session complete if cooling remains active. Stale non-emergency
+  command fail-closed handling is scoped to the reservation's session id so a
+  previous session's late command cannot emergency-stop a newer active session
+  without that session owning the fault.
 - `mark_beans_added` and `mark_first_crack` remain exposed as explicit
   override tools. The primary runtime path should be internal auto-T0 detection
   when enabled and internal first-crack detector confirmation in audio mode.
@@ -1004,14 +1011,25 @@ After completing a story:
   - Repeated `drop_beans` and `start_cooling` calls return the existing
     singleton event without resending driver commands. Emergency stop cancels
     pending non-emergency reservations before running the fail-closed driver
-    safety call, and stale completed commands reapply driver emergency stop
-    before surfacing a lifecycle error.
+    safety call, and stale completed commands surface a lifecycle error instead
+    of mutating the session. Stale-command emergency stop is reapplied only when
+    no newer active session has replaced the command's owning session.
+  - Added review hardening for remaining race and state-reporting edges:
+    session startup is reserved before driver `connect()`, reserved
+    `stop_cooling` uses the driver's returned cooling state before completing
+    the session, and stale command fail-closed handling skips global emergency
+    stop when a newer active session has replaced the reservation's session.
+  - Added MCP regression coverage for concurrent start reservation,
+    cooling-stop driver-state mismatch, and stale previous-session command
+    completion after a newer session starts.
   - Kept automatic first-crack detector startup, ONNX detector runtime,
     auto-T0 detection, rolling telemetry metrics, final log schemas, model
     training, ONNX export, Hugging Face sync, real microphone validation, and
     broad release validation out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_mcp_server.py`: 11 passed.
+  - Ran `./.venv/bin/python -m pytest tests/test_session.py`: 38 passed.
   - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
-    247 passed, required coverage `90.0%` reached, total coverage `90.28%`.
+    250 passed, required coverage `90.0%` reached, total coverage `90.39%`.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4.1-S1`
-- Current target: Wire MCP roast-control tools to configured driver
+- Active story: `E4.1-S2`
+- Current target: Expose current roaster device state through MCP
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -104,15 +104,23 @@ The first implementation milestone is a mock vertical slice that requires no roa
   local branch-aware coverage at `91.73%`. Normal CI remains mock-safe with no
   microphone, Hottop hardware, model download, or network requirement.
 - Epic 4.1 is inserted before Epic 5 because the installed Claude-local MCP
-  operational path is not complete yet. Current MCP heat/fan/drop/cooling tools
-  are covered at the existing mock/session boundary, but they are not yet wired
-  to the configured live driver. Current first-crack components resolve
+  operational path is not complete yet. E4.1-S1 wires MCP heat/fan/drop/cooling
+  tools to the configured `RoasterDriver` boundary while preserving the default
+  mock path, one-session store semantics, fail-closed emergency behavior, and
+  no-live-hardware CI. Current first-crack components resolve
   artifacts, capture audio windows, adapt detector outputs, and write to the
   session timeline, but there is not yet a released-artifact ONNX runtime
   backend or session-owned detector loop. Epic 4.1 makes the operational MCP
   flow explicit: Claude should be able to start a roast, adjust the configured
   roaster, read current device/session state, and know whether first crack has
   happened before Epic 5 adds richer telemetry metrics and final log schemas.
+- `E4.1-S1` keeps driver commands outside the store lock while ensuring invalid
+  drop/cooling phase calls fail before the driver boundary is touched. Driver
+  command failures surface as MCP tool errors before session mutation, while
+  emergency stop continues to record a fail-closed fault event even if the
+  driver safety call fails. `drop_beans` records both `beans_dropped` and
+  `cooling_started` when the driver reports cooling active, which is the normal
+  Hottop compound drop/cooling path and the mock-safe default path.
 - `mark_beans_added` and `mark_first_crack` remain exposed as explicit
   override tools. The primary runtime path should be internal auto-T0 detection
   when enabled and internal first-crack detector confirmation in audio mode.
@@ -127,10 +135,9 @@ The first implementation milestone is a mock vertical slice that requires no roa
 
 ## Current Risks
 
-- Normal MCP heat, fan, drop, and cooling tools are not yet wired to live
-  Hottop driver commands; current Hottop hardware readiness applies to the
-  driver boundary validated by E3-S9, and Epic 4.1 now tracks the normal MCP
-  operational wiring.
+- Current MCP state output does not yet expose the full normalized device state
+  required for operator decisions; E4.1-S2 owns that schema and tool response
+  work.
 - The first-crack path does not yet include a released-artifact ONNX runtime
   backend or session-owned detector loop; Epic 4.1 now tracks this before Epic
   5 metrics/logging work.
@@ -321,7 +328,7 @@ first crack has happened through MCP tools.
 
 ### Stories
 
-- [ ] `E4.1-S1` Wire MCP roast-control tools to configured driver.
+- [x] `E4.1-S1` Wire MCP roast-control tools to configured driver.
   - Done when `start_roast_session`, `set_heat`, `set_fan`, `drop_beans`,
     `start_cooling`, `stop_cooling`, and `emergency_stop` call the configured
     `RoasterDriver` boundary where appropriate while preserving the mock
@@ -972,3 +979,39 @@ After completing a story:
     27 passed.
   - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
     241 passed, required coverage `90.0%` reached, total coverage `91.73%`.
+- Validation run for E4.1-S1:
+  - Wired `start_roast_session` to call the configured driver `connect()`
+    before creating a session, preserving the default mock path and requiring
+    explicit Hottop configuration for live hardware.
+  - Wired MCP `set_heat`, `set_fan`, `drop_beans`, `start_cooling`, and
+    `stop_cooling` to the configured `RoasterDriver` methods and mirrored the
+    returned normalized heat, fan, and cooling state into the authoritative
+    session snapshot.
+  - Updated the mock driver drop path to match the normal operational
+    drop/cooling transition: heat off, fan `100%`, cooling on.
+  - Kept `drop_beans` as the normal agent/operator path for drop plus cooling
+    transition; `start_cooling` remains available as an explicit advanced or
+    recovery command and is idempotent after drop-triggered cooling has already
+    been recorded.
+  - Added pre-driver phase guards so invalid drop, cooling-start, and
+    cooling-stop calls fail before any driver command is sent.
+  - Added driver-double MCP coverage proving configured-driver calls happen,
+    driver command failures do not mutate session state, and connect failures
+    do not create a roast session.
+  - PR review hardening added store-owned non-emergency driver command
+    reservations. Driver I/O now runs outside the store lock, but completion
+    must still own the active reservation before session state is updated.
+  - Repeated `drop_beans` and `start_cooling` calls return the existing
+    singleton event without resending driver commands. Emergency stop cancels
+    pending non-emergency reservations before running the fail-closed driver
+    safety call, and stale completed commands reapply driver emergency stop
+    before surfacing a lifecycle error.
+  - Kept automatic first-crack detector startup, ONNX detector runtime,
+    auto-T0 detection, rolling telemetry metrics, final log schemas, model
+    training, ONNX export, Hugging Face sync, real microphone validation, and
+    broad release validation out of scope.
+  - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+    247 passed, required coverage `90.0%` reached, total coverage `90.28%`.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -30,7 +30,7 @@ drop and emergency stop included. A follow-up 60-second stability test also held
 fan at `10%`, heat at `40%` for 30 seconds, then heat at `100%` for 30 seconds
 with continuous command streaming and no command-loop or status-read errors.
 
-Epic 4 is complete pending merge of E4-S10. The first-crack path now resolves the configured ONNX model
+Epic 4 is complete. The first-crack path now resolves the configured ONNX model
 artifact for both supported real-model precisions: `int8` selects
 `onnx/int8/model_quantized.onnx`, and `fp32` selects `onnx/fp32/model.onnx`
 through the artifact resolver. When `first_crack.local_model_dir` is configured,
@@ -78,18 +78,22 @@ continues to expose first-crack timestamp and metrics only until Epic 5 final
 schemas land. Coverage now has a stable `90%` package floor, with local
 branch-aware coverage at `91.73%`. Real microphone validation remains optional
 and gated; normal CI requires no audio hardware, model download, Hottop
-hardware, or network access. Normal MCP heat/fan/drop/cooling tools still use
-the existing one-session mock/session boundary rather than live Hottop command
-wiring, and automatic first-crack detector startup is not yet an MCP runtime
-loop.
+hardware, or network access. E4-S10 did not wire live Hottop command behavior
+or automatic first-crack detector startup into the MCP runtime; those gaps moved
+into Epic 4.1.
 
-Epic 4.1 is now inserted before Epic 5 to close operational MCP runtime gaps.
+Epic 4.1 is now active before Epic 5 to close operational MCP runtime gaps.
 The target user flow is: install the MCP server locally in Claude, start a
 roast, adjust the configured roaster through MCP tools, read current device and
 session state, and know whether first crack has happened. E4.1 covers
 driver-backed MCP control tools, current roaster state exposure, released ONNX
 detector backend construction, session-owned first-crack detector lifecycle, and
-operational MCP readiness tests/docs. `mark_beans_added` and
+operational MCP readiness tests/docs. E4.1-S1 wires `start_roast_session`,
+`set_heat`, `set_fan`, `drop_beans`, `start_cooling`, and `stop_cooling` to the
+configured `RoasterDriver` boundary while preserving the default mock path and
+one-session store semantics. `drop_beans` is now the normal MCP path for drop
+and cooling transition, and invalid phase calls are rejected before driver
+commands are sent. `mark_beans_added` and
 `mark_first_crack` remain explicit override tools, while automatic T0 and
 first-crack detection are internal runtime paths. `drop_beans` is the normal
 agent/operator command for drop and cooling transition; `start_cooling` is an
@@ -97,7 +101,7 @@ advanced recovery/manual control rather than the normal roast flow. Epic 5
 remains focused on telemetry buffering, derived metrics, and final log/export
 schemas.
 
-The next story after E4-S10 merges is E4.1-S1: wire MCP roast-control tools to the configured driver.
+The next story is E4.1-S2: expose current roaster device state through MCP.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -614,9 +614,11 @@ class MockRoasterDriver:
         return self._state_snapshot()
 
     def drop_beans(self) -> RoasterState:
-        """Record a mock bean drop and force heat off."""
+        """Record a mock bean drop and enter cooling."""
         self._beans_dropped = True
         self._heat_level_percent = 0
+        self._fan_level_percent = 100
+        self._cooling_on = True
         return self._state_snapshot()
 
     def start_cooling(self) -> RoasterState:

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -15,9 +15,10 @@ from mcp.server.session import ServerSession
 
 from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.config import AppConfig, ConfigError, load_config
-from coffee_roaster_mcp.drivers import RoasterDriver, create_roaster_driver
+from coffee_roaster_mcp.drivers import RoasterDriver, RoasterState, create_roaster_driver
 from coffee_roaster_mcp.exports import export_roast_snapshot
 from coffee_roaster_mcp.session import (
+    DriverCommandReservation,
     EventPayloadValue,
     RoastEvent,
     RoastPhase,
@@ -249,7 +250,7 @@ def create_mcp_server(
         instructions=(
             "RoastPilot MCP server with a mock-safe session runtime. "
             "This tool surface supports one in-process roast session and "
-            "basic mock-path controls before hardware drivers and log writers land."
+            "driver-backed roast controls before log writers land."
         ),
         lifespan=server_lifespan,
     )
@@ -315,8 +316,11 @@ def create_mcp_server(
     def start_roast_session(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
         ctx: Context[ServerSession, ServerContext],
     ) -> StartRoastSessionResult:
-        """Start one new authoritative roast session."""
+        """Start one new authoritative roast session and prepare the driver."""
         server_context = ctx.request_context.lifespan_context
+        if server_context.session_store.get_active_session() is not None:
+            raise ValueError("An active roast session already exists.")
+        server_context.roaster_driver.connect()
         session = server_context.session_store.start_session_snapshot()
         return StartRoastSessionResult(session=_serialize_session_state(session))
 
@@ -335,12 +339,15 @@ def create_mcp_server(
         ctx: Context[ServerSession, ServerContext],
         heat_level_percent: int,
     ) -> ControlCommandResult:
-        """Set in-memory heat for the active mock session."""
+        """Set heat through the configured driver boundary."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        snapshot = server_context.session_store.set_heat_snapshot(
+        snapshot = _run_reserved_driver_control(
+            server_context,
             session,
-            heat_level_percent=heat_level_percent,
+            driver_command=lambda: server_context.roaster_driver.set_heat(
+                heat_level_percent=heat_level_percent,
+            ),
         )
         return _serialize_control_result(snapshot)
 
@@ -349,12 +356,15 @@ def create_mcp_server(
         ctx: Context[ServerSession, ServerContext],
         fan_level_percent: int,
     ) -> ControlCommandResult:
-        """Set in-memory fan for the active mock session."""
+        """Set fan through the configured driver boundary."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        snapshot = server_context.session_store.set_fan_snapshot(
+        snapshot = _run_reserved_driver_control(
+            server_context,
             session,
-            fan_level_percent=fan_level_percent,
+            driver_command=lambda: server_context.roaster_driver.set_fan(
+                fan_level_percent=fan_level_percent,
+            ),
         )
         return _serialize_control_result(snapshot)
 
@@ -379,32 +389,30 @@ def create_mcp_server(
     def drop_beans(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
         ctx: Context[ServerSession, ServerContext],
     ) -> EventCommandResult:
-        """Record bean drop and let the event timeline force heat off."""
+        """Drop beans through the driver and record the cooling transition."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        event, snapshot = server_context.session_store.record_event_snapshot(
-            session, "beans_dropped"
-        )
+        event, snapshot = _run_reserved_driver_drop(server_context, session)
         return _serialize_event_result(snapshot=snapshot, event=event)
 
     @mcp.tool()
     def start_cooling(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
         ctx: Context[ServerSession, ServerContext],
     ) -> EventCommandResult:
-        """Start cooling in the mock session state and record the event."""
+        """Start cooling through the driver as an explicit recovery command."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        event, snapshot = server_context.session_store.start_cooling_snapshot(session)
+        event, snapshot = _run_reserved_driver_start_cooling(server_context, session)
         return _serialize_event_result(snapshot=snapshot, event=event)
 
     @mcp.tool()
     def stop_cooling(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
         ctx: Context[ServerSession, ServerContext],
     ) -> EventCommandResult:
-        """Stop cooling in the mock session state and record the event."""
+        """Stop cooling through the configured driver boundary."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
-        event, snapshot = server_context.session_store.stop_cooling_snapshot(session)
+        event, snapshot = _run_reserved_driver_stop_cooling(server_context, session)
         return _serialize_event_result(snapshot=snapshot, event=event)
 
     @mcp.tool()
@@ -434,6 +442,7 @@ def create_mcp_server(
         """Call the configured driver safety method and record a fault event."""
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
+        server_context.session_store.cancel_pending_driver_command(session)
         safety_payload = run_driver_emergency_stop(server_context, reason=reason)
         event, snapshot = server_context.session_store.emergency_stop_snapshot(
             session,
@@ -493,6 +502,146 @@ def _record_session_event(
     session = _require_active_session(server_context)
     event, snapshot = server_context.session_store.record_event_snapshot(session, kind)
     return _serialize_event_result(snapshot=snapshot, event=event)
+
+
+def _run_reserved_driver_control(
+    server_context: ServerContext,
+    session: RoastSession,
+    *,
+    driver_command: Callable[[], RoasterState],
+) -> RoastSession:
+    """Run one reserved driver control command outside the store lock."""
+    reservation = server_context.session_store.reserve_driver_command(
+        session,
+        kind="control",
+    )
+    try:
+        driver_state = driver_command()
+        try:
+            return _complete_driver_control(
+                server_context,
+                session,
+                reservation=reservation,
+                driver_state=driver_state,
+            )
+        except SessionLifecycleError:
+            _fail_closed_after_stale_driver_command(server_context)
+            raise
+    except Exception:
+        server_context.session_store.clear_driver_command_reservation(session, reservation)
+        raise
+
+
+def _run_reserved_driver_drop(
+    server_context: ServerContext,
+    session: RoastSession,
+) -> tuple[RoastEvent, RoastSession]:
+    """Run a reserved drop command, preserving idempotent retry behavior."""
+    drop_reservation = server_context.session_store.reserve_driver_drop(session)
+    if drop_reservation.reservation is None:
+        if drop_reservation.existing_event is None or drop_reservation.snapshot is None:
+            raise ValueError("Drop reservation did not include the existing event snapshot.")
+        return drop_reservation.existing_event, drop_reservation.snapshot
+
+    reservation = drop_reservation.reservation
+    try:
+        driver_state = server_context.roaster_driver.drop_beans()
+        try:
+            return server_context.session_store.complete_reserved_driver_drop_snapshot(
+                session,
+                reservation=reservation,
+                heat_level_percent=driver_state.heat_level_percent,
+                fan_level_percent=driver_state.fan_level_percent,
+                cooling_on=driver_state.cooling_on,
+            )
+        except SessionLifecycleError:
+            _fail_closed_after_stale_driver_command(server_context)
+            raise
+    except Exception:
+        server_context.session_store.clear_driver_command_reservation(session, reservation)
+        raise
+
+
+def _run_reserved_driver_start_cooling(
+    server_context: ServerContext,
+    session: RoastSession,
+) -> tuple[RoastEvent, RoastSession]:
+    """Run a reserved cooling-start command or return the existing event."""
+    event_reservation = server_context.session_store.reserve_driver_start_cooling(session)
+    if event_reservation.reservation is None:
+        if event_reservation.existing_event is None or event_reservation.snapshot is None:
+            raise ValueError(
+                "Cooling-start reservation did not include the existing event snapshot."
+            )
+        return event_reservation.existing_event, event_reservation.snapshot
+
+    reservation = event_reservation.reservation
+    try:
+        driver_state = server_context.roaster_driver.start_cooling()
+        try:
+            return server_context.session_store.complete_reserved_driver_start_cooling_snapshot(
+                session,
+                reservation=reservation,
+                heat_level_percent=driver_state.heat_level_percent,
+                fan_level_percent=driver_state.fan_level_percent,
+                cooling_on=driver_state.cooling_on,
+            )
+        except SessionLifecycleError:
+            _fail_closed_after_stale_driver_command(server_context)
+            raise
+    except Exception:
+        server_context.session_store.clear_driver_command_reservation(session, reservation)
+        raise
+
+
+def _run_reserved_driver_stop_cooling(
+    server_context: ServerContext,
+    session: RoastSession,
+) -> tuple[RoastEvent, RoastSession]:
+    """Run a reserved cooling-stop command."""
+    reservation = server_context.session_store.reserve_driver_stop_cooling(session)
+    try:
+        driver_state = server_context.roaster_driver.stop_cooling()
+        try:
+            return server_context.session_store.complete_reserved_driver_stop_cooling_snapshot(
+                session,
+                reservation=reservation,
+                heat_level_percent=driver_state.heat_level_percent,
+                fan_level_percent=driver_state.fan_level_percent,
+                cooling_on=session.cooling_on,
+            )
+        except SessionLifecycleError:
+            _fail_closed_after_stale_driver_command(server_context)
+            raise
+    except Exception:
+        server_context.session_store.clear_driver_command_reservation(session, reservation)
+        raise
+
+
+def _complete_driver_control(
+    server_context: ServerContext,
+    session: RoastSession,
+    *,
+    reservation: DriverCommandReservation,
+    driver_state: RoasterState,
+    cooling_on: bool | None = None,
+) -> RoastSession:
+    """Apply one reserved driver control result to the session."""
+    return server_context.session_store.complete_reserved_driver_control_snapshot(
+        session,
+        reservation=reservation,
+        heat_level_percent=driver_state.heat_level_percent,
+        fan_level_percent=driver_state.fan_level_percent,
+        cooling_on=driver_state.cooling_on if cooling_on is None else cooling_on,
+    )
+
+
+def _fail_closed_after_stale_driver_command(server_context: ServerContext) -> None:
+    """Reapply driver safety when a completed command no longer owns the session."""
+    run_driver_emergency_stop(
+        server_context,
+        reason="stale driver command after session state changed",
+    )
 
 
 def run_driver_emergency_stop(

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -318,10 +318,13 @@ def create_mcp_server(
     ) -> StartRoastSessionResult:
         """Start one new authoritative roast session and prepare the driver."""
         server_context = ctx.request_context.lifespan_context
-        if server_context.session_store.get_active_session() is not None:
-            raise ValueError("An active roast session already exists.")
-        server_context.roaster_driver.connect()
-        session = server_context.session_store.start_session_snapshot()
+        reservation = server_context.session_store.reserve_session_start()
+        try:
+            server_context.roaster_driver.connect()
+            session = server_context.session_store.complete_session_start_snapshot(reservation)
+        except Exception:
+            server_context.session_store.clear_session_start_reservation(reservation)
+            raise
         return StartRoastSessionResult(session=_serialize_session_state(session))
 
     @mcp.tool()
@@ -525,7 +528,7 @@ def _run_reserved_driver_control(
                 driver_state=driver_state,
             )
         except SessionLifecycleError:
-            _fail_closed_after_stale_driver_command(server_context)
+            _fail_closed_after_stale_driver_command(server_context, reservation=reservation)
             raise
     except Exception:
         server_context.session_store.clear_driver_command_reservation(session, reservation)
@@ -555,7 +558,7 @@ def _run_reserved_driver_drop(
                 cooling_on=driver_state.cooling_on,
             )
         except SessionLifecycleError:
-            _fail_closed_after_stale_driver_command(server_context)
+            _fail_closed_after_stale_driver_command(server_context, reservation=reservation)
             raise
     except Exception:
         server_context.session_store.clear_driver_command_reservation(session, reservation)
@@ -587,7 +590,7 @@ def _run_reserved_driver_start_cooling(
                 cooling_on=driver_state.cooling_on,
             )
         except SessionLifecycleError:
-            _fail_closed_after_stale_driver_command(server_context)
+            _fail_closed_after_stale_driver_command(server_context, reservation=reservation)
             raise
     except Exception:
         server_context.session_store.clear_driver_command_reservation(session, reservation)
@@ -608,10 +611,10 @@ def _run_reserved_driver_stop_cooling(
                 reservation=reservation,
                 heat_level_percent=driver_state.heat_level_percent,
                 fan_level_percent=driver_state.fan_level_percent,
-                cooling_on=session.cooling_on,
+                cooling_on=driver_state.cooling_on,
             )
         except SessionLifecycleError:
-            _fail_closed_after_stale_driver_command(server_context)
+            _fail_closed_after_stale_driver_command(server_context, reservation=reservation)
             raise
     except Exception:
         server_context.session_store.clear_driver_command_reservation(session, reservation)
@@ -636,8 +639,15 @@ def _complete_driver_control(
     )
 
 
-def _fail_closed_after_stale_driver_command(server_context: ServerContext) -> None:
+def _fail_closed_after_stale_driver_command(
+    server_context: ServerContext,
+    *,
+    reservation: DriverCommandReservation,
+) -> None:
     """Reapply driver safety when a completed command no longer owns the session."""
+    active_session = server_context.session_store.get_active_session()
+    if active_session is not None and active_session.id != reservation.session_id:
+        return
     run_driver_emergency_stop(
         server_context,
         reason="stale driver command after session state changed",

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -34,6 +34,7 @@ RoastEventKind = Literal[
     "fault",
 ]
 EventPayloadValue = str | int | float | bool | None
+DriverCommandKind = Literal["control", "drop", "start_cooling", "stop_cooling"]
 
 _SINGLETON_EVENT_KINDS: frozenset[RoastEventKind] = frozenset(
     {
@@ -158,6 +159,45 @@ class TelemetrySample:
 
 
 @dataclass(frozen=True)
+class DriverCommandReservation:
+    """Reservation for one non-emergency driver command.
+
+    Attributes:
+        session_id: Session that owns the reservation.
+        token: Opaque reservation token.
+        kind: Reserved command kind.
+    """
+
+    session_id: str
+    token: str
+    kind: DriverCommandKind
+
+
+@dataclass(frozen=True)
+class DriverDropReservation:
+    """Result of reserving the driver drop command.
+
+    Attributes:
+        reservation: Reservation to complete when a new drop command is needed.
+        existing_event: Existing singleton drop event for idempotent retries.
+        snapshot: Session snapshot returned for idempotent retries.
+    """
+
+    reservation: DriverCommandReservation | None
+    existing_event: RoastEvent | None = None
+    snapshot: RoastSession | None = None
+
+
+@dataclass(frozen=True)
+class DriverEventReservation:
+    """Result of reserving a driver command that records a singleton event."""
+
+    reservation: DriverCommandReservation | None
+    existing_event: RoastEvent | None = None
+    snapshot: RoastSession | None = None
+
+
+@dataclass(frozen=True)
 class RoastMetrics:
     """Timestamp-derived roast metrics for the current session snapshot.
 
@@ -231,6 +271,8 @@ class RoastSession:
     log_writer: LogWriterReference | None = None
     stopped_at_utc: datetime | None = None
     monotonic_stop: float | None = None
+    pending_driver_command_token: str | None = None
+    pending_driver_command_kind: DriverCommandKind | None = None
 
     @property
     def active(self) -> bool:
@@ -498,6 +540,221 @@ class RoastSessionStore:
         with self._lock:
             self.set_fan(session, fan_level_percent=fan_level_percent)
             return _copy_session_for_read(session)
+
+    def apply_driver_control_state(
+        self,
+        session: RoastSession,
+        *,
+        heat_level_percent: int,
+        fan_level_percent: int,
+        cooling_on: bool,
+    ) -> RoastSession:
+        """Apply the normalized control state returned by the configured driver."""
+        with self._lock:
+            self._assert_latest_active_session(session)
+            validated_heat = validate_control_percent(
+                heat_level_percent,
+                label="heat_level_percent",
+            )
+            if session.faulted_at_utc is not None and validated_heat > 0:
+                raise SessionLifecycleError("Heat cannot be increased after a fault.")
+            session.heat_level_percent = validated_heat
+            session.fan_level_percent = validate_control_percent(
+                fan_level_percent,
+                label="fan_level_percent",
+            )
+            session.cooling_on = cooling_on
+            return session
+
+    def apply_driver_control_state_snapshot(
+        self,
+        session: RoastSession,
+        *,
+        heat_level_percent: int,
+        fan_level_percent: int,
+        cooling_on: bool,
+    ) -> RoastSession:
+        """Apply driver controls and return an atomic lightweight snapshot."""
+        with self._lock:
+            self.apply_driver_control_state(
+                session,
+                heat_level_percent=heat_level_percent,
+                fan_level_percent=fan_level_percent,
+                cooling_on=cooling_on,
+            )
+            return _copy_session_for_read(session)
+
+    def reserve_driver_command(
+        self,
+        session: RoastSession,
+        *,
+        kind: DriverCommandKind,
+    ) -> DriverCommandReservation:
+        """Reserve one non-emergency driver command for an active session."""
+        with self._lock:
+            self._assert_latest_active_session(session)
+            return self._reserve_driver_command_locked(session, kind=kind)
+
+    def reserve_driver_drop(self, session: RoastSession) -> DriverDropReservation:
+        """Reserve a driver drop command or return the existing drop event."""
+        with self._lock:
+            self._assert_latest_active_session(session)
+            existing_event = self._get_existing_singleton_event(session, "beans_dropped")
+            if existing_event is not None:
+                return DriverDropReservation(
+                    reservation=None,
+                    existing_event=existing_event,
+                    snapshot=_copy_session_for_read(session),
+                )
+            _validate_event_transition(session, "beans_dropped")
+            return DriverDropReservation(
+                reservation=self._reserve_driver_command_locked(session, kind="drop")
+            )
+
+    def reserve_driver_start_cooling(self, session: RoastSession) -> DriverEventReservation:
+        """Reserve a cooling-start command or return the existing event."""
+        with self._lock:
+            self._assert_latest_active_session(session)
+            existing_event = self._get_existing_singleton_event(session, "cooling_started")
+            if existing_event is not None:
+                return DriverEventReservation(
+                    reservation=None,
+                    existing_event=existing_event,
+                    snapshot=_copy_session_for_read(session),
+                )
+            if session.beans_dropped_at_utc is None:
+                raise SessionLifecycleError("Cooling can only start after beans are dropped.")
+            _validate_event_transition(session, "cooling_started")
+            return DriverEventReservation(
+                reservation=self._reserve_driver_command_locked(session, kind="start_cooling")
+            )
+
+    def reserve_driver_stop_cooling(self, session: RoastSession) -> DriverCommandReservation:
+        """Reserve a cooling-stop command for an active cooling session."""
+        with self._lock:
+            self._assert_latest_active_session(session)
+            if session.beans_dropped_at_utc is None:
+                raise SessionLifecycleError("Cooling cannot stop before beans are dropped.")
+            if session.cooling_started_at_utc is None or not session.cooling_on:
+                raise SessionLifecycleError("Cooling must be started before it can be stopped.")
+            return self._reserve_driver_command_locked(session, kind="stop_cooling")
+
+    def complete_reserved_driver_control_snapshot(
+        self,
+        session: RoastSession,
+        *,
+        reservation: DriverCommandReservation,
+        heat_level_percent: int,
+        fan_level_percent: int,
+        cooling_on: bool,
+    ) -> RoastSession:
+        """Complete a reserved control command and return a session snapshot."""
+        with self._lock:
+            self._assert_driver_command_reservation(session, reservation)
+            self.apply_driver_control_state(
+                session,
+                heat_level_percent=heat_level_percent,
+                fan_level_percent=fan_level_percent,
+                cooling_on=cooling_on,
+            )
+            self._clear_driver_command_reservation_locked(session, reservation)
+            return _copy_session_for_read(session)
+
+    def complete_reserved_driver_drop_snapshot(
+        self,
+        session: RoastSession,
+        *,
+        reservation: DriverCommandReservation,
+        heat_level_percent: int,
+        fan_level_percent: int,
+        cooling_on: bool,
+    ) -> tuple[RoastEvent, RoastSession]:
+        """Complete a reserved drop command and record resulting events.
+
+        Args:
+            session: Session to mutate.
+            reservation: Active drop command reservation.
+            heat_level_percent: Driver heat level after the drop command.
+            fan_level_percent: Driver fan level after the drop command.
+            cooling_on: Driver cooling state after the drop command.
+
+        Returns:
+            The bean-drop event plus an atomic lightweight session snapshot.
+        """
+        with self._lock:
+            self._assert_driver_command_reservation(session, reservation)
+            self.apply_driver_control_state(
+                session,
+                heat_level_percent=heat_level_percent,
+                fan_level_percent=fan_level_percent,
+                cooling_on=cooling_on,
+            )
+            event = self.record_event(session, "beans_dropped")
+            if cooling_on:
+                self.record_event(session, "cooling_started")
+            self._clear_driver_command_reservation_locked(session, reservation)
+            return event, _copy_session_for_read(session)
+
+    def complete_reserved_driver_start_cooling_snapshot(
+        self,
+        session: RoastSession,
+        *,
+        reservation: DriverCommandReservation,
+        heat_level_percent: int,
+        fan_level_percent: int,
+        cooling_on: bool,
+    ) -> tuple[RoastEvent, RoastSession]:
+        """Complete a reserved cooling-start command and record the event."""
+        with self._lock:
+            self._assert_driver_command_reservation(session, reservation)
+            self.apply_driver_control_state(
+                session,
+                heat_level_percent=heat_level_percent,
+                fan_level_percent=fan_level_percent,
+                cooling_on=cooling_on,
+            )
+            event = self.record_event(session, "cooling_started")
+            self._clear_driver_command_reservation_locked(session, reservation)
+            return event, _copy_session_for_read(session)
+
+    def complete_reserved_driver_stop_cooling_snapshot(
+        self,
+        session: RoastSession,
+        *,
+        reservation: DriverCommandReservation,
+        heat_level_percent: int,
+        fan_level_percent: int,
+        cooling_on: bool,
+    ) -> tuple[RoastEvent, RoastSession]:
+        """Complete a reserved cooling-stop command and record the event."""
+        with self._lock:
+            self._assert_driver_command_reservation(session, reservation)
+            self.apply_driver_control_state(
+                session,
+                heat_level_percent=heat_level_percent,
+                fan_level_percent=fan_level_percent,
+                cooling_on=cooling_on,
+            )
+            event = self.stop_cooling(session)
+            self._clear_driver_command_reservation_locked(session, reservation)
+            return event, _copy_session_for_read(session)
+
+    def clear_driver_command_reservation(
+        self,
+        session: RoastSession,
+        reservation: DriverCommandReservation,
+    ) -> None:
+        """Clear a pending driver command reservation if it is still current."""
+        with self._lock:
+            if session.pending_driver_command_token == reservation.token:
+                self._clear_driver_command_reservation_locked(session, reservation)
+
+    def cancel_pending_driver_command(self, session: RoastSession) -> None:
+        """Cancel any pending non-emergency driver command for one session."""
+        with self._lock:
+            self._assert_latest_session(session)
+            session.pending_driver_command_token = None
+            session.pending_driver_command_kind = None
 
     def start_cooling(self, session: RoastSession) -> RoastEvent:
         """Start cooling for one active session."""
@@ -771,6 +1028,50 @@ class RoastSessionStore:
                 return event
         return None
 
+    def _reserve_driver_command_locked(
+        self,
+        session: RoastSession,
+        *,
+        kind: DriverCommandKind,
+    ) -> DriverCommandReservation:
+        """Reserve a driver command while the store lock is already held."""
+        if session.pending_driver_command_token is not None:
+            raise SessionLifecycleError("Another driver command is already in progress.")
+        reservation = DriverCommandReservation(
+            session_id=session.id,
+            token=_generate_session_id(),
+            kind=kind,
+        )
+        session.pending_driver_command_token = reservation.token
+        session.pending_driver_command_kind = reservation.kind
+        return reservation
+
+    def _assert_driver_command_reservation(
+        self,
+        session: RoastSession,
+        reservation: DriverCommandReservation,
+    ) -> None:
+        """Validate a reservation before applying one driver command result."""
+        self._assert_latest_active_session(session)
+        if reservation.session_id != session.id:
+            raise SessionLifecycleError("Driver command reservation belongs to another session.")
+        if (
+            session.pending_driver_command_token != reservation.token
+            or session.pending_driver_command_kind != reservation.kind
+        ):
+            raise SessionLifecycleError("Driver command reservation is no longer active.")
+
+    def _clear_driver_command_reservation_locked(
+        self,
+        session: RoastSession,
+        reservation: DriverCommandReservation,
+    ) -> None:
+        """Clear a driver command reservation while the store lock is held."""
+        if session.pending_driver_command_token != reservation.token:
+            return
+        session.pending_driver_command_token = None
+        session.pending_driver_command_kind = None
+
     def _prune_session_history_locked(self) -> None:
         """Evict oldest completed sessions once retained history exceeds the limit."""
         while len(self._session_id_order) > self._session_history_limit:
@@ -1016,4 +1317,6 @@ def _copy_session_for_read(session: RoastSession) -> RoastSession:
         log_writer=session.log_writer,
         stopped_at_utc=session.stopped_at_utc,
         monotonic_stop=session.monotonic_stop,
+        pending_driver_command_token=session.pending_driver_command_token,
+        pending_driver_command_kind=session.pending_driver_command_kind,
     )

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -159,6 +159,13 @@ class TelemetrySample:
 
 
 @dataclass(frozen=True)
+class SessionStartReservation:
+    """Reservation for preparing a driver before creating a session."""
+
+    token: str
+
+
+@dataclass(frozen=True)
 class DriverCommandReservation:
     """Reservation for one non-emergency driver command.
 
@@ -409,6 +416,7 @@ class RoastSessionStore:
         self._latest_session: RoastSession | None = None
         self._sessions_by_id: dict[str, RoastSession] = {}
         self._session_id_order: deque[str] = deque()
+        self._pending_session_start_token: str | None = None
 
     def start_session(self) -> RoastSession:
         """Start one new active session.
@@ -420,30 +428,48 @@ class RoastSessionStore:
             SessionLifecycleError: If an active session already exists.
         """
         with self._lock:
-            if self._latest_session is not None and self._latest_session.active:
-                raise SessionLifecycleError("An active roast session already exists.")
-
-            session_id = self._session_id_factory()
-            session = RoastSession(
-                id=session_id,
-                created_at_utc=self._utc_now(),
-                monotonic_start=self._monotonic_now(),
-                log_writer=LogWriterReference(
-                    session_id=session_id,
-                    log_dir=self._default_log_dir / session_id,
-                ),
-            )
-            self._latest_session = session
-            self._sessions_by_id[session_id] = session
-            self._session_id_order.append(session_id)
-            self._prune_session_history_locked()
-            return session
+            if self._pending_session_start_token is not None:
+                raise SessionLifecycleError("A roast session start is already in progress.")
+            return self._start_session_locked()
 
     def start_session_snapshot(self) -> RoastSession:
         """Start one new session and return an atomic lightweight snapshot."""
         with self._lock:
             session = self.start_session()
             return _copy_session_for_read(session)
+
+    def reserve_session_start(self) -> SessionStartReservation:
+        """Reserve session startup before preparing the configured driver."""
+        with self._lock:
+            if self._latest_session is not None and self._latest_session.active:
+                raise SessionLifecycleError("An active roast session already exists.")
+            if self._pending_session_start_token is not None:
+                raise SessionLifecycleError("A roast session start is already in progress.")
+            reservation = SessionStartReservation(token=_generate_session_id())
+            self._pending_session_start_token = reservation.token
+            return reservation
+
+    def complete_session_start_snapshot(
+        self,
+        reservation: SessionStartReservation,
+    ) -> RoastSession:
+        """Create the reserved session and return an atomic lightweight snapshot."""
+        with self._lock:
+            self._assert_session_start_reservation(reservation)
+            try:
+                session = self._start_session_locked()
+            finally:
+                self._pending_session_start_token = None
+            return _copy_session_for_read(session)
+
+    def clear_session_start_reservation(
+        self,
+        reservation: SessionStartReservation,
+    ) -> None:
+        """Clear a pending session-start reservation if it is still current."""
+        with self._lock:
+            if self._pending_session_start_token == reservation.token:
+                self._pending_session_start_token = None
 
     def stop_session(self, *, phase: RoastPhase = "complete") -> RoastSession | None:
         """Stop the active session if one exists.
@@ -729,13 +755,27 @@ class RoastSessionStore:
         """Complete a reserved cooling-stop command and record the event."""
         with self._lock:
             self._assert_driver_command_reservation(session, reservation)
-            self.apply_driver_control_state(
-                session,
-                heat_level_percent=heat_level_percent,
-                fan_level_percent=fan_level_percent,
-                cooling_on=cooling_on,
+            if cooling_on:
+                raise SessionLifecycleError(
+                    "Driver still reports cooling active after stop_cooling."
+                )
+            validated_heat = validate_control_percent(
+                heat_level_percent,
+                label="heat_level_percent",
             )
-            event = self.stop_cooling(session)
+            validated_fan = validate_control_percent(
+                fan_level_percent,
+                label="fan_level_percent",
+            )
+            event = self.record_event(session, "cooling_stopped")
+            session.heat_level_percent = validated_heat
+            session.fan_level_percent = validated_fan
+            session.cooling_on = False
+            session.stop(
+                utc_now=self._utc_now,
+                monotonic_now=self._monotonic_now,
+                phase="complete",
+            )
             self._clear_driver_command_reservation_locked(session, reservation)
             return event, _copy_session_for_read(session)
 
@@ -1014,6 +1054,35 @@ class RoastSessionStore:
         """Validate that one session is the latest known session."""
         if self._latest_session is not session:
             raise SessionLifecycleError("Only the latest session can be mutated.")
+
+    def _start_session_locked(self) -> RoastSession:
+        """Start one new active session while the store lock is already held."""
+        if self._latest_session is not None and self._latest_session.active:
+            raise SessionLifecycleError("An active roast session already exists.")
+
+        session_id = self._session_id_factory()
+        session = RoastSession(
+            id=session_id,
+            created_at_utc=self._utc_now(),
+            monotonic_start=self._monotonic_now(),
+            log_writer=LogWriterReference(
+                session_id=session_id,
+                log_dir=self._default_log_dir / session_id,
+            ),
+        )
+        self._latest_session = session
+        self._sessions_by_id[session_id] = session
+        self._session_id_order.append(session_id)
+        self._prune_session_history_locked()
+        return session
+
+    def _assert_session_start_reservation(
+        self,
+        reservation: SessionStartReservation,
+    ) -> None:
+        """Validate a session-start reservation before creating the session."""
+        if self._pending_session_start_token != reservation.token:
+            raise SessionLifecycleError("Session start reservation is no longer active.")
 
     def _get_existing_singleton_event(
         self,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from threading import Event, Thread
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from mcp.server.fastmcp import FastMCP
 
+from coffee_roaster_mcp.drivers import EmergencyStopResult, MockRoasterDriver, RoasterState
 from coffee_roaster_mcp.mcp_server import ServerContext, build_server_context, create_mcp_server
+from coffee_roaster_mcp.session import SessionLifecycleError
 
 
 def test_in_process_mcp_tools_cover_mock_roast_and_export(tmp_path: Path) -> None:
@@ -45,7 +48,7 @@ def test_in_process_mcp_tools_cover_mock_roast_and_export(tmp_path: Path) -> Non
     complete = _call_tool(server, "stop_cooling", ctx)
     assert beans_added.event.kind == "beans_added"
     assert first_crack.event.kind == "first_crack_detected"
-    assert drop.phase == "dropped"
+    assert drop.phase == "cooling"
     assert cooling.phase == "cooling"
     assert complete.phase == "complete"
 
@@ -114,9 +117,303 @@ def test_in_process_mcp_tools_surface_errors_and_audio_bootstrap_state(tmp_path:
         _call_tool(server, "get_roast_state", ctx, session_id="missing-session")
 
 
+def test_mcp_roast_controls_call_configured_driver_boundary(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver()
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    _call_tool(server, "start_roast_session", ctx)
+    heat = _call_tool(server, "set_heat", ctx, heat_level_percent=65)
+    fan = _call_tool(server, "set_fan", ctx, fan_level_percent=45)
+    _call_tool(server, "mark_beans_added", ctx)
+    drop = _call_tool(server, "drop_beans", ctx)
+    repeated_drop = _call_tool(server, "drop_beans", ctx)
+    cooling = _call_tool(server, "start_cooling", ctx)
+    complete = _call_tool(server, "stop_cooling", ctx)
+
+    assert driver.actions == [
+        "connect",
+        "set_heat:65",
+        "set_fan:45",
+        "drop_beans",
+        "stop_cooling",
+    ]
+    assert heat.heat_level_percent == 65
+    assert fan.fan_level_percent == 45
+    assert drop.event.kind == "beans_dropped"
+    assert drop.phase == "cooling"
+    assert repeated_drop.event.kind == "beans_dropped"
+    assert repeated_drop.phase == "cooling"
+    assert cooling.event.kind == "cooling_started"
+    assert complete.phase == "complete"
+
+
+def test_driver_command_failure_does_not_mutate_session_state(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(fail_heat=True)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    with pytest.raises(RuntimeError, match="heat command failed"):
+        _call_tool(server, "set_heat", ctx, heat_level_percent=65)
+
+    state = _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+    assert driver.actions == ["connect", "set_heat:65"]
+    assert state.heat_level_percent == 0
+    assert state.fan_level_percent == 0
+    assert state.cooling_on is False
+    assert state.events == ()
+
+
+def test_invalid_event_phase_blocks_driver_command(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver()
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    _call_tool(server, "start_roast_session", ctx)
+    with pytest.raises(SessionLifecycleError, match="roasting, development"):
+        _call_tool(server, "drop_beans", ctx)
+    with pytest.raises(
+        SessionLifecycleError, match="Cooling can only start after beans are dropped"
+    ):
+        _call_tool(server, "start_cooling", ctx)
+    with pytest.raises(SessionLifecycleError, match="Cooling cannot stop before beans are dropped"):
+        _call_tool(server, "stop_cooling", ctx)
+
+    assert driver.actions == ["connect"]
+
+
+def test_driver_connect_failure_prevents_session_creation(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    object.__setattr__(server_context, "roaster_driver", RecordingRoasterDriver(fail_connect=True))
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    with pytest.raises(RuntimeError, match="connect failed"):
+        _call_tool(server, "start_roast_session", ctx)
+    with pytest.raises(ValueError, match="No roast session exists"):
+        _call_tool(server, "get_roast_state", ctx)
+
+
+def test_stale_heat_command_fails_closed_after_emergency_stop(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    command_started = Event()
+    release_command = Event()
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(block_heat=(command_started, release_command))
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+    errors: list[BaseException] = []
+
+    _call_tool(server, "start_roast_session", ctx)
+    heat_thread = Thread(
+        target=_record_tool_error,
+        args=(errors, server, "set_heat", ctx),
+        kwargs={"heat_level_percent": 65},
+    )
+    heat_thread.start()
+    assert command_started.wait(timeout=1.0)
+
+    emergency = _call_tool(server, "emergency_stop", ctx, reason="unit-test")
+    release_command.set()
+    heat_thread.join(timeout=1.0)
+
+    assert not heat_thread.is_alive()
+    assert isinstance(errors[0], SessionLifecycleError)
+    assert emergency.event.kind == "fault"
+    assert driver.heat_level_percent == 0
+    assert driver.fan_level_percent == 100
+    assert driver.cooling_on is True
+    assert driver.actions == [
+        "connect",
+        "set_heat:65",
+        "emergency_stop:unit-test",
+        "emergency_stop:stale driver command after session state changed",
+    ]
+
+
+def test_blocked_drop_command_does_not_block_emergency_stop(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    command_started = Event()
+    release_command = Event()
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(block_drop=(command_started, release_command))
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+    errors: list[BaseException] = []
+
+    _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "mark_beans_added", ctx)
+    drop_thread = Thread(
+        target=_record_tool_error,
+        args=(errors, server, "drop_beans", ctx),
+    )
+    drop_thread.start()
+    assert command_started.wait(timeout=1.0)
+
+    emergency = _call_tool(server, "emergency_stop", ctx, reason="unit-test")
+    release_command.set()
+    drop_thread.join(timeout=1.0)
+
+    assert not drop_thread.is_alive()
+    assert isinstance(errors[0], SessionLifecycleError)
+    assert emergency.event.kind == "fault"
+    assert driver.actions == [
+        "connect",
+        "drop_beans",
+        "emergency_stop:unit-test",
+        "emergency_stop:stale driver command after session state changed",
+    ]
+
+
+class RecordingRoasterDriver:
+    """Driver double that records MCP boundary calls."""
+
+    name = "recording"
+
+    def __init__(
+        self,
+        *,
+        fail_connect: bool = False,
+        fail_heat: bool = False,
+        block_heat: tuple[Event, Event] | None = None,
+        block_drop: tuple[Event, Event] | None = None,
+    ) -> None:
+        """Initialize a deterministic recording driver."""
+        self.actions: list[str] = []
+        self.fail_connect = fail_connect
+        self.fail_heat = fail_heat
+        self.block_heat = block_heat
+        self.block_drop = block_drop
+        self.connected = False
+        self.heat_level_percent = 0
+        self.fan_level_percent = 0
+        self.cooling_on = False
+
+    @property
+    def capabilities(self) -> object:
+        """Return mock-compatible capabilities for tests."""
+        return MockRoasterDriver().capabilities
+
+    def connect(self) -> None:
+        """Record connect calls."""
+        self.actions.append("connect")
+        if self.fail_connect:
+            raise RuntimeError("connect failed")
+        self.connected = True
+
+    def disconnect(self) -> None:
+        """Record disconnect calls."""
+        self.actions.append("disconnect")
+        self.connected = False
+
+    def read_state(self) -> RoasterState:
+        """Return the current test state."""
+        return self._state()
+
+    def set_heat(self, *, heat_level_percent: int) -> RoasterState:
+        """Record heat commands."""
+        self.actions.append(f"set_heat:{heat_level_percent}")
+        if self.fail_heat:
+            raise RuntimeError("heat command failed")
+        if self.block_heat is not None:
+            started, release = self.block_heat
+            started.set()
+            assert release.wait(timeout=1.0)
+        self.heat_level_percent = heat_level_percent
+        return self._state()
+
+    def set_fan(self, *, fan_level_percent: int) -> RoasterState:
+        """Record fan commands."""
+        self.actions.append(f"set_fan:{fan_level_percent}")
+        self.fan_level_percent = fan_level_percent
+        return self._state()
+
+    def drop_beans(self) -> RoasterState:
+        """Record drop commands and enter cooling."""
+        self.actions.append("drop_beans")
+        if self.block_drop is not None:
+            started, release = self.block_drop
+            started.set()
+            assert release.wait(timeout=1.0)
+        self.heat_level_percent = 0
+        self.fan_level_percent = 100
+        self.cooling_on = True
+        return self._state()
+
+    def start_cooling(self) -> RoasterState:
+        """Record cooling-start commands."""
+        self.actions.append("start_cooling")
+        self.cooling_on = True
+        return self._state()
+
+    def stop_cooling(self) -> RoasterState:
+        """Record cooling-stop commands."""
+        self.actions.append("stop_cooling")
+        self.cooling_on = False
+        return self._state()
+
+    def emergency_stop(self, *, reason: str) -> EmergencyStopResult:
+        """Record emergency-stop commands."""
+        self.actions.append(f"emergency_stop:{reason}")
+        self.heat_level_percent = 0
+        self.fan_level_percent = 100
+        self.cooling_on = True
+        return EmergencyStopResult(
+            driver=self.name,
+            safety_method="emergency_stop",
+            heat_level_percent=self.heat_level_percent,
+            fan_level_percent=self.fan_level_percent,
+            cooling_on=self.cooling_on,
+        )
+
+    def _state(self) -> RoasterState:
+        return RoasterState(
+            driver=self.name,
+            connected=self.connected,
+            bean_temp_c=None,
+            env_temp_c=None,
+            heat_level_percent=self.heat_level_percent,
+            fan_level_percent=self.fan_level_percent,
+            cooling_on=self.cooling_on,
+        )
+
+
 def _ctx(server_context: ServerContext) -> Any:
     """Build the minimal context shape used by FastMCP tool functions."""
     return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=server_context))
+
+
+def _record_tool_error(
+    errors: list[BaseException],
+    server: FastMCP,
+    tool_name: str,
+    ctx: Any,
+    **kwargs: object,
+) -> None:
+    """Run one tool in a background thread and record any exception."""
+    try:
+        _call_tool(server, tool_name, ctx, **kwargs)
+    except BaseException as exc:
+        errors.append(exc)
 
 
 def _call_tool(server: FastMCP, tool_name: str, ctx: Any, **kwargs: object) -> Any:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -209,6 +209,38 @@ def test_driver_connect_failure_prevents_session_creation(tmp_path: Path) -> Non
         _call_tool(server, "get_roast_state", ctx)
 
 
+def test_concurrent_session_start_reserves_before_driver_connect(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    connect_started = Event()
+    release_connect = Event()
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(block_connect=(connect_started, release_connect))
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+    results: list[object] = []
+    errors: list[BaseException] = []
+
+    start_thread = Thread(
+        target=_record_tool_result,
+        args=(results, errors, server, "start_roast_session", ctx),
+    )
+    start_thread.start()
+    assert connect_started.wait(timeout=1.0)
+
+    with pytest.raises(SessionLifecycleError, match="start is already in progress"):
+        _call_tool(server, "start_roast_session", ctx)
+
+    release_connect.set()
+    start_thread.join(timeout=1.0)
+
+    assert not start_thread.is_alive()
+    assert errors == []
+    assert len(results) == 1
+    assert driver.actions == ["connect"]
+
+
 def test_stale_heat_command_fails_closed_after_emergency_stop(tmp_path: Path) -> None:
     config_path = tmp_path / "coffee-roaster-mcp.yaml"
     config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
@@ -248,6 +280,51 @@ def test_stale_heat_command_fails_closed_after_emergency_stop(tmp_path: Path) ->
     ]
 
 
+def test_stale_command_does_not_emergency_stop_newer_active_session(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    command_started = Event()
+    release_command = Event()
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(block_heat=(command_started, release_command))
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+    errors: list[BaseException] = []
+
+    first_start = _call_tool(server, "start_roast_session", ctx)
+    heat_thread = Thread(
+        target=_record_tool_error,
+        args=(errors, server, "set_heat", ctx),
+        kwargs={"heat_level_percent": 65},
+    )
+    heat_thread.start()
+    assert command_started.wait(timeout=1.0)
+
+    _call_tool(server, "emergency_stop", ctx, reason="unit-test")
+    second_start = _call_tool(server, "start_roast_session", ctx)
+    release_command.set()
+    heat_thread.join(timeout=1.0)
+
+    assert not heat_thread.is_alive()
+    assert isinstance(errors[0], SessionLifecycleError)
+    assert second_start.session.session_id != first_start.session.session_id
+    second_state = _call_tool(
+        server,
+        "get_roast_state",
+        ctx,
+        session_id=second_start.session.session_id,
+    )
+    assert second_state.active is True
+    assert second_state.phase == "pre_roast"
+    assert driver.actions == [
+        "connect",
+        "set_heat:65",
+        "emergency_stop:unit-test",
+        "connect",
+    ]
+
+
 def test_blocked_drop_command_does_not_block_emergency_stop(tmp_path: Path) -> None:
     config_path = tmp_path / "coffee-roaster-mcp.yaml"
     config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
@@ -284,6 +361,39 @@ def test_blocked_drop_command_does_not_block_emergency_stop(tmp_path: Path) -> N
     ]
 
 
+def test_stop_cooling_uses_driver_cooling_state_before_completing(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(stop_cooling_stays_on=True)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "mark_beans_added", ctx)
+    _call_tool(server, "drop_beans", ctx)
+
+    with pytest.raises(SessionLifecycleError, match="still reports cooling active"):
+        _call_tool(server, "stop_cooling", ctx)
+
+    state = _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+    assert state.active is True
+    assert state.phase == "cooling"
+    assert state.cooling_on is True
+    assert [event.kind for event in state.events] == [
+        "beans_added",
+        "beans_dropped",
+        "cooling_started",
+    ]
+    assert driver.actions == [
+        "connect",
+        "drop_beans",
+        "stop_cooling",
+        "emergency_stop:stale driver command after session state changed",
+    ]
+
+
 class RecordingRoasterDriver:
     """Driver double that records MCP boundary calls."""
 
@@ -294,15 +404,19 @@ class RecordingRoasterDriver:
         *,
         fail_connect: bool = False,
         fail_heat: bool = False,
+        block_connect: tuple[Event, Event] | None = None,
         block_heat: tuple[Event, Event] | None = None,
         block_drop: tuple[Event, Event] | None = None,
+        stop_cooling_stays_on: bool = False,
     ) -> None:
         """Initialize a deterministic recording driver."""
         self.actions: list[str] = []
         self.fail_connect = fail_connect
         self.fail_heat = fail_heat
+        self.block_connect = block_connect
         self.block_heat = block_heat
         self.block_drop = block_drop
+        self.stop_cooling_stays_on = stop_cooling_stays_on
         self.connected = False
         self.heat_level_percent = 0
         self.fan_level_percent = 0
@@ -316,6 +430,10 @@ class RecordingRoasterDriver:
     def connect(self) -> None:
         """Record connect calls."""
         self.actions.append("connect")
+        if self.block_connect is not None:
+            started, release = self.block_connect
+            started.set()
+            assert release.wait(timeout=1.0)
         if self.fail_connect:
             raise RuntimeError("connect failed")
         self.connected = True
@@ -368,7 +486,7 @@ class RecordingRoasterDriver:
     def stop_cooling(self) -> RoasterState:
         """Record cooling-stop commands."""
         self.actions.append("stop_cooling")
-        self.cooling_on = False
+        self.cooling_on = self.stop_cooling_stays_on
         return self._state()
 
     def emergency_stop(self, *, reason: str) -> EmergencyStopResult:
@@ -412,6 +530,21 @@ def _record_tool_error(
     """Run one tool in a background thread and record any exception."""
     try:
         _call_tool(server, tool_name, ctx, **kwargs)
+    except BaseException as exc:
+        errors.append(exc)
+
+
+def _record_tool_result(
+    results: list[object],
+    errors: list[BaseException],
+    server: FastMCP,
+    tool_name: str,
+    ctx: Any,
+    **kwargs: object,
+) -> None:
+    """Run one tool in a background thread and record its result or exception."""
+    try:
+        results.append(_call_tool(server, tool_name, ctx, **kwargs))
     except BaseException as exc:
         errors.append(exc)
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -187,14 +187,14 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
             await _call_with_timeout(session.call_tool("drop_beans", {})),
         )
         assert drop_result.structuredContent["event"]["kind"] == "beans_dropped"
-        assert drop_result.structuredContent["phase"] == "dropped"
+        assert drop_result.structuredContent["phase"] == "cooling"
 
         repeated_drop_result = cast(
             Any,
             await _call_with_timeout(session.call_tool("drop_beans", {})),
         )
         assert repeated_drop_result.structuredContent["event"]["kind"] == "beans_dropped"
-        assert repeated_drop_result.structuredContent["event_count"] == 3
+        assert repeated_drop_result.structuredContent["event_count"] == 4
 
         cooling_result = cast(
             Any,
@@ -219,7 +219,7 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         assert state_result.structuredContent["session_id"] == session_id
         assert state_result.structuredContent["active"] is False
         assert state_result.structuredContent["heat_level_percent"] == 0
-        assert state_result.structuredContent["fan_level_percent"] == 35
+        assert state_result.structuredContent["fan_level_percent"] == 100
         assert state_result.structuredContent["cooling_on"] is False
         assert state_result.structuredContent["roast_elapsed_seconds"] is not None
         assert state_result.structuredContent["development_time_seconds"] is not None


### PR DESCRIPTION
## Summary
- Wire `start_roast_session`, `set_heat`, `set_fan`, `drop_beans`, `start_cooling`, and `stop_cooling` to the configured `RoasterDriver` boundary.
- Keep the default mock path mock-safe while making `drop_beans` perform the normal drop plus cooling transition.
- Add non-emergency driver command reservations so hardware I/O runs outside the session-store lock, but completion must still own the active session reservation before session state is updated.
- Harden idempotency so duplicate `drop_beans` and `start_cooling` calls return existing singleton events without re-sending driver commands.
- Keep emergency stop fail-closed by canceling pending non-emergency reservations before the driver safety call and reapplying driver emergency stop if a stale command completes afterward.
- Add regression coverage for configured-driver calls, command failure without session mutation, connect failure, stale command cancellation, blocked drop plus emergency stop, and idempotent retries.
- Update durable state and add the E4.1-S1 session summary.

## Validation
- `./.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_package.py::test_stdio_server_supports_basic_mock_roast_tool_flow tests/test_session.py` (47 passed)
- `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov` (247 passed, coverage 90.28%)
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`

Closes #104