### PR TITLE
E4.1-S2 expose roaster device state

### DIFF
--- a/docs/session-summaries/2026-05-18-e4-1-s2-expose-roaster-device-state.md
+++ b/docs/session-summaries/2026-05-18-e4-1-s2-expose-roaster-device-state.md
@@ -55,6 +55,21 @@ Behavior implemented:
   or faulted. The status enum also reserves `unavailable` for later detector
   runtime failures when E4.1-S4 owns detector startup.
 
+## PR Review Fixes
+
+Review `4312989085` on `PR #110` found one relevant issue:
+
+- Manual first-crack mode with `allow_manual_override: false` returned
+  `status="manual"` and a reason telling clients to wait for
+  `mark_first_crack`, even though that tool is rejected by configuration.
+
+Fix:
+
+- `get_roast_state` now reports first-crack `status="unavailable"` for
+  `first_crack.mode: manual` plus `allow_manual_override: false`, with a reason
+  that explicitly says manual override is disabled.
+- Added MCP regression coverage for that configuration.
+
 Out of scope kept out:
 
 - Rolling telemetry retention, 60-second deltas, RoR, and final log schemas.
@@ -70,6 +85,13 @@ Out of scope kept out:
 - Ran `./.venv/bin/python -m pytest tests/test_package.py`: `15 passed`.
 - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
   `253 passed`, required coverage `90.0%` reached, total coverage `90.56%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
+
+Review-fix validation:
+
+- Ran `./.venv/bin/python -m pytest tests/test_mcp_server.py`: `14 passed`.
 - Ran `./.venv/bin/python -m ruff check .`: passed.
 - Ran `./.venv/bin/python -m ruff format --check .`: passed.
 - Ran `./.venv/bin/python -m pyright`: `0 errors`.

--- a/docs/session-summaries/2026-05-18-e4-1-s2-expose-roaster-device-state.md
+++ b/docs/session-summaries/2026-05-18-e4-1-s2-expose-roaster-device-state.md
@@ -14,7 +14,13 @@ Hottop validation boundary, and E4.1-S1 configured-driver control wiring.
 
 ## Context Usage
 
-No new context-usage snapshot was supplied during this session.
+Final context snapshot supplied by the operator after PR feedback was addressed:
+
+- Context window: `48% left (139K used / 258K)`
+- 5h limit: `100% left`, resets `01:10 on 19 May`
+- Weekly limit: `94% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `01:10 on 19 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `20:10 on 25 May`
 
 ## Pre-Story Verification
 
@@ -92,9 +98,18 @@ Out of scope kept out:
 Review-fix validation:
 
 - Ran `./.venv/bin/python -m pytest tests/test_mcp_server.py`: `14 passed`.
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `253 passed`, required coverage `90.0%` reached, total coverage `90.57%`.
 - Ran `./.venv/bin/python -m ruff check .`: passed.
 - Ran `./.venv/bin/python -m ruff format --check .`: passed.
 - Ran `./.venv/bin/python -m pyright`: `0 errors`.
+
+## Pull Request Status
+
+`PR #110` is open at
+<https://github.com/syamaner/coffee-roaster-mcp/pull/110>. After the review fix
+commit `06fa8bf`, GitHub CI reported both `Checks` and `Build Package` passed.
+The operator confirmed there is no remaining PR feedback.
 
 ## Handoff
 

--- a/docs/session-summaries/2026-05-18-e4-1-s2-expose-roaster-device-state.md
+++ b/docs/session-summaries/2026-05-18-e4-1-s2-expose-roaster-device-state.md
@@ -1,0 +1,81 @@
+# E4.1-S2 Expose Roaster Device State Session
+
+## Scope
+
+This session resumed after `PR #109` for `E4.1-S1` was squashed and merged, and
+issue `#104` was closed. Work started from updated `main` on branch
+`feature/105-expose-current-roaster-device-state-through-mcp` for issue `#105`,
+`E4.1-S2: Expose current roaster device state through MCP`.
+
+The story goal was to expose current configured-device state through MCP for
+operator decisions while preserving the mock default, Epic 2 one-session store
+boundary, MCP semantics, fail-closed safety behavior, coverage workflow, Epic 3
+Hottop validation boundary, and E4.1-S1 configured-driver control wiring.
+
+## Context Usage
+
+No new context-usage snapshot was supplied during this session.
+
+## Pre-Story Verification
+
+Before starting E4.1-S2:
+
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding through the E4.1-S1
+  merge.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-18-e4-1-s1-wire-mcp-roast-control-tools.md`,
+  and GitHub issue `#105`.
+- Created branch
+  `feature/105-expose-current-roaster-device-state-through-mcp`.
+
+## Implementation
+
+Updated:
+
+- `src/coffee_roaster_mcp/mcp_server.py`
+- `tests/test_mcp_server.py`
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+Behavior implemented:
+
+- `get_roast_state` now reads the configured `RoasterDriver.read_state()`
+  boundary and returns `device_state` with driver id, connected status,
+  bean/environment temperatures when available, heat/fan levels, cooling state,
+  and flat safe raw diagnostics.
+- Driver state-read failures surface as clear MCP tool errors and do not mutate
+  authoritative session history.
+- `RoastSessionState` now exposes authoritative monotonic event timestamp fields
+  alongside existing UTC fields for beans added, first crack, bean drop, cooling
+  start, cooling stop, and faults.
+- `RoastSessionState` now exposes structured first-crack status derived from
+  configuration and the session timeline: disabled, manual, pending, detected,
+  or faulted. The status enum also reserves `unavailable` for later detector
+  runtime failures when E4.1-S4 owns detector startup.
+
+Out of scope kept out:
+
+- Rolling telemetry retention, 60-second deltas, RoR, and final log schemas.
+- Released-artifact ONNX detector runtime construction.
+- Session-owned first-crack detector startup.
+- Auto-T0 detection.
+- Model training, ONNX export, Hugging Face sync, real microphone validation,
+  live Hottop validation, or broad release validation.
+
+## Validation
+
+- Ran `./.venv/bin/python -m pytest tests/test_mcp_server.py`: `14 passed`.
+- Ran `./.venv/bin/python -m pytest tests/test_package.py`: `15 passed`.
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `253 passed`, required coverage `90.0%` reached, total coverage `90.56%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
+
+## Handoff
+
+Durable state now points to `E4.1-S3`, issue `#106`, for the released-artifact
+ONNX first-crack detector backend. Continue to preserve normal CI as mock-safe:
+no Hottop hardware, microphone, model download, or network should be required.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -1052,6 +1052,9 @@ After completing a story:
     MCP output reports disabled, manual, pending, detected, or faulted from
     configuration and the authoritative session timeline; the status enum leaves
     room for unavailable runtime failures when E4.1-S4 owns detector startup.
+  - PR review hardening changed manual first-crack mode with
+    `allow_manual_override: false` to report `status="unavailable"` instead of
+    telling clients to wait for a rejected `mark_first_crack` override.
   - Driver state-read failures now surface as clear `get_roast_state` tool
     errors and do not mutate session history.
   - Kept rolling telemetry retention, RoR/60-second deltas, final log schemas,

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4.1-S2`
-- Current target: Expose current roaster device state through MCP
+- Active story: `E4.1-S3`
+- Current target: Add released-artifact ONNX first-crack detector backend
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -128,6 +128,16 @@ The first implementation milestone is a mock vertical slice that requires no roa
   command fail-closed handling is scoped to the reservation's session id so a
   previous session's late command cannot emergency-stop a newer active session
   without that session owning the fault.
+- `E4.1-S2` expands `get_roast_state` into the operational MCP state read for
+  Claude/operator decisions. The tool now reads the configured driver through
+  the existing `RoasterDriver.read_state()` boundary and returns connected
+  status, driver id, bean/environment temperatures when available, heat/fan
+  levels, cooling state, and flat safe raw diagnostics. The same response now
+  includes authoritative UTC and monotonic event timestamps for beans added,
+  first crack, bean drop, cooling start, cooling stop, and faults, plus a
+  structured first-crack status derived from current config and the session
+  timeline. Driver state-read failures surface as clear MCP tool errors and do
+  not mutate session history.
 - `mark_beans_added` and `mark_first_crack` remain exposed as explicit
   override tools. The primary runtime path should be internal auto-T0 detection
   when enabled and internal first-crack detector confirmation in audio mode.
@@ -142,9 +152,6 @@ The first implementation milestone is a mock vertical slice that requires no roa
 
 ## Current Risks
 
-- Current MCP state output does not yet expose the full normalized device state
-  required for operator decisions; E4.1-S2 owns that schema and tool response
-  work.
 - The first-crack path does not yet include a released-artifact ONNX runtime
   backend or session-owned detector loop; Epic 4.1 now tracks this before Epic
   5 metrics/logging work.
@@ -344,7 +351,7 @@ first crack has happened through MCP tools.
     cooling transition; `start_cooling` remains available only as an explicit
     advanced/manual recovery control.
 
-- [ ] `E4.1-S2` Expose current roaster device state through MCP.
+- [x] `E4.1-S2` Expose current roaster device state through MCP.
   - Done when MCP state output includes current driver state needed for
     operational decisions: connected status, bean/environment temperatures when
     available, heat/fan levels, cooling state, driver id, and safe raw
@@ -1030,6 +1037,31 @@ After completing a story:
   - Ran `./.venv/bin/python -m pytest tests/test_session.py`: 38 passed.
   - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
     250 passed, required coverage `90.0%` reached, total coverage `90.39%`.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E4.1-S2:
+  - Expanded `get_roast_state` with a current `device_state` snapshot from the
+    configured `RoasterDriver.read_state()` boundary: driver id, connected
+    status, bean/environment temperatures when available, heat/fan levels,
+    cooling state, and flat safe raw diagnostics.
+  - Added authoritative monotonic event timestamp fields alongside existing UTC
+    fields for beans added, first crack, bean drop, cooling start, cooling stop,
+    and faults.
+  - Added structured first-crack status fields for operator decisions. Current
+    MCP output reports disabled, manual, pending, detected, or faulted from
+    configuration and the authoritative session timeline; the status enum leaves
+    room for unavailable runtime failures when E4.1-S4 owns detector startup.
+  - Driver state-read failures now surface as clear `get_roast_state` tool
+    errors and do not mutate session history.
+  - Kept rolling telemetry retention, RoR/60-second deltas, final log schemas,
+    released-artifact ONNX runtime construction, detector startup, auto-T0
+    detection, training/export/sync behavior, real microphone validation, and
+    live Hottop validation out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_mcp_server.py`: 14 passed.
+  - Ran `./.venv/bin/python -m pytest tests/test_package.py`: 15 passed.
+  - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+    253 passed, required coverage `90.0%` reached, total coverage `90.56%`.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -97,11 +97,16 @@ commands are sent. `mark_beans_added` and
 `mark_first_crack` remain explicit override tools, while automatic T0 and
 first-crack detection are internal runtime paths. `drop_beans` is the normal
 agent/operator command for drop and cooling transition; `start_cooling` is an
-advanced recovery/manual control rather than the normal roast flow. Epic 5
+advanced recovery/manual control rather than the normal roast flow. E4.1-S2
+expands `get_roast_state` with the current configured-device state from
+`RoasterDriver.read_state()`, authoritative UTC and monotonic lifecycle event
+timestamps, and a structured first-crack status for operator decisions. Driver
+state-read failures surface clearly and do not mutate session history. Epic 5
 remains focused on telemetry buffering, derived metrics, and final log/export
 schemas.
 
-The next story is E4.1-S2: expose current roaster device state through MCP.
+The next story is E4.1-S3: add the released-artifact ONNX first-crack detector
+backend.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -854,6 +854,15 @@ def _serialize_first_crack_status(
             reason="Automatic first-crack detection is disabled by configuration.",
         )
     if config.first_crack.mode == "manual":
+        if not config.first_crack.allow_manual_override:
+            return FirstCrackStatus(
+                mode=config.first_crack.mode,
+                status="unavailable",
+                detected_at_utc=None,
+                detected_monotonic_seconds=None,
+                allow_manual_override=config.first_crack.allow_manual_override,
+                reason=("Manual first-crack mode is configured, but manual override is disabled."),
+            )
         return FirstCrackStatus(
             mode=config.first_crack.mode,
             status="manual",

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -14,7 +14,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 
 from coffee_roaster_mcp import __version__
-from coffee_roaster_mcp.config import AppConfig, ConfigError, load_config
+from coffee_roaster_mcp.config import AppConfig, ConfigError, FirstCrackMode, load_config
 from coffee_roaster_mcp.drivers import RoasterDriver, RoasterState, create_roaster_driver
 from coffee_roaster_mcp.exports import export_roast_snapshot
 from coffee_roaster_mcp.session import (
@@ -124,6 +124,62 @@ class EventSnapshot:
     payload: dict[str, EventPayloadValue]
 
 
+FirstCrackRuntimeStatus = Literal[
+    "disabled",
+    "manual",
+    "pending",
+    "detected",
+    "faulted",
+    "unavailable",
+]
+
+
+@dataclass(frozen=True)
+class RoasterDeviceState:
+    """Serializable configured-device state returned by MCP tools.
+
+    Attributes:
+        driver: Stable driver identifier returned by the configured driver.
+        connected: Whether the driver reports an open roaster connection.
+        bean_temp_c: Current bean temperature in Celsius when available.
+        env_temp_c: Current environment temperature in Celsius when available.
+        heat_level_percent: Current heat control level.
+        fan_level_percent: Current fan control level.
+        cooling_on: Whether cooling is currently active.
+        raw_vendor_data: Flat safe diagnostic fields from the driver boundary.
+    """
+
+    driver: str
+    connected: bool
+    bean_temp_c: float | None
+    env_temp_c: float | None
+    heat_level_percent: int
+    fan_level_percent: int
+    cooling_on: bool
+    raw_vendor_data: dict[str, EventPayloadValue]
+
+
+@dataclass(frozen=True)
+class FirstCrackStatus:
+    """Serializable first-crack status for operator decisions.
+
+    Attributes:
+        mode: Configured first-crack mode.
+        status: Current first-crack runtime status.
+        detected_at_utc: Authoritative detection timestamp when first crack exists.
+        detected_monotonic_seconds: Authoritative monotonic detection timestamp.
+        allow_manual_override: Whether the explicit override tool is enabled.
+        reason: Human-readable reason when status needs extra context.
+    """
+
+    mode: FirstCrackMode
+    status: FirstCrackRuntimeStatus
+    detected_at_utc: str | None
+    detected_monotonic_seconds: float | None
+    allow_manual_override: bool
+    reason: str | None = None
+
+
 @dataclass(frozen=True)
 class RoastSessionState:
     """Serializable roast session state returned by MCP tools."""
@@ -143,9 +199,17 @@ class RoastSessionState:
     cooling_started_at_utc: str | None
     cooling_stopped_at_utc: str | None
     faulted_at_utc: str | None
+    beans_added_monotonic_seconds: float | None
+    first_crack_monotonic_seconds: float | None
+    beans_dropped_monotonic_seconds: float | None
+    cooling_started_monotonic_seconds: float | None
+    cooling_stopped_monotonic_seconds: float | None
+    faulted_monotonic_seconds: float | None
     roast_elapsed_seconds: float | None
     development_time_seconds: float | None
     development_percent: float | None
+    device_state: RoasterDeviceState | None
+    first_crack_status: FirstCrackStatus
     events: tuple[EventSnapshot, ...]
     log_dir: str | None
 
@@ -325,7 +389,9 @@ def create_mcp_server(
         except Exception:
             server_context.session_store.clear_session_start_reservation(reservation)
             raise
-        return StartRoastSessionResult(session=_serialize_session_state(session))
+        return StartRoastSessionResult(
+            session=_serialize_session_state(session, config=server_context.config)
+        )
 
     @mcp.tool()
     def get_roast_state(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -335,7 +401,12 @@ def create_mcp_server(
         """Return the current authoritative roast session state."""
         server_context = ctx.request_context.lifespan_context
         session = _resolve_session(server_context, session_id=session_id)
-        return _serialize_session_state(session)
+        device_state = _read_current_device_state(server_context)
+        return _serialize_session_state(
+            session,
+            config=server_context.config,
+            device_state=device_state,
+        )
 
     @mcp.tool()
     def set_heat(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -681,8 +752,24 @@ def _snapshot_session(
         raise ValueError(str(exc)) from exc
 
 
+def _read_current_device_state(server_context: ServerContext) -> RoasterDeviceState:
+    """Read and serialize the configured driver state for MCP output."""
+    try:
+        driver_state = server_context.roaster_driver.read_state()
+    except Exception as exc:
+        driver_name = server_context.config.roaster.driver
+        raise RuntimeError(
+            f"Could not read current roaster state from driver {driver_name}: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+    return _serialize_device_state(driver_state)
+
+
 def _serialize_session_state(
     session: RoastSession,
+    *,
+    config: AppConfig,
+    device_state: RoasterDeviceState | None = None,
 ) -> RoastSessionState:
     """Convert one in-memory session into an MCP-safe snapshot."""
     metrics = compute_roast_metrics(session)
@@ -702,13 +789,86 @@ def _serialize_session_state(
         cooling_started_at_utc=_iso_or_none(session.cooling_started_at_utc),
         cooling_stopped_at_utc=_iso_or_none(session.cooling_stopped_at_utc),
         faulted_at_utc=_iso_or_none(session.faulted_at_utc),
+        beans_added_monotonic_seconds=session.beans_added_monotonic_seconds,
+        first_crack_monotonic_seconds=session.first_crack_monotonic_seconds,
+        beans_dropped_monotonic_seconds=session.beans_dropped_monotonic_seconds,
+        cooling_started_monotonic_seconds=session.cooling_started_monotonic_seconds,
+        cooling_stopped_monotonic_seconds=session.cooling_stopped_monotonic_seconds,
+        faulted_monotonic_seconds=session.faulted_monotonic_seconds,
         roast_elapsed_seconds=metrics.roast_elapsed_seconds,
         development_time_seconds=metrics.development_time_seconds,
         development_percent=metrics.development_percent,
+        device_state=device_state,
+        first_crack_status=_serialize_first_crack_status(session, config=config),
         events=tuple(_serialize_event(event) for event in session.event_timeline),
         log_dir=str(session.log_writer.log_dir.resolve())
         if session.log_writer is not None
         else None,
+    )
+
+
+def _serialize_device_state(driver_state: RoasterState) -> RoasterDeviceState:
+    """Convert normalized driver state into an MCP-safe device snapshot."""
+    return RoasterDeviceState(
+        driver=driver_state.driver,
+        connected=driver_state.connected,
+        bean_temp_c=driver_state.bean_temp_c,
+        env_temp_c=driver_state.env_temp_c,
+        heat_level_percent=driver_state.heat_level_percent,
+        fan_level_percent=driver_state.fan_level_percent,
+        cooling_on=driver_state.cooling_on,
+        raw_vendor_data=dict(driver_state.raw_vendor_data),
+    )
+
+
+def _serialize_first_crack_status(
+    session: RoastSession,
+    *,
+    config: AppConfig,
+) -> FirstCrackStatus:
+    """Derive first-crack status from config and the session timeline."""
+    if session.first_crack_at_utc is not None:
+        return FirstCrackStatus(
+            mode=config.first_crack.mode,
+            status="detected",
+            detected_at_utc=session.first_crack_at_utc.isoformat(),
+            detected_monotonic_seconds=session.first_crack_monotonic_seconds,
+            allow_manual_override=config.first_crack.allow_manual_override,
+        )
+    if session.faulted_at_utc is not None:
+        return FirstCrackStatus(
+            mode=config.first_crack.mode,
+            status="faulted",
+            detected_at_utc=None,
+            detected_monotonic_seconds=None,
+            allow_manual_override=config.first_crack.allow_manual_override,
+            reason="Session faulted before first crack was recorded.",
+        )
+    if config.first_crack.mode == "disabled":
+        return FirstCrackStatus(
+            mode=config.first_crack.mode,
+            status="disabled",
+            detected_at_utc=None,
+            detected_monotonic_seconds=None,
+            allow_manual_override=config.first_crack.allow_manual_override,
+            reason="Automatic first-crack detection is disabled by configuration.",
+        )
+    if config.first_crack.mode == "manual":
+        return FirstCrackStatus(
+            mode=config.first_crack.mode,
+            status="manual",
+            detected_at_utc=None,
+            detected_monotonic_seconds=None,
+            allow_manual_override=config.first_crack.allow_manual_override,
+            reason="Waiting for explicit mark_first_crack override.",
+        )
+    return FirstCrackStatus(
+        mode=config.first_crack.mode,
+        status="pending",
+        detected_at_utc=None,
+        detected_monotonic_seconds=None,
+        allow_manual_override=config.first_crack.allow_manual_override,
+        reason="Audio first-crack detection has not recorded first crack for this session.",
     )
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -242,6 +242,39 @@ def test_get_roast_state_exposes_first_crack_statuses(tmp_path: Path) -> None:
     assert manual_state.first_crack_status.status == "manual"
     assert manual_state.first_crack_status.allow_manual_override is True
 
+    manual_unavailable_config_path = tmp_path / "manual-unavailable.yaml"
+    manual_unavailable_config_path.write_text(
+        "\n".join(
+            [
+                "first_crack:",
+                "  mode: manual",
+                "  allow_manual_override: false",
+                f"logging:\n  log_dir: {tmp_path / 'manual-unavailable-logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    manual_unavailable_context = build_server_context(config_path=manual_unavailable_config_path)
+    manual_unavailable_server = create_mcp_server(config_path=manual_unavailable_config_path)
+    manual_unavailable_ctx = _ctx(manual_unavailable_context)
+    manual_unavailable_start = _call_tool(
+        manual_unavailable_server,
+        "start_roast_session",
+        manual_unavailable_ctx,
+    )
+    manual_unavailable_state = _call_tool(
+        manual_unavailable_server,
+        "get_roast_state",
+        manual_unavailable_ctx,
+        session_id=manual_unavailable_start.session.session_id,
+    )
+    assert manual_unavailable_state.first_crack_status.status == "unavailable"
+    assert manual_unavailable_state.first_crack_status.allow_manual_override is False
+    assert (
+        manual_unavailable_state.first_crack_status.reason
+        == "Manual first-crack mode is configured, but manual override is disabled."
+    )
+
     audio_config_path = tmp_path / "audio.yaml"
     audio_config_path.write_text(
         "\n".join(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -152,6 +152,159 @@ def test_mcp_roast_controls_call_configured_driver_boundary(tmp_path: Path) -> N
     assert complete.phase == "complete"
 
 
+def test_get_roast_state_exposes_current_driver_state_and_event_timestamps(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(
+        bean_temp_c=151.25,
+        env_temp_c=204.5,
+        raw_vendor_data={"status_packet_count": 7, "vendor_note": "ready"},
+    )
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "set_heat", ctx, heat_level_percent=55)
+    _call_tool(server, "set_fan", ctx, fan_level_percent=35)
+    beans_added = _call_tool(server, "mark_beans_added", ctx)
+
+    state = _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+
+    assert state.device_state is not None
+    assert state.device_state.driver == "recording"
+    assert state.device_state.connected is True
+    assert state.device_state.bean_temp_c == 151.25
+    assert state.device_state.env_temp_c == 204.5
+    assert state.device_state.heat_level_percent == 55
+    assert state.device_state.fan_level_percent == 35
+    assert state.device_state.cooling_on is False
+    assert state.device_state.raw_vendor_data == {
+        "status_packet_count": 7,
+        "vendor_note": "ready",
+    }
+    assert state.beans_added_at_utc == beans_added.event.recorded_at_utc
+    assert state.beans_added_monotonic_seconds == beans_added.event.monotonic_seconds
+    assert state.first_crack_status.status == "disabled"
+    assert state.first_crack_status.mode == "disabled"
+    assert state.first_crack_status.detected_at_utc is None
+    assert state.first_crack_status.detected_monotonic_seconds is None
+
+
+def test_get_roast_state_driver_read_failure_does_not_mutate_session(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(fail_read=True)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "mark_beans_added", ctx)
+
+    with pytest.raises(RuntimeError, match="Could not read current roaster state"):
+        _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+
+    driver.fail_read = False
+    state = _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+    assert [event.kind for event in state.events] == ["beans_added"]
+    assert state.phase == "roasting"
+
+
+def test_get_roast_state_exposes_first_crack_statuses(tmp_path: Path) -> None:
+    manual_config_path = tmp_path / "manual.yaml"
+    manual_config_path.write_text(
+        "\n".join(
+            [
+                "first_crack:",
+                "  mode: manual",
+                f"logging:\n  log_dir: {tmp_path / 'manual-logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    manual_context = build_server_context(config_path=manual_config_path)
+    manual_server = create_mcp_server(config_path=manual_config_path)
+    manual_ctx = _ctx(manual_context)
+    manual_start = _call_tool(manual_server, "start_roast_session", manual_ctx)
+    manual_state = _call_tool(
+        manual_server,
+        "get_roast_state",
+        manual_ctx,
+        session_id=manual_start.session.session_id,
+    )
+    assert manual_state.first_crack_status.status == "manual"
+    assert manual_state.first_crack_status.allow_manual_override is True
+
+    audio_config_path = tmp_path / "audio.yaml"
+    audio_config_path.write_text(
+        "\n".join(
+            [
+                "first_crack:",
+                "  mode: audio",
+                f"logging:\n  log_dir: {tmp_path / 'audio-logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    audio_context = build_server_context(config_path=audio_config_path)
+    audio_server = create_mcp_server(config_path=audio_config_path)
+    audio_ctx = _ctx(audio_context)
+    audio_start = _call_tool(audio_server, "start_roast_session", audio_ctx)
+    audio_state = _call_tool(
+        audio_server,
+        "get_roast_state",
+        audio_ctx,
+        session_id=audio_start.session.session_id,
+    )
+    assert audio_state.first_crack_status.status == "pending"
+
+    _call_tool(audio_server, "mark_beans_added", audio_ctx)
+    detected = _call_tool(audio_server, "mark_first_crack", audio_ctx)
+    detected_state = _call_tool(
+        audio_server,
+        "get_roast_state",
+        audio_ctx,
+        session_id=audio_start.session.session_id,
+    )
+    assert detected_state.first_crack_status.status == "detected"
+    assert detected_state.first_crack_status.detected_at_utc == detected.event.recorded_at_utc
+    assert (
+        detected_state.first_crack_status.detected_monotonic_seconds
+        == detected.event.monotonic_seconds
+    )
+
+    fault_config_path = tmp_path / "fault.yaml"
+    fault_config_path.write_text(
+        "\n".join(
+            [
+                "first_crack:",
+                "  mode: audio",
+                f"logging:\n  log_dir: {tmp_path / 'fault-logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fault_context = build_server_context(config_path=fault_config_path)
+    fault_server = create_mcp_server(config_path=fault_config_path)
+    fault_ctx = _ctx(fault_context)
+    fault_start = _call_tool(fault_server, "start_roast_session", fault_ctx)
+    _call_tool(fault_server, "emergency_stop", fault_ctx, reason="unit-test")
+    fault_state = _call_tool(
+        fault_server,
+        "get_roast_state",
+        fault_ctx,
+        session_id=fault_start.session.session_id,
+    )
+    assert fault_state.first_crack_status.status == "faulted"
+
+
 def test_driver_command_failure_does_not_mutate_session_state(tmp_path: Path) -> None:
     config_path = tmp_path / "coffee-roaster-mcp.yaml"
     config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
@@ -404,15 +557,20 @@ class RecordingRoasterDriver:
         *,
         fail_connect: bool = False,
         fail_heat: bool = False,
+        fail_read: bool = False,
         block_connect: tuple[Event, Event] | None = None,
         block_heat: tuple[Event, Event] | None = None,
         block_drop: tuple[Event, Event] | None = None,
         stop_cooling_stays_on: bool = False,
+        bean_temp_c: float | None = None,
+        env_temp_c: float | None = None,
+        raw_vendor_data: dict[str, str | int | float | bool | None] | None = None,
     ) -> None:
         """Initialize a deterministic recording driver."""
         self.actions: list[str] = []
         self.fail_connect = fail_connect
         self.fail_heat = fail_heat
+        self.fail_read = fail_read
         self.block_connect = block_connect
         self.block_heat = block_heat
         self.block_drop = block_drop
@@ -421,6 +579,9 @@ class RecordingRoasterDriver:
         self.heat_level_percent = 0
         self.fan_level_percent = 0
         self.cooling_on = False
+        self.bean_temp_c = bean_temp_c
+        self.env_temp_c = env_temp_c
+        self.raw_vendor_data = {} if raw_vendor_data is None else dict(raw_vendor_data)
 
     @property
     def capabilities(self) -> object:
@@ -445,6 +606,8 @@ class RecordingRoasterDriver:
 
     def read_state(self) -> RoasterState:
         """Return the current test state."""
+        if self.fail_read:
+            raise RuntimeError("read failed")
         return self._state()
 
     def set_heat(self, *, heat_level_percent: int) -> RoasterState:
@@ -507,11 +670,12 @@ class RecordingRoasterDriver:
         return RoasterState(
             driver=self.name,
             connected=self.connected,
-            bean_temp_c=None,
-            env_temp_c=None,
+            bean_temp_c=self.bean_temp_c,
+            env_temp_c=self.env_temp_c,
             heat_level_percent=self.heat_level_percent,
             fan_level_percent=self.fan_level_percent,
             cooling_on=self.cooling_on,
+            raw_vendor_data=self.raw_vendor_data,
         )
 
 


### PR DESCRIPTION
## Summary
- expand get_roast_state with current configured-device state from RoasterDriver.read_state
- expose lifecycle monotonic timestamps and structured first-crack status for operator decisions
- keep driver read failures conservative by surfacing clear tool errors without mutating session history
- update durable epic/registry state and add an E4.1-S2 session summary

## Validation
- ./.venv/bin/python -m pytest tests/test_mcp_server.py
- ./.venv/bin/python -m pytest tests/test_package.py
- ./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov
- ./.venv/bin/python -m ruff check .
- ./.venv/bin/python -m ruff format --check .
- ./.venv/bin/python -m pyright

Closes #105