### PR TITLE
E4.1-S3: Add released-artifact ONNX detector backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,12 @@ Current first-crack defaults are kept safe for local development:
 - `precision: int8`
 - `repo_id: syamaner/coffee-first-crack-detection`
 
-That default keeps local setup free from Hugging Face network access until first-crack runtime stories are implemented.
+That default keeps local setup free from Hugging Face network access until
+audio mode is deliberately configured.
+When `first_crack.mode: audio` is deliberately configured, RoastPilot consumes
+the released ONNX artifacts with ONNX Runtime and the released AST preprocessor
+config with `transformers.ASTFeatureExtractor`; model training, export, and Hub
+publishing remain outside this repository.
 
 ## Log Export
 

--- a/docs/session-summaries/2026-05-18-e4-1-s3-released-onnx-detector-backend.md
+++ b/docs/session-summaries/2026-05-18-e4-1-s3-released-onnx-detector-backend.md
@@ -1,0 +1,123 @@
+# E4.1-S3 Released ONNX Detector Backend Session
+
+## Scope
+
+This session resumed after `PR #113` for the full-roast readiness roadmap
+update was merged, `PR #110` for `E4.1-S2` was merged, issue `#105` was
+closed, and issues `#111` and `#112` existed. Work started from updated `main`
+on branch `feature/106-add-released-artifact-onnx-first-crack-detector-backend`
+for issue `#106`, `E4.1-S3: Add released-artifact ONNX first-crack detector
+backend`.
+
+The story goal was to add the released-artifact ONNX first-crack detector
+backend while preserving the mock default, Epic 2 one-session store boundary,
+MCP semantics, fail-closed safety behavior, coverage workflow, Epic 3 Hottop
+validation boundary, E4.1-S1 configured-driver control wiring, E4.1-S2
+`get_roast_state` device/status response shape, and the E4.1-S6 automatic T0
+story boundary.
+
+## Context Usage
+
+Final context snapshot supplied by the operator after confirming no PR feedback:
+
+- Context window: `45% left (147K used / 258K)`
+- 5h limit: `98% left`, resets `01:13 on 19 May`
+- Weekly limit: `93% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `01:23 on 19 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `20:23 on 25 May`
+- Warning: limits may be stale; run `/status` again shortly.
+
+## Pre-Story Verification
+
+Before starting E4.1-S3:
+
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding through the roadmap
+  update.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/github-issues.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-18-e4-1-s2-expose-roaster-device-state.md`,
+  and GitHub issue `#106`.
+- Created branch
+  `feature/106-add-released-artifact-onnx-first-crack-detector-backend`.
+
+## Implementation
+
+Updated:
+
+- `src/coffee_roaster_mcp/detector.py`
+- `tests/test_detector.py`
+- `pyproject.toml`
+- `README.md`
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+Behavior implemented:
+
+- Added `OnnxFirstCrackDetectorBackend` for released first-crack ONNX artifacts.
+- Added `build_released_onnx_first_crack_detector_backend(...)` for already
+  resolved detector artifacts.
+- Added `build_released_onnx_first_crack_detector_adapter(...)` so
+  `first_crack.mode: audio` resolves configured INT8/FP32 artifacts through the
+  existing Hugging Face/local resolver boundary before backend construction.
+- The backend loads the precision-specific `preprocessor_config.json`, builds a
+  local `transformers.ASTFeatureExtractor`, creates an ONNX Runtime CPU session
+  for the resolved ONNX model, and converts logits into the existing detector
+  output confidence path.
+- Runtime dependencies are lazy at backend construction time, so mock/default
+  config does not import or start ONNX Runtime or Transformers.
+- Added declared runtime dependencies for `onnxruntime` and `transformers`.
+
+Fail-fast behavior added:
+
+- Rejects non-audio mode for the released ONNX backend.
+- Rejects invalid `first_crack.onnx_threads`.
+- Fails clearly for missing, malformed, non-object, or invalid
+  `preprocessor_config.json`.
+- Fails clearly when ONNX Runtime or `ASTFeatureExtractor` is unavailable.
+- Rejects sample-rate mismatches between the audio window and preprocessor
+  config.
+- Rejects feature-extractor output without `input_values`, ONNX models without
+  inputs, empty outputs, empty logits, and non-numeric logits.
+
+Out of scope kept out:
+
+- Session-owned detector startup or automatic first-crack detector lifecycle.
+- Audio capture lifecycle wiring.
+- Automatic T0 implementation.
+- Rolling telemetry metrics and final log schemas.
+- Model training, ONNX export, Hugging Face sync, real microphone validation,
+  live Hottop validation, or broad release validation.
+
+## Validation
+
+- Ran `./.venv/bin/python -m pytest tests/test_detector.py tests/test_artifacts.py`:
+  `43 passed`.
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `272 passed`, required coverage `90.0%` reached, total coverage `90.45%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
+- GitHub CI for `PR #114` passed `Checks` and `Build Package`.
+
+## Pull Request Status
+
+`PR #114` is open at
+<https://github.com/syamaner/coffee-roaster-mcp/pull/114>. At summary time:
+
+- PR state: open.
+- Merge state: clean and mergeable.
+- Review comments: none.
+- Reviews: none.
+- Branch:
+  `feature/106-add-released-artifact-onnx-first-crack-detector-backend`.
+- Commits before this summary:
+  - `ea5aed1 feat: add released onnx detector backend`
+
+## Handoff
+
+Durable state now points to `E4.1-S4`, issue `#107`, for starting the
+first-crack detection runtime with roast sessions. Continue to preserve normal
+CI as mock-safe: no Hottop hardware, microphone, model download, or network
+should be required.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4.1-S3`
-- Current target: Add released-artifact ONNX first-crack detector backend
+- Active story: `E4.1-S4`
+- Current target: Start first-crack detection runtime with roast sessions
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -153,6 +153,16 @@ The first implementation milestone is a mock vertical slice that requires no roa
   the runtime should track the max preheat/charge bean temperature before T0,
   then record `beans_added` when current bean temperature drops from that max by
   the configured threshold. The pre-drop max is the charge temperature.
+- `E4.1-S3` adds the released-artifact ONNX first-crack detector backend
+  without starting any session-owned detector loop. `first_crack.mode: audio`
+  can now resolve the configured precision-specific Hugging Face artifacts,
+  load `onnx/{precision}/preprocessor_config.json` through
+  `transformers.ASTFeatureExtractor`, create an ONNX Runtime CPU session for the
+  resolved ONNX model using configured thread limits, and adapt model logits
+  into existing detector outputs with first-crack confidence. Tests use fake
+  artifact paths, fake feature extraction, and fake ONNX sessions so normal CI
+  remains mock-safe and requires no model download, microphone, Hottop hardware,
+  or network.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -367,7 +377,7 @@ first crack has happened through MCP tools.
     crack, bean drop, cooling start, and cooling stop, without implementing Epic
     5 rolling metrics.
 
-- [ ] `E4.1-S3` Add released-artifact ONNX first-crack detector backend.
+- [x] `E4.1-S3` Add released-artifact ONNX first-crack detector backend.
   - Done when `first_crack.mode: audio` can construct a detector backend from
     the resolved Hugging Face ONNX model and feature-extractor config using the
     existing released-artifact resolver boundary, with mock-safe tests and no
@@ -1105,6 +1115,33 @@ After completing a story:
   - Ran `./.venv/bin/python -m pytest tests/test_package.py`: 15 passed.
   - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
     253 passed, required coverage `90.0%` reached, total coverage `90.56%`.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E4.1-S3:
+  - Added `OnnxFirstCrackDetectorBackend` and
+    `build_released_onnx_first_crack_detector_adapter(...)` so
+    `first_crack.mode: audio` can resolve the configured released Hugging Face
+    detector artifacts, load the precision-specific
+    `preprocessor_config.json`, construct an ONNX Runtime CPU session for the
+    resolved ONNX model, and feed output through the existing detector adapter
+    metadata path.
+  - Added lazy, clearly failing runtime dependency boundaries for
+    `onnxruntime` and `transformers.ASTFeatureExtractor`; default mock
+    configuration still does not import or start either dependency.
+  - Added fake-backed tests for INT8/FP32 artifact resolution, ONNX session
+    construction, AST feature-extractor construction, confidence parsing,
+    sample-rate validation, missing/invalid preprocessor config, missing model
+    inputs, empty outputs, and dependency failures without requiring model
+    downloads, real ONNX files, microphone input, Hottop hardware, or network.
+  - Kept session-owned detector startup, audio capture lifecycle wiring,
+    automatic T0, rolling metrics, final log schemas, model training, ONNX
+    export, Hugging Face sync, real microphone validation, live Hottop
+    validation, and broad release validation out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_detector.py tests/test_artifacts.py`:
+    43 passed.
+  - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+    272 passed, required coverage `90.0%` reached, total coverage `90.45%`.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -111,14 +111,25 @@ state-read failures surface clearly and do not mutate session history. Epic 5
 remains focused on telemetry buffering, derived metrics, and final log/export
 schemas.
 
+E4.1-S3 added the released-artifact ONNX first-crack detector backend without
+starting any session-owned detector lifecycle. `first_crack.mode: audio` can
+now construct an ONNX detector adapter from the existing released-artifact
+resolver boundary: configured INT8/FP32 artifacts resolve from Hugging Face or
+`local_model_dir`, the precision-specific `preprocessor_config.json` is loaded
+through `transformers.ASTFeatureExtractor`, and the resolved ONNX model is
+opened through an ONNX Runtime CPU session using configured thread limits.
+Backend output is adapted into the existing detector confidence metadata path.
+Normal CI remains mock-safe through fake artifact paths, fake feature
+extraction, and fake ONNX sessions.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E4.1-S3: add the released-artifact ONNX first-crack detector
-backend.
+The next story is E4.1-S4: start first-crack detection runtime with roast
+sessions.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,11 @@ classifiers = [
 dependencies = [
   "huggingface_hub>=0.23,<1",
   "mcp>=1.0.0,<2",
+  "onnxruntime>=1.18,<2",
   "pyserial>=3.5",
   "PyYAML>=6.0.2",
-  "sounddevice>=0.5,<1"
+  "sounddevice>=0.5,<1",
+  "transformers>=4.40,<5"
 ]
 
 [project.urls]

--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -2,16 +2,25 @@
 
 from __future__ import annotations
 
+import json
 import math
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Literal, Protocol
+from importlib import import_module
+from pathlib import Path
+from typing import Literal, Protocol, cast
 
-from coffee_roaster_mcp.artifacts import ResolvedDetectorArtifacts
+from coffee_roaster_mcp.artifacts import (
+    HuggingFaceDownloader,
+    ResolvedDetectorArtifacts,
+    resolve_first_crack_detector_artifacts,
+)
 from coffee_roaster_mcp.audio import AudioWindow
 from coffee_roaster_mcp.config import FirstCrackConfig, ModelPrecision
 from coffee_roaster_mcp.session import RoastEvent, RoastSession, RoastSessionStore
 
 FirstCrackDetectorEventKind = Literal["first_crack_detected"]
+DEFAULT_FIRST_CRACK_CONFIDENCE_THRESHOLD = 0.9
 
 
 class FirstCrackDetectorError(RuntimeError):
@@ -24,6 +33,46 @@ class FirstCrackDetectorBackend(Protocol):
     def detect(self, window: AudioWindow) -> FirstCrackDetectorOutput:
         """Run detection for one audio window."""
         ...
+
+
+class OnnxInputInfo(Protocol):
+    """Input metadata exposed by an ONNX Runtime inference session."""
+
+    name: str
+
+
+class OnnxInferenceSession(Protocol):
+    """Narrow ONNX Runtime session protocol used by the detector backend."""
+
+    def get_inputs(self) -> Sequence[OnnxInputInfo]:
+        """Return model input metadata."""
+        ...
+
+    def run(
+        self,
+        output_names: Sequence[str] | None,
+        input_feed: Mapping[str, object],
+    ) -> Sequence[object]:
+        """Run one ONNX inference call."""
+        ...
+
+
+class OnnxFeatureExtractor(Protocol):
+    """Callable feature extractor loaded from a resolved preprocessor config."""
+
+    def __call__(
+        self,
+        raw_speech: Sequence[Sequence[float]],
+        *,
+        sampling_rate: int,
+        return_tensors: str,
+    ) -> Mapping[str, object]:
+        """Convert raw mono audio into model input tensors."""
+        ...
+
+
+OnnxSessionFactory = Callable[[Path, int], OnnxInferenceSession]
+OnnxFeatureExtractorFactory = Callable[[Path], OnnxFeatureExtractor]
 
 
 @dataclass(frozen=True)
@@ -125,6 +174,57 @@ class FirstCrackDetectorAdapter:
 
 
 @dataclass(frozen=True)
+class OnnxPreprocessorConfig:
+    """Validated detector preprocessor configuration metadata."""
+
+    sampling_rate: int | None
+
+
+@dataclass(frozen=True)
+class OnnxFirstCrackDetectorBackend:
+    """ONNX Runtime backend for released first-crack detector artifacts."""
+
+    session: OnnxInferenceSession
+    feature_extractor: OnnxFeatureExtractor
+    preprocessor_config: OnnxPreprocessorConfig
+    confidence_threshold: float = DEFAULT_FIRST_CRACK_CONFIDENCE_THRESHOLD
+
+    def detect(self, window: AudioWindow) -> FirstCrackDetectorOutput:
+        """Run ONNX inference for one audio window."""
+        if (
+            self.preprocessor_config.sampling_rate is not None
+            and window.sample_rate != self.preprocessor_config.sampling_rate
+        ):
+            raise FirstCrackDetectorError(
+                "Audio window sample_rate "
+                f"{window.sample_rate} does not match first-crack preprocessor "
+                f"sampling_rate {self.preprocessor_config.sampling_rate}."
+            )
+
+        inputs = self.feature_extractor(
+            [list(window.samples)],
+            sampling_rate=window.sample_rate,
+            return_tensors="np",
+        )
+        model_input = inputs.get("input_values")
+        if model_input is None:
+            raise FirstCrackDetectorError(
+                "First-crack feature extractor output must include 'input_values'."
+            )
+
+        input_infos = self.session.get_inputs()
+        if not input_infos:
+            raise FirstCrackDetectorError("First-crack ONNX model exposes no inputs.")
+
+        outputs = self.session.run(None, {input_infos[0].name: model_input})
+        confidence = _first_crack_confidence(outputs)
+        return FirstCrackDetectorOutput(
+            confirmed=confidence >= self.confidence_threshold,
+            confidence=confidence,
+        )
+
+
+@dataclass(frozen=True)
 class FirstCrackTimelineIntegrationResult:
     """Result of applying one confirmed detector event to the session timeline.
 
@@ -149,6 +249,79 @@ def build_first_crack_detector_adapter(
         artifacts=artifacts,
         backend=backend,
     )
+
+
+def build_released_onnx_first_crack_detector_backend(
+    config: FirstCrackConfig,
+    artifacts: ResolvedDetectorArtifacts,
+    *,
+    session_factory: OnnxSessionFactory | None = None,
+    feature_extractor_factory: OnnxFeatureExtractorFactory | None = None,
+) -> OnnxFirstCrackDetectorBackend:
+    """Build the released-artifact ONNX first-crack detector backend.
+
+    Args:
+        config: First-crack runtime configuration. The released ONNX backend is
+            only valid for `first_crack.mode: audio`.
+        artifacts: Resolved ONNX model and precision-specific preprocessor
+            config artifacts.
+        session_factory: Optional test double for ONNX Runtime session creation.
+        feature_extractor_factory: Optional test double for local feature
+            extractor loading.
+
+    Returns:
+        ONNX detector backend ready to process audio windows.
+
+    Raises:
+        FirstCrackDetectorError: If mode, artifacts, preprocessor config, or
+            runtime dependencies are invalid.
+    """
+    if config.mode != "audio":
+        raise FirstCrackDetectorError(
+            "Released ONNX first-crack detector backend requires first_crack.mode 'audio'."
+        )
+    if config.onnx_threads <= 0:
+        raise FirstCrackDetectorError("first_crack.onnx_threads must be greater than 0.")
+
+    preprocessor_config = _load_onnx_preprocessor_config(
+        artifacts.feature_extractor_config.local_path
+    )
+    create_session = session_factory or _build_onnx_runtime_session
+    create_feature_extractor = feature_extractor_factory or _build_ast_feature_extractor
+    return OnnxFirstCrackDetectorBackend(
+        session=create_session(artifacts.onnx_model.local_path, config.onnx_threads),
+        feature_extractor=create_feature_extractor(artifacts.feature_extractor_config.local_path),
+        preprocessor_config=preprocessor_config,
+    )
+
+
+def build_released_onnx_first_crack_detector_adapter(
+    config: FirstCrackConfig,
+    *,
+    downloader: HuggingFaceDownloader | None = None,
+    session_factory: OnnxSessionFactory | None = None,
+    feature_extractor_factory: OnnxFeatureExtractorFactory | None = None,
+) -> FirstCrackDetectorAdapter:
+    """Resolve released detector artifacts and build the ONNX detector adapter.
+
+    Args:
+        config: First-crack runtime configuration.
+        downloader: Optional test double for Hugging Face artifact resolution.
+        session_factory: Optional test double for ONNX Runtime session creation.
+        feature_extractor_factory: Optional test double for local feature
+            extractor loading.
+
+    Returns:
+        Detector adapter backed by the released-artifact ONNX runtime backend.
+    """
+    artifacts = resolve_first_crack_detector_artifacts(config, downloader=downloader)
+    backend = build_released_onnx_first_crack_detector_backend(
+        config,
+        artifacts,
+        session_factory=session_factory,
+        feature_extractor_factory=feature_extractor_factory,
+    )
+    return build_first_crack_detector_adapter(config, artifacts, backend)
 
 
 def integrate_first_crack_window_with_session(
@@ -218,3 +391,133 @@ def _validate_optional_confidence(confidence: float | None) -> float | None:
     if not math.isfinite(normalized) or not 0.0 <= normalized <= 1.0:
         raise FirstCrackDetectorError("detector output confidence must be between 0 and 1.")
     return normalized
+
+
+def _load_onnx_preprocessor_config(path: Path) -> OnnxPreprocessorConfig:
+    try:
+        raw_config = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise FirstCrackDetectorError(
+            f"Could not read first-crack preprocessor config {path}: {exc}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise FirstCrackDetectorError(
+            f"Could not parse first-crack preprocessor config {path}: {exc}"
+        ) from exc
+
+    if not isinstance(raw_config, Mapping):
+        raise FirstCrackDetectorError("First-crack preprocessor config must be a JSON object.")
+    raw_mapping = cast(Mapping[str, object], raw_config)
+    sampling_rate = raw_mapping.get("sampling_rate")
+    if sampling_rate is None:
+        return OnnxPreprocessorConfig(sampling_rate=None)
+    if isinstance(sampling_rate, bool) or not isinstance(sampling_rate, int) or sampling_rate <= 0:
+        raise FirstCrackDetectorError(
+            "First-crack preprocessor config sampling_rate must be a positive integer."
+        )
+    return OnnxPreprocessorConfig(sampling_rate=sampling_rate)
+
+
+def _build_onnx_runtime_session(model_path: Path, onnx_threads: int) -> OnnxInferenceSession:
+    try:
+        runtime_module = import_module("onnxruntime")
+    except ImportError as exc:
+        raise FirstCrackDetectorError(
+            "first_crack.mode 'audio' requires the onnxruntime package to run released "
+            "ONNX artifacts."
+        ) from exc
+
+    try:
+        session_options = runtime_module.SessionOptions()
+        session_options.intra_op_num_threads = onnx_threads
+        session_options.inter_op_num_threads = 1
+        session = runtime_module.InferenceSession(
+            str(model_path),
+            sess_options=session_options,
+            providers=["CPUExecutionProvider"],
+        )
+    except Exception as exc:
+        raise FirstCrackDetectorError(
+            f"Could not initialize first-crack ONNX Runtime session for {model_path}: {exc}"
+        ) from exc
+    return cast(OnnxInferenceSession, session)
+
+
+def _build_ast_feature_extractor(preprocessor_config_path: Path) -> OnnxFeatureExtractor:
+    try:
+        transformers_module = import_module("transformers")
+        extractor_type = transformers_module.ASTFeatureExtractor
+    except (AttributeError, ImportError) as exc:
+        raise FirstCrackDetectorError(
+            "first_crack.mode 'audio' requires transformers.ASTFeatureExtractor to load "
+            "the released preprocessor config."
+        ) from exc
+
+    try:
+        extractor = extractor_type.from_pretrained(str(preprocessor_config_path.parent))
+    except Exception as exc:
+        raise FirstCrackDetectorError(
+            "Could not initialize first-crack AST feature extractor from "
+            f"{preprocessor_config_path}: {exc}"
+        ) from exc
+    return cast(OnnxFeatureExtractor, extractor)
+
+
+def _first_crack_confidence(outputs: Sequence[object]) -> float:
+    if not outputs:
+        raise FirstCrackDetectorError("First-crack ONNX model returned no outputs.")
+
+    try:
+        rows = _logit_rows(outputs[0])
+    except Exception as exc:
+        raise FirstCrackDetectorError(
+            f"First-crack ONNX output could not be interpreted as logits: {exc}"
+        ) from exc
+
+    if not rows or not rows[0]:
+        raise FirstCrackDetectorError("First-crack ONNX output logits must not be empty.")
+
+    first_row = rows[0]
+    if len(first_row) == 1:
+        value = float(first_row[0])
+        confidence = 1.0 / (1.0 + math.exp(-value))
+    else:
+        first_crack_index = 1
+        max_logit = max(first_row)
+        exp_logits = [math.exp(logit - max_logit) for logit in first_row]
+        exp_sum = sum(exp_logits)
+        confidence = exp_logits[first_crack_index] / exp_sum
+
+    if not math.isfinite(confidence) or not 0.0 <= confidence <= 1.0:
+        raise FirstCrackDetectorError(
+            "First-crack ONNX output confidence must be finite and between 0 and 1."
+        )
+    return confidence
+
+
+def _logit_rows(value: object) -> list[list[float]]:
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        value = tolist()
+
+    if isinstance(value, bool):
+        raise TypeError("boolean logits are not supported")
+    if isinstance(value, (int, float)):
+        return [[float(value)]]
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise TypeError("logits must be numeric or a numeric sequence")
+
+    raw_items = list(cast(Sequence[object], value))
+    if not raw_items:
+        return []
+    if all(_is_number(item) for item in raw_items):
+        return [[float(cast(int | float, item)) for item in raw_items]]
+
+    rows: list[list[float]] = []
+    for item in raw_items:
+        rows.extend(_logit_rows(item))
+    return rows
+
+
+def _is_number(value: object) -> bool:
+    return not isinstance(value, bool) and isinstance(value, (int, float))

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,9 +1,11 @@
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
 import pytest
 
+import coffee_roaster_mcp.detector as detector_module
 from coffee_roaster_mcp.artifacts import ResolvedArtifact, ResolvedDetectorArtifacts
 from coffee_roaster_mcp.audio import AudioWindow
 from coffee_roaster_mcp.config import FirstCrackConfig
@@ -11,7 +13,12 @@ from coffee_roaster_mcp.detector import (
     FirstCrackDetectorAdapter,
     FirstCrackDetectorError,
     FirstCrackDetectorOutput,
+    OnnxFeatureExtractor,
+    OnnxInferenceSession,
+    OnnxInputInfo,
     build_first_crack_detector_adapter,
+    build_released_onnx_first_crack_detector_adapter,
+    build_released_onnx_first_crack_detector_backend,
 )
 
 
@@ -35,6 +42,66 @@ class BadConfirmationBackend:
                 detected_at_monotonic_seconds=None,
             ),
         )
+
+
+class FakeInputInfo:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class FakeOnnxSession:
+    def __init__(self, logits: object = ((-3.0, 3.0),)) -> None:
+        self.logits = logits
+        self.input_feed: list[dict[str, object]] = []
+
+    def get_inputs(self) -> tuple[OnnxInputInfo, ...]:
+        return (FakeInputInfo("input_values"),)
+
+    def run(
+        self,
+        output_names: Sequence[str] | None,
+        input_feed: Mapping[str, object],
+    ) -> tuple[object, ...]:
+        self.input_feed.append(dict(input_feed))
+        return (self.logits,)
+
+
+class EmptyInputOnnxSession(FakeOnnxSession):
+    def get_inputs(self) -> tuple[OnnxInputInfo, ...]:
+        return ()
+
+
+class FakeFeatureExtractor:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(
+        self,
+        raw_speech: Sequence[Sequence[float]],
+        *,
+        sampling_rate: int,
+        return_tensors: str,
+    ) -> dict[str, object]:
+        self.calls.append(
+            {
+                "raw_speech": raw_speech,
+                "sampling_rate": sampling_rate,
+                "return_tensors": return_tensors,
+            }
+        )
+        return {"input_values": (("features",),)}
+
+
+class MissingInputFeatureExtractor(FakeFeatureExtractor):
+    def __call__(
+        self,
+        raw_speech: Sequence[Sequence[float]],
+        *,
+        sampling_rate: int,
+        return_tensors: str,
+    ) -> dict[str, object]:
+        super().__call__(raw_speech, sampling_rate=sampling_rate, return_tensors=return_tensors)
+        return {"not_input_values": ()}
 
 
 def test_detector_adapter_ignores_unconfirmed_detector_output() -> None:
@@ -165,16 +232,340 @@ def test_detector_adapter_rejects_non_boolean_confirmation() -> None:
         adapter.process_window(_audio_window())
 
 
+def test_released_onnx_backend_builds_from_resolved_artifacts(tmp_path: Path) -> None:
+    artifacts = _resolved_detector_artifacts_with_files(tmp_path)
+    config = FirstCrackConfig(mode="audio", onnx_threads=4)
+    session = FakeOnnxSession()
+    extractor = FakeFeatureExtractor()
+    session_calls: list[tuple[Path, int]] = []
+    extractor_calls: list[Path] = []
+
+    def session_factory(model_path: Path, onnx_threads: int) -> OnnxInferenceSession:
+        session_calls.append((model_path, onnx_threads))
+        return session
+
+    def extractor_factory(preprocessor_config_path: Path) -> OnnxFeatureExtractor:
+        extractor_calls.append(preprocessor_config_path)
+        return extractor
+
+    backend = build_released_onnx_first_crack_detector_backend(
+        config,
+        artifacts,
+        session_factory=session_factory,
+        feature_extractor_factory=extractor_factory,
+    )
+
+    output = backend.detect(_audio_window(sample_rate=16_000))
+
+    assert output.confirmed is True
+    assert output.confidence is not None
+    assert abs(output.confidence - 0.997527) < 0.000001
+    assert session_calls == [(artifacts.onnx_model.local_path, 4)]
+    assert extractor_calls == [artifacts.feature_extractor_config.local_path]
+    assert extractor.calls == [
+        {
+            "raw_speech": [[0.1, 0.2, 0.3, 0.4]],
+            "sampling_rate": 16_000,
+            "return_tensors": "np",
+        }
+    ]
+    assert session.input_feed == [{"input_values": (("features",),)}]
+
+
+def test_released_onnx_adapter_resolves_artifacts_before_backend(tmp_path: Path) -> None:
+    artifacts = _resolved_detector_artifacts_with_files(tmp_path)
+    calls: list[dict[str, str | None]] = []
+
+    def downloader(*, repo_id: str, filename: str, revision: str | None) -> str:
+        calls.append({"repo_id": repo_id, "filename": filename, "revision": revision})
+        if filename == "onnx/fp32/model.onnx":
+            return str(artifacts.onnx_model.local_path)
+        if filename == "onnx/fp32/preprocessor_config.json":
+            return str(artifacts.feature_extractor_config.local_path)
+        raise AssertionError(f"unexpected artifact {filename}")
+
+    adapter = build_released_onnx_first_crack_detector_adapter(
+        FirstCrackConfig(mode="audio", precision="fp32", revision="release-sha"),
+        downloader=downloader,
+        session_factory=lambda _path, _threads: FakeOnnxSession(),
+        feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+    )
+
+    event = adapter.process_window(_audio_window(sample_rate=16_000))
+
+    assert event is not None
+    assert event.precision == "fp32"
+    assert event.repo_id == "syamaner/coffee-first-crack-detection"
+    assert event.revision == "release-sha"
+    assert event.onnx_model_filename == "onnx/fp32/model.onnx"
+    assert event.feature_extractor_filename == "onnx/fp32/preprocessor_config.json"
+    assert event.confidence is not None
+    assert calls == [
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "onnx/fp32/model.onnx",
+            "revision": "release-sha",
+        },
+        {
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "filename": "onnx/fp32/preprocessor_config.json",
+            "revision": "release-sha",
+        },
+    ]
+
+
+def test_released_onnx_backend_returns_unconfirmed_below_threshold(tmp_path: Path) -> None:
+    backend = build_released_onnx_first_crack_detector_backend(
+        FirstCrackConfig(mode="audio"),
+        _resolved_detector_artifacts_with_files(tmp_path),
+        session_factory=lambda _path, _threads: FakeOnnxSession(((4.0, -4.0),)),
+        feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+    )
+
+    output = backend.detect(_audio_window(sample_rate=16_000))
+
+    assert output.confirmed is False
+    assert output.confidence is not None
+    assert abs(output.confidence - 0.00033535) < 0.000001
+
+
+def test_released_onnx_backend_rejects_non_audio_mode(tmp_path: Path) -> None:
+    with pytest.raises(FirstCrackDetectorError, match="mode 'audio'"):
+        build_released_onnx_first_crack_detector_backend(
+            FirstCrackConfig(mode="disabled"),
+            _resolved_detector_artifacts_with_files(tmp_path),
+            session_factory=lambda _path, _threads: FakeOnnxSession(),
+            feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+        )
+
+
+def test_released_onnx_backend_rejects_invalid_onnx_threads(tmp_path: Path) -> None:
+    with pytest.raises(FirstCrackDetectorError, match="onnx_threads"):
+        build_released_onnx_first_crack_detector_backend(
+            FirstCrackConfig(mode="audio", onnx_threads=0),
+            _resolved_detector_artifacts_with_files(tmp_path),
+            session_factory=lambda _path, _threads: FakeOnnxSession(),
+            feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+        )
+
+
+def test_released_onnx_backend_rejects_invalid_preprocessor_config(tmp_path: Path) -> None:
+    artifacts = _resolved_detector_artifacts_with_files(
+        tmp_path,
+        preprocessor_config='{"sampling_rate": false}',
+    )
+
+    with pytest.raises(FirstCrackDetectorError, match="sampling_rate"):
+        build_released_onnx_first_crack_detector_backend(
+            FirstCrackConfig(mode="audio"),
+            artifacts,
+            session_factory=lambda _path, _threads: FakeOnnxSession(),
+            feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+        )
+
+
+def test_released_onnx_backend_rejects_missing_preprocessor_config(tmp_path: Path) -> None:
+    artifacts = _resolved_detector_artifacts_with_files(tmp_path)
+    artifacts.feature_extractor_config.local_path.unlink()
+
+    with pytest.raises(FirstCrackDetectorError, match="Could not read"):
+        build_released_onnx_first_crack_detector_backend(
+            FirstCrackConfig(mode="audio"),
+            artifacts,
+            session_factory=lambda _path, _threads: FakeOnnxSession(),
+            feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+        )
+
+
+def test_released_onnx_backend_rejects_malformed_preprocessor_config(tmp_path: Path) -> None:
+    artifacts = _resolved_detector_artifacts_with_files(tmp_path, preprocessor_config="{")
+
+    with pytest.raises(FirstCrackDetectorError, match="Could not parse"):
+        build_released_onnx_first_crack_detector_backend(
+            FirstCrackConfig(mode="audio"),
+            artifacts,
+            session_factory=lambda _path, _threads: FakeOnnxSession(),
+            feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+        )
+
+
+def test_released_onnx_backend_rejects_non_object_preprocessor_config(tmp_path: Path) -> None:
+    artifacts = _resolved_detector_artifacts_with_files(tmp_path, preprocessor_config="[]")
+
+    with pytest.raises(FirstCrackDetectorError, match="JSON object"):
+        build_released_onnx_first_crack_detector_backend(
+            FirstCrackConfig(mode="audio"),
+            artifacts,
+            session_factory=lambda _path, _threads: FakeOnnxSession(),
+            feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+        )
+
+
+def test_released_onnx_backend_allows_preprocessor_without_sampling_rate(
+    tmp_path: Path,
+) -> None:
+    backend = build_released_onnx_first_crack_detector_backend(
+        FirstCrackConfig(mode="audio"),
+        _resolved_detector_artifacts_with_files(tmp_path, preprocessor_config="{}"),
+        session_factory=lambda _path, _threads: FakeOnnxSession((10.0,)),
+        feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+    )
+
+    output = backend.detect(_audio_window(sample_rate=8_000))
+
+    assert output.confirmed is True
+    assert output.confidence is not None
+    assert abs(output.confidence - 0.9999546) < 0.000001
+
+
+def test_released_onnx_backend_rejects_sample_rate_mismatch(tmp_path: Path) -> None:
+    backend = build_released_onnx_first_crack_detector_backend(
+        FirstCrackConfig(mode="audio"),
+        _resolved_detector_artifacts_with_files(tmp_path),
+        session_factory=lambda _path, _threads: FakeOnnxSession(),
+        feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+    )
+
+    with pytest.raises(FirstCrackDetectorError, match="sample_rate"):
+        backend.detect(_audio_window(sample_rate=8_000))
+
+
+def test_released_onnx_backend_rejects_missing_feature_extractor_input(
+    tmp_path: Path,
+) -> None:
+    backend = build_released_onnx_first_crack_detector_backend(
+        FirstCrackConfig(mode="audio"),
+        _resolved_detector_artifacts_with_files(tmp_path),
+        session_factory=lambda _path, _threads: FakeOnnxSession(),
+        feature_extractor_factory=lambda _path: MissingInputFeatureExtractor(),
+    )
+
+    with pytest.raises(FirstCrackDetectorError, match="input_values"):
+        backend.detect(_audio_window(sample_rate=16_000))
+
+
+def test_released_onnx_backend_rejects_model_without_inputs(tmp_path: Path) -> None:
+    backend = build_released_onnx_first_crack_detector_backend(
+        FirstCrackConfig(mode="audio"),
+        _resolved_detector_artifacts_with_files(tmp_path),
+        session_factory=lambda _path, _threads: EmptyInputOnnxSession(),
+        feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+    )
+
+    with pytest.raises(FirstCrackDetectorError, match="no inputs"):
+        backend.detect(_audio_window(sample_rate=16_000))
+
+
+def test_released_onnx_backend_rejects_empty_model_outputs(tmp_path: Path) -> None:
+    class EmptyOutputOnnxSession(FakeOnnxSession):
+        def run(
+            self,
+            output_names: Sequence[str] | None,
+            input_feed: Mapping[str, object],
+        ) -> tuple[object, ...]:
+            return ()
+
+    backend = build_released_onnx_first_crack_detector_backend(
+        FirstCrackConfig(mode="audio"),
+        _resolved_detector_artifacts_with_files(tmp_path),
+        session_factory=lambda _path, _threads: EmptyOutputOnnxSession(),
+        feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+    )
+
+    with pytest.raises(FirstCrackDetectorError, match="returned no outputs"):
+        backend.detect(_audio_window(sample_rate=16_000))
+
+
+def test_released_onnx_backend_rejects_empty_logits(tmp_path: Path) -> None:
+    backend = build_released_onnx_first_crack_detector_backend(
+        FirstCrackConfig(mode="audio"),
+        _resolved_detector_artifacts_with_files(tmp_path),
+        session_factory=lambda _path, _threads: FakeOnnxSession(()),
+        feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+    )
+
+    with pytest.raises(FirstCrackDetectorError, match="logits must not be empty"):
+        backend.detect(_audio_window(sample_rate=16_000))
+
+
+def test_released_onnx_backend_rejects_non_numeric_logits(tmp_path: Path) -> None:
+    backend = build_released_onnx_first_crack_detector_backend(
+        FirstCrackConfig(mode="audio"),
+        _resolved_detector_artifacts_with_files(tmp_path),
+        session_factory=lambda _path, _threads: FakeOnnxSession("first-crack"),
+        feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+    )
+
+    with pytest.raises(FirstCrackDetectorError, match="could not be interpreted"):
+        backend.detect(_audio_window(sample_rate=16_000))
+
+
+def test_released_onnx_backend_supports_array_like_outputs(tmp_path: Path) -> None:
+    class ArrayLikeLogits:
+        def tolist(self) -> list[list[float]]:
+            return [[-3.0, 3.0]]
+
+    backend = build_released_onnx_first_crack_detector_backend(
+        FirstCrackConfig(mode="audio"),
+        _resolved_detector_artifacts_with_files(tmp_path),
+        session_factory=lambda _path, _threads: FakeOnnxSession(ArrayLikeLogits()),
+        feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+    )
+
+    output = backend.detect(_audio_window(sample_rate=16_000))
+
+    assert output.confirmed is True
+
+
+def test_released_onnx_backend_fails_clearly_when_onnxruntime_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing_onnxruntime(name: str, package: str | None = None) -> object:
+        if name == "onnxruntime":
+            raise ImportError(name)
+        return __import__(name)
+
+    monkeypatch.setattr(detector_module, "import_module", missing_onnxruntime)
+
+    with pytest.raises(FirstCrackDetectorError, match="onnxruntime"):
+        build_released_onnx_first_crack_detector_backend(
+            FirstCrackConfig(mode="audio"),
+            _resolved_detector_artifacts_with_files(tmp_path),
+            feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+        )
+
+
+def test_released_onnx_backend_fails_clearly_when_transformers_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing_transformers(name: str, package: str | None = None) -> object:
+        if name == "transformers":
+            raise ImportError(name)
+        return __import__(name)
+
+    monkeypatch.setattr(detector_module, "import_module", missing_transformers)
+
+    with pytest.raises(FirstCrackDetectorError, match="ASTFeatureExtractor"):
+        build_released_onnx_first_crack_detector_backend(
+            FirstCrackConfig(mode="audio"),
+            _resolved_detector_artifacts_with_files(tmp_path),
+            session_factory=lambda _path, _threads: FakeOnnxSession(),
+        )
+
+
 def _audio_window(
     *,
     sequence_number: int = 3,
     started_at_monotonic_seconds: float = 10.0,
     duration_seconds: float = 1.0,
+    sample_rate: int = 4,
 ) -> AudioWindow:
     return AudioWindow(
         sequence_number=sequence_number,
         input_device="mock-audio",
-        sample_rate=4,
+        sample_rate=sample_rate,
         started_at_monotonic_seconds=started_at_monotonic_seconds,
         duration_seconds=duration_seconds,
         samples=(0.1, 0.2, 0.3, 0.4),
@@ -200,5 +591,31 @@ def _resolved_detector_artifacts(
             revision=revision,
             filename=feature_extractor_filename,
             local_path=Path("/tmp/preprocessor_config.json"),
+        ),
+    )
+
+
+def _resolved_detector_artifacts_with_files(
+    tmp_path: Path,
+    *,
+    preprocessor_config: str = '{"sampling_rate": 16000}',
+) -> ResolvedDetectorArtifacts:
+    model_path = tmp_path / "onnx" / "int8" / "model_quantized.onnx"
+    preprocessor_path = tmp_path / "onnx" / "int8" / "preprocessor_config.json"
+    model_path.parent.mkdir(parents=True)
+    model_path.write_bytes(b"fake-onnx")
+    preprocessor_path.write_text(preprocessor_config, encoding="utf-8")
+    return ResolvedDetectorArtifacts(
+        onnx_model=ResolvedArtifact(
+            repo_id="syamaner/coffee-first-crack-detection",
+            revision="release-sha",
+            filename="onnx/int8/model_quantized.onnx",
+            local_path=model_path,
+        ),
+        feature_extractor_config=ResolvedArtifact(
+            repo_id="syamaner/coffee-first-crack-detection",
+            revision="release-sha",
+            filename="onnx/int8/preprocessor_config.json",
+            local_path=preprocessor_path,
         ),
     )


### PR DESCRIPTION
## Summary
- add a released-artifact ONNX first-crack detector backend for `first_crack.mode: audio`
- resolve INT8/FP32 detector artifacts through the existing Hugging Face/local resolver boundary before backend construction
- load the precision-specific AST preprocessor config and construct an ONNX Runtime CPU session with configured thread limits
- keep tests fake-backed so CI remains mock-safe and requires no model download, microphone, Hottop hardware, or network
- update durable state docs for E4.1-S3 completion and E4.1-S4 as the next story

## Validation
- `./.venv/bin/python -m pytest tests/test_detector.py tests/test_artifacts.py`: 43 passed
- `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`: 272 passed, coverage 90.45%
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: passed
- `./.venv/bin/python -m pyright`: 0 errors

Closes #106