### PR TITLE
Add full roast readiness stories

### DIFF
--- a/docs/session-summaries/2026-05-18-e4-1-s2-expose-roaster-device-state.md
+++ b/docs/session-summaries/2026-05-18-e4-1-s2-expose-roaster-device-state.md
@@ -111,6 +111,26 @@ Review-fix validation:
 commit `06fa8bf`, GitHub CI reported both `Checks` and `Build Package` passed.
 The operator confirmed there is no remaining PR feedback.
 
+## Roadmap Follow-Up
+
+After reviewing whether the remaining epics guarantee a fully functional MCP for
+agent-run roasts, two explicit stories were added:
+
+- GitHub issue `#111`, `E4.1-S6: Add automatic T0 runtime path`. This owns the
+  internal automatic beans-added/T0 path so a fully agent-driven roast does not
+  depend on `mark_beans_added` as the primary runtime path when auto-T0 is
+  enabled. `mark_beans_added` remains an explicit override and auto-T0 remains
+  disabled by default.
+- GitHub issue `#112`, `E7-S6: Run end-to-end agent roast validation with HF
+  ONNX audio path`. This owns final validation that a real MCP client or agent
+  can run a full roast with configured Hottop hardware, real microphone/audio
+  input, released Hugging Face ONNX first-crack artifacts, correct state/stats,
+  and exported log evidence.
+
+Updated `docs/state/github-issues.md`, `docs/state/registry.md`, and
+`docs/state/epics/coffee-roaster-mcp-v0.1.md` to include these stories and make
+the Hugging Face ONNX artifact requirement explicit.
+
 ## Handoff
 
 Durable state now points to `E4.1-S3`, issue `#106`, for the released-artifact

--- a/docs/session-summaries/2026-05-18-e4-1-s2-expose-roaster-device-state.md
+++ b/docs/session-summaries/2026-05-18-e4-1-s2-expose-roaster-device-state.md
@@ -119,8 +119,12 @@ agent-run roasts, two explicit stories were added:
 - GitHub issue `#111`, `E4.1-S6: Add automatic T0 runtime path`. This owns the
   internal automatic beans-added/T0 path so a fully agent-driven roast does not
   depend on `mark_beans_added` as the primary runtime path when auto-T0 is
-  enabled. `mark_beans_added` remains an explicit override and auto-T0 remains
-  disabled by default.
+  enabled. After checking the old `coffee-roasting` prototype
+  `RoastTracker`, the story was tightened so T0 is beans added, detected when
+  current bean temperature drops from the tracked max preheat/charge
+  temperature by the configured threshold; the pre-drop max is preserved as the
+  charge temperature. `mark_beans_added` remains an explicit override and
+  auto-T0 remains disabled by default.
 - GitHub issue `#112`, `E7-S6: Run end-to-end agent roast validation with HF
   ONNX audio path`. This owns final validation that a real MCP client or agent
   can run a full roast with configured Hottop hardware, real microphone/audio

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -110,10 +110,11 @@ The first implementation milestone is a mock vertical slice that requires no roa
   no-live-hardware CI. Current first-crack components resolve
   artifacts, capture audio windows, adapt detector outputs, and write to the
   session timeline, but there is not yet a released-artifact ONNX runtime
-  backend or session-owned detector loop. Epic 4.1 makes the operational MCP
-  flow explicit: Claude should be able to start a roast, adjust the configured
-  roaster, read current device/session state, and know whether first crack has
-  happened before Epic 5 adds richer telemetry metrics and final log schemas.
+  backend, session-owned detector loop, or automatic T0 runtime path. Epic 4.1
+  makes the operational MCP flow explicit: Claude should be able to start a
+  roast, adjust the configured roaster, read current device/session state, and
+  know whether first crack has happened before Epic 5 adds richer telemetry
+  metrics and final log schemas.
 - `E4.1-S1` keeps driver commands outside the store lock while ensuring invalid
   drop/cooling phase calls fail before the driver boundary is touched. Driver
   command failures surface as MCP tool errors before session mutation, while
@@ -145,6 +146,10 @@ The first implementation milestone is a mock vertical slice that requires no roa
   roaster drop/cooling behavior and record the relevant session events;
   `start_cooling` remains an advanced recovery/manual tool, not the normal
   Claude roast flow.
+- `E4.1-S6` is added so the automatic T0 runtime path is explicitly owned
+  before the operational epic closes. The explicit `mark_beans_added` override
+  remains available, but a fully agent-driven roast should not depend on that
+  override as the primary T0 path when auto-T0 is enabled.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -361,9 +366,9 @@ first crack has happened through MCP tools.
 
 - [ ] `E4.1-S3` Add released-artifact ONNX first-crack detector backend.
   - Done when `first_crack.mode: audio` can construct a detector backend from
-    the resolved ONNX model and feature-extractor config using the existing
-    released-artifact resolver boundary, with mock-safe tests and no training,
-    export, or Hugging Face sync behavior.
+    the resolved Hugging Face ONNX model and feature-extractor config using the
+    existing released-artifact resolver boundary, with mock-safe tests and no
+    training, export, or Hugging Face sync behavior.
 
 - [ ] `E4.1-S4` Start first-crack detection runtime with roast sessions.
   - Done when audio mode starts/stops the configured audio pipeline and detector
@@ -381,6 +386,14 @@ first crack has happened through MCP tools.
     documented as the normal drop/cooling command, and optional live
     Hottop/real microphone validation docs remain explicitly gated.
 
+- [ ] `E4.1-S6` Add automatic T0 runtime path.
+  - Done when `session.auto_t0_detection_enabled` can record the authoritative
+    `beans_added` event internally through `RoastSessionStore` without using
+    `mark_beans_added` as the primary path, remains disabled by default,
+    preserves `mark_beans_added` as an explicit idempotent override, rejects
+    invalid phases and duplicates, exposes the resulting T0 timestamps through
+    `get_roast_state`, and keeps normal CI mock-safe.
+
 ### Epic Acceptance Criteria
 
 - Claude can start a roast through MCP.
@@ -394,6 +407,9 @@ first crack has happened through MCP tools.
   cooling started, and cooling stopped from `get_roast_state`.
 - Automatic T0 and automatic first-crack detection are internal runtime paths;
   exposed mark tools are explicit overrides.
+- In audio mode, first-crack runtime uses released Hugging Face ONNX artifacts
+  consumed by this repo; model training, ONNX export, and Hugging Face sync stay
+  in `coffee-first-crack-detection`.
 - `drop_beans` is the normal operational command for drop and cooling
   transition; `start_cooling` is an advanced/manual recovery path.
 - Normal CI requires no Hottop hardware, microphone, model download, or network.
@@ -495,11 +511,23 @@ Goal: prove the package works from install through mock roast, MCP client calls,
 - [ ] `E7-S5` Produce v0.1 release checklist.
   - Done when release steps cover tests, package build, version alignment, HF revision pin, PyPI publish, registry publish, GitHub release, and hardware-ready labeling.
 
+- [ ] `E7-S6` Run end-to-end agent roast validation with HF ONNX audio path.
+  - Done when a real MCP client or agent can install/connect to the package and
+    run a full roast flow using public MCP tools, configured Hottop hardware,
+    released Hugging Face ONNX first-crack artifacts, and real microphone/audio
+    input; validation evidence records lifecycle timestamps, first-crack
+    status/metadata, roaster device state, Epic 5 metrics/stat fields,
+    exported logs, configuration, artifact revision, hardware/audio setup, and
+    operator interventions.
+
 ### Epic Acceptance Criteria
 
 - Full mock roast works from install to exported logs.
 - MCP client can discover and call tools.
 - Manual hardware results are recorded.
+- A real MCP client or agent can complete an end-to-end roast validation using
+  configured hardware, real audio, and released Hugging Face ONNX first-crack
+  artifacts, with correct state, stats, and exported logs recorded as evidence.
 - Release is tagged only after package, registry, and smoke tests pass.
 
 ## Spikes

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -149,7 +149,10 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - `E4.1-S6` is added so the automatic T0 runtime path is explicitly owned
   before the operational epic closes. The explicit `mark_beans_added` override
   remains available, but a fully agent-driven roast should not depend on that
-  override as the primary T0 path when auto-T0 is enabled.
+  override as the primary T0 path when auto-T0 is enabled. T0 is beans added:
+  the runtime should track the max preheat/charge bean temperature before T0,
+  then record `beans_added` when current bean temperature drops from that max by
+  the configured threshold. The pre-drop max is the charge temperature.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -389,10 +392,16 @@ first crack has happened through MCP tools.
 - [ ] `E4.1-S6` Add automatic T0 runtime path.
   - Done when `session.auto_t0_detection_enabled` can record the authoritative
     `beans_added` event internally through `RoastSessionStore` without using
-    `mark_beans_added` as the primary path, remains disabled by default,
+    `mark_beans_added` as the primary path, tracks max preheat/charge bean
+    temperature from `RoasterDriver.read_state()` before T0, records T0 at the
+    first reading where current bean temperature drops from that max by the
+    configured threshold, preserves the pre-drop max as charge temperature in
+    diagnostics, handles gradual drops by comparing against the tracked max
+    rather than only the previous reading, remains disabled by default,
     preserves `mark_beans_added` as an explicit idempotent override, rejects
-    invalid phases and duplicates, exposes the resulting T0 timestamps through
-    `get_roast_state`, and keeps normal CI mock-safe.
+    invalid phases and duplicates, exposes the resulting T0 timestamps and
+    charge-temperature diagnostics through `get_roast_state`, and keeps normal
+    CI mock-safe.
 
 ### Epic Acceptance Criteria
 
@@ -407,6 +416,9 @@ first crack has happened through MCP tools.
   cooling started, and cooling stopped from `get_roast_state`.
 - Automatic T0 and automatic first-crack detection are internal runtime paths;
   exposed mark tools are explicit overrides.
+- Automatic T0 means bean-charge detection from a configured bean-temperature
+  drop threshold against max preheat/charge temperature, not temperature
+  recovery after the drop.
 - In audio mode, first-crack runtime uses released Hugging Face ONNX artifacts
   consumed by this repo; model training, ONNX export, and Hugging Face sync stay
   in `coffee-first-crack-detection`.

--- a/docs/state/github-issues.md
+++ b/docs/state/github-issues.md
@@ -69,6 +69,7 @@ Milestone: `v0.1`
 - #106 E4.1-S3: Add released-artifact ONNX first-crack detector backend
 - #107 E4.1-S4: Start first-crack detection runtime with roast sessions
 - #108 E4.1-S5: Add MCP operational readiness tests and docs
+- #111 E4.1-S6: Add automatic T0 runtime path
 
 ## Epic 5 Stories
 
@@ -99,6 +100,7 @@ Milestone: `v0.1`
 - #58 E7-S3: Test MCP client connection
 - #59 E7-S4: Run Hottop manual hardware validation
 - #60 E7-S5: Produce v0.1 release checklist
+- #112 E7-S6: Run end-to-end agent roast validation with HF ONNX audio path
 
 ## Standalone Spikes
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -90,7 +90,10 @@ driver-backed MCP control tools, current roaster state exposure, released ONNX
 detector backend construction, session-owned first-crack detector lifecycle, and
 operational MCP readiness tests/docs. E4.1 now also explicitly owns the
 automatic T0 runtime path so a fully agent-driven roast does not depend on
-`mark_beans_added` as the primary T0 path when auto-T0 is enabled. E4.1-S1
+`mark_beans_added` as the primary T0 path when auto-T0 is enabled. T0 is beans
+added: the automatic path should track the max preheat/charge bean temperature
+and record `beans_added` when current bean temperature drops from that max by
+the configured threshold; the pre-drop max is the charge temperature. E4.1-S1
 wires `start_roast_session`, `set_heat`, `set_fan`, `drop_beans`,
 `start_cooling`, and `stop_cooling` to the configured `RoasterDriver` boundary
 while preserving the default mock path and one-session store semantics.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -88,22 +88,31 @@ roast, adjust the configured roaster through MCP tools, read current device and
 session state, and know whether first crack has happened. E4.1 covers
 driver-backed MCP control tools, current roaster state exposure, released ONNX
 detector backend construction, session-owned first-crack detector lifecycle, and
-operational MCP readiness tests/docs. E4.1-S1 wires `start_roast_session`,
-`set_heat`, `set_fan`, `drop_beans`, `start_cooling`, and `stop_cooling` to the
-configured `RoasterDriver` boundary while preserving the default mock path and
-one-session store semantics. `drop_beans` is now the normal MCP path for drop
-and cooling transition, and invalid phase calls are rejected before driver
-commands are sent. `mark_beans_added` and
-`mark_first_crack` remain explicit override tools, while automatic T0 and
-first-crack detection are internal runtime paths. `drop_beans` is the normal
-agent/operator command for drop and cooling transition; `start_cooling` is an
-advanced recovery/manual control rather than the normal roast flow. E4.1-S2
+operational MCP readiness tests/docs. E4.1 now also explicitly owns the
+automatic T0 runtime path so a fully agent-driven roast does not depend on
+`mark_beans_added` as the primary T0 path when auto-T0 is enabled. E4.1-S1
+wires `start_roast_session`, `set_heat`, `set_fan`, `drop_beans`,
+`start_cooling`, and `stop_cooling` to the configured `RoasterDriver` boundary
+while preserving the default mock path and one-session store semantics.
+`drop_beans` is now the normal MCP path for drop and cooling transition, and
+invalid phase calls are rejected before driver commands are sent.
+`mark_beans_added` and `mark_first_crack` remain explicit override tools, while
+automatic T0 and first-crack detection are internal runtime paths. `drop_beans`
+is the normal agent/operator command for drop and cooling transition;
+`start_cooling` is an advanced recovery/manual control rather than the normal
+roast flow. E4.1-S2
 expands `get_roast_state` with the current configured-device state from
 `RoasterDriver.read_state()`, authoritative UTC and monotonic lifecycle event
 timestamps, and a structured first-crack status for operator decisions. Driver
 state-read failures surface clearly and do not mutate session history. Epic 5
 remains focused on telemetry buffering, derived metrics, and final log/export
 schemas.
+
+Epic 7 now includes a final end-to-end agent roast validation story that uses a
+real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
+first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
+surface to prove the release candidate can support full roasts with recorded
+evidence.
 
 The next story is E4.1-S3: add the released-artifact ONNX first-crack detector
 backend.


### PR DESCRIPTION
## Summary
- add E4.1-S6 for the automatic T0 runtime path so agent-driven roasts do not depend on mark_beans_added as the primary path when enabled
- add E7-S6 for end-to-end agent roast validation with configured Hottop hardware, real audio, released Hugging Face ONNX first-crack artifacts, and correct stats/log evidence
- update the issue index, epic state, registry, and E4.1-S2 session summary

## Validation
- Docs-only roadmap/state update; no code validation run.

Created issues:
- #111
- #112