### PR TITLE
E4.1-S4: Start first-crack detection runtime with roast sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,12 @@ coffee-roaster-mcp hottop-validate \
   --include-emergency-stop
 ```
 
-Hardware safety matters here: command-loop cadence, packet handling, temperature units, drop behavior, cooling behavior, emergency stop, and cleanup must be validated on a supervised roaster before the Hottop path is treated as release-ready. The current MCP roast-session tools preserve their existing one-session store semantics; driver-level validation does not imply MCP heat, fan, drop, or cooling tools are live-hardware control surfaces yet.
+Hardware safety matters here: command-loop cadence, packet handling,
+temperature units, drop behavior, cooling behavior, emergency stop, and cleanup
+must be validated on a supervised roaster before the Hottop path is treated as
+release-ready. The current MCP roast-session tools call the configured driver
+boundary, so keep normal development on the mock driver unless a guarded Hottop
+validation run is explicitly intended.
 
 ## Configuration
 
@@ -278,6 +283,18 @@ When `first_crack.mode: audio` is deliberately configured, RoastPilot consumes
 the released ONNX artifacts with ONNX Runtime and the released AST preprocessor
 config with `transformers.ASTFeatureExtractor`; model training, export, and Hub
 publishing remain outside this repository.
+
+In audio mode, starting a roast session prepares the configured audio capture
+pipeline and released-artifact detector runtime. Detector windows are processed
+only after T0 is recorded and the active session is in `roasting`. Confirmed
+detector output records `first_crack_detected` once through the authoritative
+session timeline. The runtime stops when first crack is recorded automatically
+or through the explicit manual override, and also stops on drop, cooling
+completion, emergency stop, and process shutdown. Missing artifacts,
+unavailable audio capture, and detector errors are surfaced through
+`get_roast_state.first_crack_status` as `unavailable` or `faulted` rather than
+crashing normal roast controls. Disabled and manual first-crack modes do not
+start audio capture or detector runtime.
 
 ## Log Export
 

--- a/docs/session-summaries/2026-05-18-e4-1-s4-start-first-crack-runtime.md
+++ b/docs/session-summaries/2026-05-18-e4-1-s4-start-first-crack-runtime.md
@@ -1,0 +1,145 @@
+# E4.1-S4 First-Crack Runtime Session
+
+## Scope
+
+This session resumed after `PR #114` for `E4.1-S3` was squashed and merged,
+and issue `#106` was closed. Work started from updated `main` on branch
+`feature/107-start-first-crack-detection-runtime-with-roast-sessions` for issue
+`#107`, `E4.1-S4: Start first-crack detection runtime with roast sessions`.
+
+The story goal was to start and stop the configured first-crack detection
+runtime with roast sessions while preserving the mock default, Epic 2
+one-session store boundary, MCP semantics, fail-closed safety behavior,
+coverage workflow, Epic 3 Hottop validation boundary, E4.1-S1 configured-driver
+control wiring, E4.1-S2 `get_roast_state` device/status response shape,
+E4.1-S3 released-artifact ONNX backend boundary, and E4.1-S6 automatic T0 story
+boundary.
+
+## Context Usage
+
+Final context snapshot supplied by the operator after review fixes:
+
+- Context window: `35% left (173K used / 258K)`
+- 5h limit: `95% left`, resets `01:10 on 19 May`
+- Weekly limit: `93% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `02:20 on 19 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `21:20 on 25 May`
+- Warning: limits may be stale; run `/status` again shortly.
+
+## Pre-Story Verification
+
+Before starting E4.1-S4:
+
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding through the merged
+  E4.1-S3 changes.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/github-issues.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-18-e4-1-s3-released-onnx-detector-backend.md`,
+  and GitHub issue `#107`.
+- Created branch
+  `feature/107-start-first-crack-detection-runtime-with-roast-sessions`.
+
+## Implementation
+
+Updated:
+
+- `src/coffee_roaster_mcp/first_crack_runtime.py`
+- `src/coffee_roaster_mcp/mcp_server.py`
+- `tests/test_first_crack_runtime.py`
+- `tests/test_mcp_server.py`
+- `README.md`
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+Behavior implemented:
+
+- Added `FirstCrackSessionRuntime` as the session-owned coordinator for audio
+  capture and detector processing.
+- In `first_crack.mode: audio`, `start_roast_session` prepares the configured
+  audio capture pipeline and the released-artifact ONNX detector adapter.
+- Disabled and manual modes do not start audio capture or detector runtime.
+- Queued detector windows are processed only for the owning active session after
+  authoritative T0 moves the session into `roasting`.
+- Confirmed detector output records `first_crack_detected` exactly once through
+  the existing detector adapter and `RoastSessionStore` integration path.
+- Runtime artifact, audio-capture, and detector failures surface through
+  `get_roast_state.first_crack_status` as `unavailable` or `faulted` without
+  crashing normal session control.
+- Runtime stop is wired to confirmed first crack, explicit `mark_first_crack`
+  override, `drop_beans`, `stop_cooling`, `emergency_stop`, and MCP process
+  shutdown.
+
+Out of scope kept out:
+
+- Automatic T0 implementation.
+- Rolling telemetry metrics and final log schemas.
+- Model training, ONNX export, Hugging Face sync, real microphone validation,
+  live Hottop validation, or broad release validation.
+
+## Review Fixes
+
+`PR #115` received two automated review comments in
+<https://github.com/syamaner/coffee-roaster-mcp/pull/115#pullrequestreview-4313625992>.
+Both were actionable and were fixed in commit `eea7135`.
+
+Fixes made:
+
+- `get_roast_state` now resolves the session and reads the configured driver
+  state before processing queued first-crack windows. If driver `read_state()`
+  fails, the failed state query does not mutate the session timeline.
+- `mark_beans_added` now returns the original `beans_added` event together with
+  a refreshed phase and event count after any immediate detector side effects.
+  If an already queued detector window confirms first crack during the same
+  command, the response reflects the post-detection `development` phase and
+  updated event count.
+
+Regression coverage added:
+
+- `test_get_roast_state_reads_driver_before_detector_side_effects`
+- `test_mark_beans_added_returns_snapshot_after_immediate_detector_confirmation`
+
+## Validation
+
+Initial implementation validation:
+
+- Ran `./.venv/bin/python -m pytest tests/test_first_crack_runtime.py tests/test_mcp_server.py tests/test_first_crack_integration.py`:
+  `29 passed`.
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `278 passed`, required coverage `90.0%` reached, total coverage `90.20%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
+
+Post-review validation after commit `eea7135`:
+
+- Ran `./.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_first_crack_runtime.py`:
+  `22 passed`.
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `280 passed`, required coverage `90.0%` reached, total coverage `90.15%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
+- GitHub CI for `PR #115` passed `Checks` and `Build Package` after both the
+  initial implementation commit and the review-fix commit.
+
+## Pull Request Status
+
+`PR #115` is open at
+<https://github.com/syamaner/coffee-roaster-mcp/pull/115>. At summary time:
+
+- PR state: open.
+- Merge state: mergeable.
+- Branch:
+  `feature/107-start-first-crack-detection-runtime-with-roast-sessions`.
+- Commits before this summary:
+  - `c52a5d7 feat: start first-crack runtime with sessions`
+  - `eea7135 fix: keep first-crack side effects consistent`
+
+## Handoff
+
+Durable state now points to `E4.1-S5`, issue `#108`, for MCP operational
+readiness tests and docs. Continue to preserve normal CI as mock-safe: no
+Hottop hardware, microphone, model download, real ONNX file, or network should
+be required.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -1183,7 +1183,7 @@ After completing a story:
   - Ran `./.venv/bin/python -m pytest tests/test_first_crack_runtime.py tests/test_mcp_server.py tests/test_first_crack_integration.py`:
     29 passed.
   - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
-    278 passed, required coverage `90.0%` reached, total coverage `90.20%`.
+    280 passed, required coverage `90.0%` reached, total coverage `90.15%`.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4.1-S4`
-- Current target: Start first-crack detection runtime with roast sessions
+- Active story: `E4.1-S5`
+- Current target: Add MCP operational readiness tests and docs
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -108,9 +108,9 @@ The first implementation milestone is a mock vertical slice that requires no roa
   tools to the configured `RoasterDriver` boundary while preserving the default
   mock path, one-session store semantics, fail-closed emergency behavior, and
   no-live-hardware CI. Current first-crack components resolve
-  artifacts, capture audio windows, adapt detector outputs, and write to the
-  session timeline, but there is not yet a released-artifact ONNX runtime
-  backend, session-owned detector loop, or automatic T0 runtime path. Epic 4.1
+  released artifacts, capture audio windows, run the released ONNX detector
+  adapter, and write confirmed first crack to the session timeline through a
+  session-owned runtime. Automatic T0 remains a later Epic 4.1 story. Epic 4.1
   makes the operational MCP flow explicit: Claude should be able to start a
   roast, adjust the configured roaster, read current device/session state, and
   know whether first crack has happened before Epic 5 adds richer telemetry
@@ -163,6 +163,19 @@ The first implementation milestone is a mock vertical slice that requires no roa
   artifact paths, fake feature extraction, and fake ONNX sessions so normal CI
   remains mock-safe and requires no model download, microphone, Hottop hardware,
   or network.
+- `E4.1-S4` adds the session-owned first-crack runtime. In
+  `first_crack.mode: audio`, `start_roast_session` prepares the configured
+  audio capture pipeline and released-artifact ONNX detector adapter without
+  requiring CI to use real microphone input, real model files, Hottop hardware,
+  or network. Detector processing is activated only after authoritative T0 puts
+  the active session into `roasting`; queued windows are processed through the
+  existing detector adapter and `RoastSessionStore` integration path, confirmed
+  output records first crack exactly once, and capture/detector/artifact
+  failures are reflected through MCP first-crack status as `faulted` or
+  `unavailable` without crashing normal session control. The runtime stops on
+  confirmed first crack, explicit manual first-crack override, drop, cooling
+  completion, emergency stop, and process shutdown. Disabled and manual modes do
+  not start audio or detector runtime.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -170,9 +183,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 
 ## Current Risks
 
-- The first-crack path does not yet include a released-artifact ONNX runtime
-  backend or session-owned detector loop; Epic 4.1 now tracks this before Epic
-  5 metrics/logging work.
+- Automatic T0 detection remains to be wired in E4.1-S6 before the fully
+  agent-driven roast path can avoid `mark_beans_added` as its primary T0 path.
 - MCP Registry publishing is preview and needs verification before release.
 - First-crack event integration must preserve one authoritative session timeline.
 - Log schema changes need compatibility discipline once users start collecting roast logs.
@@ -383,7 +395,7 @@ first crack has happened through MCP tools.
     existing released-artifact resolver boundary, with mock-safe tests and no
     training, export, or Hugging Face sync behavior.
 
-- [ ] `E4.1-S4` Start first-crack detection runtime with roast sessions.
+- [x] `E4.1-S4` Start first-crack detection runtime with roast sessions.
   - Done when audio mode starts/stops the configured audio pipeline and detector
     runtime with the roast session, records confirmed first crack exactly once,
     exposes disabled/manual/pending/detected/faulted/unavailable status through
@@ -1142,6 +1154,36 @@ After completing a story:
     43 passed.
   - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
     272 passed, required coverage `90.0%` reached, total coverage `90.45%`.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E4.1-S4:
+  - Added `FirstCrackSessionRuntime` as the session-owned coordinator for audio
+    capture and detector processing. `start_roast_session` now prepares the
+    runtime in `first_crack.mode: audio`, while disabled and manual modes do not
+    start audio or detector runtime.
+  - Runtime processing drains queued audio windows only for the owning active
+    session after authoritative T0 moves the session into `roasting`, then uses
+    the existing detector adapter plus `RoastSessionStore` integration helper to
+    record confirmed first crack exactly once.
+  - `get_roast_state.first_crack_status` now reflects runtime-level
+    `pending`, `detected`, `faulted`, and `unavailable` audio-mode status,
+    including artifact, audio-capture, and detector failures, without crashing
+    normal session control.
+  - Runtime stop is wired to confirmed first crack, explicit
+    `mark_first_crack` override, `drop_beans`, `stop_cooling`,
+    `emergency_stop`, and MCP process shutdown. No automatic T0 implementation,
+    rolling telemetry metrics, final log schemas, model training/export/sync,
+    real microphone validation, live Hottop validation, or broad release
+    validation was added.
+  - Added fake-backed tests for disabled/manual no-start behavior, audio-mode
+    preparation, activation after beans-added, no-confirmation pending status,
+    duplicate confirmation handling, artifact unavailability, capture faults,
+    detector faults, and terminal runtime stop behavior.
+  - Ran `./.venv/bin/python -m pytest tests/test_first_crack_runtime.py tests/test_mcp_server.py tests/test_first_crack_integration.py`:
+    29 passed.
+  - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+    278 passed, required coverage `90.0%` reached, total coverage `90.20%`.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -122,14 +122,27 @@ Backend output is adapted into the existing detector confidence metadata path.
 Normal CI remains mock-safe through fake artifact paths, fake feature
 extraction, and fake ONNX sessions.
 
+E4.1-S4 starts and stops a session-owned first-crack runtime when
+`first_crack.mode: audio` is configured. Starting a roast session now prepares
+the configured audio capture pipeline and released-artifact ONNX detector
+adapter; preparation failures such as missing artifacts, unavailable audio
+capture, or detector dependency failures are reflected through
+`get_roast_state.first_crack_status` as `unavailable` instead of crashing normal
+session control. During active `roasting` after T0, queued detector windows are
+processed through the existing detector/session integration helper and confirmed
+output records exactly one authoritative `first_crack_detected` event. Runtime
+capture or detector errors surface as `faulted` first-crack status. The runtime
+stops on first-crack confirmation, explicit manual first-crack override, drop,
+cooling completion, emergency stop, and process shutdown. Disabled and manual
+modes still do not start audio or detector runtime.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E4.1-S4: start first-crack detection runtime with roast
-sessions.
+The next story is E4.1-S5: add MCP operational readiness tests and docs.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -1,0 +1,329 @@
+"""Session-owned first-crack detector runtime orchestration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from threading import RLock
+from typing import Literal, Protocol
+
+from coffee_roaster_mcp.artifacts import ArtifactResolutionError
+from coffee_roaster_mcp.audio import (
+    AudioCaptureError,
+    AudioCapturePipeline,
+    AudioCaptureSnapshot,
+    AudioWindow,
+    build_audio_capture_pipeline,
+)
+from coffee_roaster_mcp.config import AppConfig, AudioConfig, FirstCrackConfig
+from coffee_roaster_mcp.detector import (
+    FirstCrackDetectorAdapter,
+    FirstCrackDetectorError,
+    build_released_onnx_first_crack_detector_adapter,
+    integrate_first_crack_window_with_session,
+)
+from coffee_roaster_mcp.session import RoastSession, RoastSessionStore, SessionLifecycleError
+
+FirstCrackRuntimeState = Literal[
+    "disabled",
+    "manual",
+    "pending",
+    "detected",
+    "faulted",
+    "unavailable",
+]
+
+
+class FirstCrackAudioPipeline(Protocol):
+    """Audio pipeline operations required by the first-crack runtime."""
+
+    def start(self) -> AudioCaptureSnapshot:
+        """Start capture and return capture status."""
+        ...
+
+    def stop(self, *, timeout_seconds: float = 1.0) -> AudioCaptureSnapshot:
+        """Stop capture and return capture status."""
+        ...
+
+    def drain_windows(self, *, max_windows: int | None = None) -> tuple[AudioWindow, ...]:
+        """Return queued detector windows without blocking."""
+        ...
+
+    def snapshot(self) -> AudioCaptureSnapshot:
+        """Return current capture status."""
+        ...
+
+
+FirstCrackAudioPipelineFactory = Callable[[AudioConfig], FirstCrackAudioPipeline]
+FirstCrackDetectorAdapterFactory = Callable[[FirstCrackConfig], FirstCrackDetectorAdapter]
+
+
+@dataclass(frozen=True)
+class FirstCrackRuntimeSnapshot:
+    """MCP-visible first-crack runtime status.
+
+    Attributes:
+        status: Current runtime state.
+        active_session_id: Session id that owns the runtime, if any.
+        active: Whether the runtime currently owns an active capture pipeline.
+        reason: Human-readable status detail.
+        audio_running: Whether the audio capture worker is alive.
+        queued_window_count: Detector windows waiting to be processed.
+        emitted_window_count: Windows emitted by the capture pipeline.
+        dropped_window_count: Windows dropped by the capture queue.
+        processed_window_count: Windows processed by this runtime.
+    """
+
+    status: FirstCrackRuntimeState
+    active_session_id: str | None
+    active: bool
+    reason: str | None = None
+    audio_running: bool = False
+    queued_window_count: int = 0
+    emitted_window_count: int = 0
+    dropped_window_count: int = 0
+    processed_window_count: int = 0
+
+
+class FirstCrackSessionRuntime:
+    """Own first-crack audio and detector processing for roast sessions."""
+
+    def __init__(
+        self,
+        *,
+        config: AppConfig,
+        audio_pipeline_factory: FirstCrackAudioPipelineFactory | None = None,
+        detector_adapter_factory: FirstCrackDetectorAdapterFactory | None = None,
+        stop_timeout_seconds: float = 1.0,
+    ) -> None:
+        """Initialize a session-owned first-crack runtime.
+
+        Args:
+            config: Application configuration.
+            audio_pipeline_factory: Optional test double for audio capture.
+            detector_adapter_factory: Optional test double for detector adapter construction.
+            stop_timeout_seconds: Maximum seconds to wait for capture shutdown.
+        """
+        self._config = config
+        self._audio_pipeline_factory = audio_pipeline_factory or _build_audio_pipeline
+        self._detector_adapter_factory = (
+            detector_adapter_factory or _build_released_detector_adapter
+        )
+        self._stop_timeout_seconds = stop_timeout_seconds
+        self._lock = RLock()
+        self._active_session_id: str | None = None
+        self._pipeline: FirstCrackAudioPipeline | None = None
+        self._adapter: FirstCrackDetectorAdapter | None = None
+        self._status: FirstCrackRuntimeState = _initial_status(config.first_crack)
+        self._reason: str | None = _initial_reason(config.first_crack)
+        self._processed_window_count = 0
+
+    def start_for_session(self, session: RoastSession) -> FirstCrackRuntimeSnapshot:
+        """Start or prepare first-crack detection for a roast session."""
+        with self._lock:
+            self._stop_locked(reason="new roast session")
+            self._active_session_id = session.id
+            self._processed_window_count = 0
+
+            if self._config.first_crack.mode != "audio":
+                self._status = _initial_status(self._config.first_crack)
+                self._reason = _initial_reason(self._config.first_crack)
+                return self.snapshot()
+
+            self._status = "pending"
+            self._reason = "Audio first-crack detection is prepared for this session."
+            try:
+                adapter = self._detector_adapter_factory(self._config.first_crack)
+                pipeline = self._audio_pipeline_factory(self._config.audio)
+                pipeline.start()
+            except ArtifactResolutionError as exc:
+                self._status = "unavailable"
+                self._reason = f"First-crack detector artifacts are unavailable: {exc}"
+                self._adapter = None
+                self._pipeline = None
+                return self.snapshot()
+            except (AudioCaptureError, FirstCrackDetectorError) as exc:
+                self._status = "unavailable"
+                self._reason = f"Audio first-crack detection is unavailable: {exc}"
+                self._adapter = None
+                self._pipeline = None
+                return self.snapshot()
+            except Exception as exc:  # noqa: BLE001 - dependency backends vary.
+                self._status = "unavailable"
+                self._reason = (
+                    "Audio first-crack detection could not be prepared: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+                self._adapter = None
+                self._pipeline = None
+                return self.snapshot()
+
+            self._adapter = adapter
+            self._pipeline = pipeline
+            return self.snapshot()
+
+    def process_available_windows(
+        self,
+        *,
+        session_store: RoastSessionStore,
+        session: RoastSession,
+    ) -> FirstCrackRuntimeSnapshot:
+        """Process queued detector windows for the owning active roast session."""
+        with self._lock:
+            if not self._can_process_locked(session):
+                return self.snapshot()
+
+            pipeline = self._pipeline
+            adapter = self._adapter
+            if pipeline is None or adapter is None:
+                return self.snapshot()
+
+            capture_snapshot = pipeline.snapshot()
+            if capture_snapshot.latest_error is not None:
+                self._mark_faulted_locked(f"Audio capture failed: {capture_snapshot.latest_error}")
+                return self.snapshot()
+
+            try:
+                for window in pipeline.drain_windows():
+                    self._processed_window_count += 1
+                    result = integrate_first_crack_window_with_session(
+                        config=self._config.first_crack,
+                        adapter=adapter,
+                        session_store=session_store,
+                        session=session,
+                        window=window,
+                    )
+                    if result is not None:
+                        self._status = "detected"
+                        self._reason = "First crack was recorded by audio detection."
+                        self._stop_locked(reason="first crack detected")
+                        break
+            except (AudioCaptureError, FirstCrackDetectorError, SessionLifecycleError) as exc:
+                self._mark_faulted_locked(f"First-crack detection failed: {exc}")
+            except Exception as exc:  # noqa: BLE001 - detector backends vary.
+                self._mark_faulted_locked(
+                    f"First-crack detection failed: {type(exc).__name__}: {exc}"
+                )
+
+            return self.snapshot()
+
+    def stop_for_session(
+        self,
+        session_id: str,
+        *,
+        reason: str,
+    ) -> FirstCrackRuntimeSnapshot:
+        """Stop first-crack detection if it belongs to the supplied session."""
+        with self._lock:
+            if self._active_session_id != session_id:
+                return self.snapshot()
+            self._stop_locked(reason=reason)
+            return self.snapshot()
+
+    def shutdown(self) -> FirstCrackRuntimeSnapshot:
+        """Stop any active detector runtime for process shutdown."""
+        with self._lock:
+            self._stop_locked(reason="process shutdown")
+            return self.snapshot()
+
+    def snapshot(self) -> FirstCrackRuntimeSnapshot:
+        """Return an MCP-visible runtime snapshot."""
+        with self._lock:
+            capture_snapshot = self._pipeline.snapshot() if self._pipeline is not None else None
+            status = self._status
+            reason = self._reason
+            if (
+                status == "pending"
+                and capture_snapshot is not None
+                and capture_snapshot.latest_error is not None
+            ):
+                status = "faulted"
+                reason = f"Audio capture failed: {capture_snapshot.latest_error}"
+
+            return FirstCrackRuntimeSnapshot(
+                status=status,
+                active_session_id=self._active_session_id,
+                active=self._pipeline is not None,
+                reason=reason,
+                audio_running=False if capture_snapshot is None else capture_snapshot.running,
+                queued_window_count=0
+                if capture_snapshot is None
+                else capture_snapshot.queued_window_count,
+                emitted_window_count=0
+                if capture_snapshot is None
+                else capture_snapshot.emitted_window_count,
+                dropped_window_count=0
+                if capture_snapshot is None
+                else capture_snapshot.dropped_window_count,
+                processed_window_count=self._processed_window_count,
+            )
+
+    def _can_process_locked(self, session: RoastSession) -> bool:
+        if self._config.first_crack.mode != "audio":
+            return False
+        if self._active_session_id != session.id:
+            return False
+        if self._status != "pending":
+            return False
+        return session.active and session.phase == "roasting"
+
+    def _mark_faulted_locked(self, reason: str) -> None:
+        self._status = "faulted"
+        self._reason = reason
+        self._stop_locked(reason="runtime fault")
+
+    def _stop_locked(self, *, reason: str) -> None:
+        pipeline = self._pipeline
+        if pipeline is not None:
+            try:
+                pipeline.stop(timeout_seconds=self._stop_timeout_seconds)
+            except Exception as exc:  # noqa: BLE001 - shutdown should be best effort.
+                self._status = "faulted"
+                self._reason = f"Audio capture stop failed: {type(exc).__name__}: {exc}"
+            finally:
+                self._pipeline = None
+                self._adapter = None
+        if self._status == "pending":
+            self._reason = f"Audio first-crack detection stopped before confirmation: {reason}."
+
+
+def build_first_crack_session_runtime(
+    config: AppConfig,
+    *,
+    audio_pipeline_factory: FirstCrackAudioPipelineFactory | None = None,
+    detector_adapter_factory: FirstCrackDetectorAdapterFactory | None = None,
+) -> FirstCrackSessionRuntime:
+    """Build the configured session-owned first-crack runtime."""
+    return FirstCrackSessionRuntime(
+        config=config,
+        audio_pipeline_factory=audio_pipeline_factory,
+        detector_adapter_factory=detector_adapter_factory,
+    )
+
+
+def _build_audio_pipeline(config: AudioConfig) -> AudioCapturePipeline:
+    return build_audio_capture_pipeline(config)
+
+
+def _build_released_detector_adapter(config: FirstCrackConfig) -> FirstCrackDetectorAdapter:
+    return build_released_onnx_first_crack_detector_adapter(config)
+
+
+def _initial_status(config: FirstCrackConfig) -> FirstCrackRuntimeState:
+    if config.mode == "disabled":
+        return "disabled"
+    if config.mode == "manual":
+        if not config.allow_manual_override:
+            return "unavailable"
+        return "manual"
+    return "pending"
+
+
+def _initial_reason(config: FirstCrackConfig) -> str:
+    if config.mode == "disabled":
+        return "Automatic first-crack detection is disabled by configuration."
+    if config.mode == "manual":
+        if not config.allow_manual_override:
+            return "Manual first-crack mode is configured, but manual override is disabled."
+        return "Waiting for explicit mark_first_crack override."
+    return "Audio first-crack detection has not started."

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -417,9 +417,10 @@ def create_mcp_server(
     ) -> RoastSessionState:
         """Return the current authoritative roast session state."""
         server_context = ctx.request_context.lifespan_context
-        _process_first_crack_runtime_for_active_session(server_context, session_id=session_id)
         session = _resolve_session(server_context, session_id=session_id)
         device_state = _read_current_device_state(server_context)
+        _process_first_crack_runtime_for_active_session(server_context, session_id=session_id)
+        session = _resolve_session(server_context, session_id=session_id)
         return _serialize_session_state(
             session,
             config=server_context.config,
@@ -471,7 +472,16 @@ def create_mcp_server(
             ctx.request_context.lifespan_context,
             session_id=result.session_id,
         )
-        return result
+        snapshot = _snapshot_session(
+            ctx.request_context.lifespan_context,
+            session_id=result.session_id,
+        )
+        return EventCommandResult(
+            session_id=snapshot.id,
+            phase=snapshot.phase,
+            event=result.event,
+            event_count=len(snapshot.event_timeline),
+        )
 
     @mcp.tool()
     def mark_first_crack(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -17,6 +17,11 @@ from coffee_roaster_mcp import __version__
 from coffee_roaster_mcp.config import AppConfig, ConfigError, FirstCrackMode, load_config
 from coffee_roaster_mcp.drivers import RoasterDriver, RoasterState, create_roaster_driver
 from coffee_roaster_mcp.exports import export_roast_snapshot
+from coffee_roaster_mcp.first_crack_runtime import (
+    FirstCrackRuntimeSnapshot,
+    FirstCrackSessionRuntime,
+    build_first_crack_session_runtime,
+)
 from coffee_roaster_mcp.session import (
     DriverCommandReservation,
     EventPayloadValue,
@@ -39,6 +44,7 @@ class ServerContext:
         transport: Actual MCP transport used by this server process.
         session_store: Authoritative in-process roast session owner.
         roaster_driver: Configured driver boundary.
+        first_crack_runtime: Session-owned first-crack detector runtime.
         started_at_utc: UTC time when the MCP process initialized.
     """
 
@@ -46,6 +52,7 @@ class ServerContext:
     transport: str
     session_store: RoastSessionStore
     roaster_driver: RoasterDriver
+    first_crack_runtime: FirstCrackSessionRuntime
     started_at_utc: datetime
 
 
@@ -285,6 +292,7 @@ def build_server_context(
         transport=transport,
         session_store=RoastSessionStore(default_log_dir=config.logging.log_dir / "roasts"),
         roaster_driver=roaster_driver,
+        first_crack_runtime=build_first_crack_session_runtime(config),
         started_at_utc=datetime.now(UTC),
     )
 
@@ -307,7 +315,11 @@ def create_mcp_server(
     @asynccontextmanager
     async def server_lifespan(_: FastMCP) -> AsyncGenerator[ServerContext, None]:
         """Load typed config once for the MCP process lifetime."""
-        yield build_server_context(config_path=config_path, transport=transport)
+        server_context = build_server_context(config_path=config_path, transport=transport)
+        try:
+            yield server_context
+        finally:
+            server_context.first_crack_runtime.shutdown()
 
     mcp = FastMCP(
         name="RoastPilot",
@@ -389,8 +401,13 @@ def create_mcp_server(
         except Exception:
             server_context.session_store.clear_session_start_reservation(reservation)
             raise
+        _start_first_crack_runtime(server_context, session=session)
         return StartRoastSessionResult(
-            session=_serialize_session_state(session, config=server_context.config)
+            session=_serialize_session_state(
+                session,
+                config=server_context.config,
+                first_crack_runtime=server_context.first_crack_runtime.snapshot(),
+            )
         )
 
     @mcp.tool()
@@ -400,12 +417,14 @@ def create_mcp_server(
     ) -> RoastSessionState:
         """Return the current authoritative roast session state."""
         server_context = ctx.request_context.lifespan_context
+        _process_first_crack_runtime_for_active_session(server_context, session_id=session_id)
         session = _resolve_session(server_context, session_id=session_id)
         device_state = _read_current_device_state(server_context)
         return _serialize_session_state(
             session,
             config=server_context.config,
             device_state=device_state,
+            first_crack_runtime=server_context.first_crack_runtime.snapshot(),
         )
 
     @mcp.tool()
@@ -447,7 +466,12 @@ def create_mcp_server(
         ctx: Context[ServerSession, ServerContext],
     ) -> EventCommandResult:
         """Record the authoritative beans-added event."""
-        return _record_session_event(ctx, "beans_added")
+        result = _record_session_event(ctx, "beans_added")
+        _process_first_crack_runtime_for_active_session(
+            ctx.request_context.lifespan_context,
+            session_id=result.session_id,
+        )
+        return result
 
     @mcp.tool()
     def mark_first_crack(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -457,7 +481,12 @@ def create_mcp_server(
         server_context = ctx.request_context.lifespan_context
         if not server_context.config.first_crack.allow_manual_override:
             raise ValueError("Manual first-crack override is disabled by configuration.")
-        return _record_session_event(ctx, "first_crack_detected")
+        result = _record_session_event(ctx, "first_crack_detected")
+        server_context.first_crack_runtime.stop_for_session(
+            result.session_id,
+            reason="manual first-crack override",
+        )
+        return result
 
     @mcp.tool()
     def drop_beans(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
@@ -467,6 +496,10 @@ def create_mcp_server(
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
         event, snapshot = _run_reserved_driver_drop(server_context, session)
+        server_context.first_crack_runtime.stop_for_session(
+            snapshot.id,
+            reason="beans dropped",
+        )
         return _serialize_event_result(snapshot=snapshot, event=event)
 
     @mcp.tool()
@@ -487,6 +520,10 @@ def create_mcp_server(
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
         event, snapshot = _run_reserved_driver_stop_cooling(server_context, session)
+        server_context.first_crack_runtime.stop_for_session(
+            snapshot.id,
+            reason="cooling stopped",
+        )
         return _serialize_event_result(snapshot=snapshot, event=event)
 
     @mcp.tool()
@@ -523,6 +560,10 @@ def create_mcp_server(
             reason=reason,
             safety_payload=safety_payload,
             allow_stopped_latest=True,
+        )
+        server_context.first_crack_runtime.stop_for_session(
+            snapshot.id,
+            reason="emergency stop",
         )
         return _serialize_event_result(snapshot=snapshot, event=event)
 
@@ -576,6 +617,32 @@ def _record_session_event(
     session = _require_active_session(server_context)
     event, snapshot = server_context.session_store.record_event_snapshot(session, kind)
     return _serialize_event_result(snapshot=snapshot, event=event)
+
+
+def _start_first_crack_runtime(
+    server_context: ServerContext,
+    *,
+    session: RoastSession,
+) -> None:
+    """Start first-crack runtime preparation for a newly created session."""
+    server_context.first_crack_runtime.start_for_session(session)
+
+
+def _process_first_crack_runtime_for_active_session(
+    server_context: ServerContext,
+    *,
+    session_id: str | None,
+) -> None:
+    """Process queued detector windows when the requested session is active."""
+    active_session = server_context.session_store.get_active_session()
+    if active_session is None:
+        return
+    if session_id is not None and session_id != active_session.id:
+        return
+    server_context.first_crack_runtime.process_available_windows(
+        session_store=server_context.session_store,
+        session=active_session,
+    )
 
 
 def _run_reserved_driver_control(
@@ -770,6 +837,7 @@ def _serialize_session_state(
     *,
     config: AppConfig,
     device_state: RoasterDeviceState | None = None,
+    first_crack_runtime: FirstCrackRuntimeSnapshot | None = None,
 ) -> RoastSessionState:
     """Convert one in-memory session into an MCP-safe snapshot."""
     metrics = compute_roast_metrics(session)
@@ -799,7 +867,11 @@ def _serialize_session_state(
         development_time_seconds=metrics.development_time_seconds,
         development_percent=metrics.development_percent,
         device_state=device_state,
-        first_crack_status=_serialize_first_crack_status(session, config=config),
+        first_crack_status=_serialize_first_crack_status(
+            session,
+            config=config,
+            first_crack_runtime=first_crack_runtime,
+        ),
         events=tuple(_serialize_event(event) for event in session.event_timeline),
         log_dir=str(session.log_writer.log_dir.resolve())
         if session.log_writer is not None
@@ -825,6 +897,7 @@ def _serialize_first_crack_status(
     session: RoastSession,
     *,
     config: AppConfig,
+    first_crack_runtime: FirstCrackRuntimeSnapshot | None = None,
 ) -> FirstCrackStatus:
     """Derive first-crack status from config and the session timeline."""
     if session.first_crack_at_utc is not None:
@@ -871,13 +944,35 @@ def _serialize_first_crack_status(
             allow_manual_override=config.first_crack.allow_manual_override,
             reason="Waiting for explicit mark_first_crack override.",
         )
+    if (
+        config.first_crack.mode == "audio"
+        and first_crack_runtime is not None
+        and first_crack_runtime.active_session_id == session.id
+        and first_crack_runtime.status in {"faulted", "unavailable"}
+    ):
+        return FirstCrackStatus(
+            mode=config.first_crack.mode,
+            status=first_crack_runtime.status,
+            detected_at_utc=None,
+            detected_monotonic_seconds=None,
+            allow_manual_override=config.first_crack.allow_manual_override,
+            reason=first_crack_runtime.reason,
+        )
+    reason = "Audio first-crack detection has not recorded first crack for this session."
+    if (
+        config.first_crack.mode == "audio"
+        and first_crack_runtime is not None
+        and first_crack_runtime.active_session_id == session.id
+        and first_crack_runtime.reason is not None
+    ):
+        reason = first_crack_runtime.reason
     return FirstCrackStatus(
         mode=config.first_crack.mode,
         status="pending",
         detected_at_utc=None,
         detected_monotonic_seconds=None,
         allow_manual_override=config.first_crack.allow_manual_override,
-        reason="Audio first-crack detection has not recorded first crack for this session.",
+        reason=reason,
     )
 
 

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+from coffee_roaster_mcp.artifacts import (
+    ArtifactResolutionError,
+    ResolvedArtifact,
+    ResolvedDetectorArtifacts,
+)
+from coffee_roaster_mcp.audio import AudioCaptureSnapshot, AudioWindow
+from coffee_roaster_mcp.config import AppConfig, AudioConfig, FirstCrackConfig
+from coffee_roaster_mcp.detector import (
+    FirstCrackDetectorAdapter,
+    FirstCrackDetectorOutput,
+    build_first_crack_detector_adapter,
+)
+from coffee_roaster_mcp.first_crack_runtime import FirstCrackSessionRuntime
+from coffee_roaster_mcp.session import RoastSessionStore
+
+
+class ClockHarness:
+    def __init__(self) -> None:
+        self.utc_value = datetime(2026, 5, 18, 12, 0, tzinfo=UTC)
+        self.monotonic_value = 500.0
+
+    def utc_now(self) -> datetime:
+        return self.utc_value
+
+    def monotonic_now(self) -> float:
+        return self.monotonic_value
+
+
+class MockDetectorBackend:
+    def __init__(self, outputs: Sequence[FirstCrackDetectorOutput]) -> None:
+        self._outputs = list(outputs)
+        self.windows: list[AudioWindow] = []
+
+    def detect(self, window: AudioWindow) -> FirstCrackDetectorOutput:
+        self.windows.append(window)
+        return self._outputs.pop(0)
+
+
+class FakeAudioPipeline:
+    def __init__(
+        self,
+        windows: Sequence[AudioWindow] = (),
+        *,
+        latest_error: str | None = None,
+    ) -> None:
+        self._windows = list(windows)
+        self.latest_error = latest_error
+        self.started = False
+        self.stopped = False
+        self.stop_reasons: list[float] = []
+
+    def start(self) -> AudioCaptureSnapshot:
+        self.started = True
+        return self.snapshot()
+
+    def stop(self, *, timeout_seconds: float = 1.0) -> AudioCaptureSnapshot:
+        self.stopped = True
+        self.stop_reasons.append(timeout_seconds)
+        return self.snapshot()
+
+    def drain_windows(self, *, max_windows: int | None = None) -> tuple[AudioWindow, ...]:
+        if max_windows is None:
+            drained = tuple(self._windows)
+            self._windows.clear()
+            return drained
+        drained = tuple(self._windows[:max_windows])
+        del self._windows[:max_windows]
+        return drained
+
+    def snapshot(self) -> AudioCaptureSnapshot:
+        return AudioCaptureSnapshot(
+            running=self.started and not self.stopped,
+            queued_window_count=len(self._windows),
+            emitted_window_count=len(self._windows),
+            dropped_window_count=0,
+            latest_error=self.latest_error,
+        )
+
+
+def test_disabled_and_manual_modes_do_not_prepare_audio_or_detector() -> None:
+    calls: list[str] = []
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+
+    def audio_factory(config: AudioConfig) -> FakeAudioPipeline:
+        calls.append(f"audio:{config.sample_rate}")
+        return FakeAudioPipeline()
+
+    def adapter_factory(config: FirstCrackConfig) -> FirstCrackDetectorAdapter:
+        calls.append(f"adapter:{config.mode}")
+        raise AssertionError("adapter factory should not be called")
+
+    disabled_runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="disabled")),
+        audio_pipeline_factory=audio_factory,
+        detector_adapter_factory=adapter_factory,
+    )
+    disabled = disabled_runtime.start_for_session(session)
+
+    manual_runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="manual")),
+        audio_pipeline_factory=audio_factory,
+        detector_adapter_factory=adapter_factory,
+    )
+    manual = manual_runtime.start_for_session(session)
+
+    assert disabled.status == "disabled"
+    assert manual.status == "manual"
+    assert calls == []
+
+
+def test_audio_runtime_processes_after_beans_added_and_records_once() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(
+                confirmed=True,
+                confidence=0.94,
+                detected_at_monotonic_seconds=506.0,
+            ),
+            FirstCrackDetectorOutput(
+                confirmed=True,
+                confidence=0.99,
+                detected_at_monotonic_seconds=507.0,
+            ),
+        )
+    )
+    pipeline = FakeAudioPipeline(
+        (
+            _audio_window(sequence_number=1, started_at_monotonic_seconds=505.0),
+            _audio_window(sequence_number=2, started_at_monotonic_seconds=506.0),
+        )
+    )
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio", revision="v0.1.0")),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            backend,
+        ),
+    )
+
+    start = runtime.start_for_session(session)
+    pre_t0 = runtime.process_available_windows(session_store=store, session=session)
+    clock.monotonic_value = 505.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 510.0
+    detected = runtime.process_available_windows(session_store=store, session=session)
+    duplicate = runtime.process_available_windows(session_store=store, session=session)
+
+    assert start.status == "pending"
+    assert pre_t0.queued_window_count == 2
+    assert detected.status == "detected"
+    assert duplicate.status == "detected"
+    assert pipeline.stopped is True
+    assert [window.sequence_number for window in backend.windows] == [1]
+    assert [event.kind for event in session.event_timeline] == [
+        "beans_added",
+        "first_crack_detected",
+    ]
+    assert session.first_crack_monotonic_seconds == 6.0
+
+
+def test_audio_runtime_keeps_pending_status_when_detector_does_not_confirm() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=False),))
+    pipeline = FakeAudioPipeline((_audio_window(sequence_number=3),))
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio")),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            backend,
+        ),
+    )
+
+    runtime.start_for_session(session)
+    snapshot = runtime.process_available_windows(session_store=store, session=session)
+
+    assert snapshot.status == "pending"
+    assert snapshot.processed_window_count == 1
+    assert pipeline.stopped is False
+    assert [event.kind for event in session.event_timeline] == ["beans_added"]
+
+
+def test_audio_runtime_reports_unavailable_artifact_errors_without_crashing() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+
+    def adapter_factory(config: FirstCrackConfig) -> FirstCrackDetectorAdapter:
+        raise ArtifactResolutionError("missing onnx/int8/model_quantized.onnx")
+
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio")),
+        audio_pipeline_factory=lambda _: FakeAudioPipeline(),
+        detector_adapter_factory=adapter_factory,
+    )
+
+    snapshot = runtime.start_for_session(session)
+
+    assert snapshot.status == "unavailable"
+    assert "missing onnx/int8/model_quantized.onnx" in (snapshot.reason or "")
+    assert snapshot.active is False
+
+
+def test_audio_runtime_reports_capture_and_detector_faults() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    capture_session = store.start_session()
+    store.record_event(capture_session, "beans_added")
+    capture_runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio")),
+        audio_pipeline_factory=lambda _: FakeAudioPipeline(latest_error="device lost"),
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            MockDetectorBackend(()),
+        ),
+    )
+
+    capture_runtime.start_for_session(capture_session)
+    capture_fault = capture_runtime.process_available_windows(
+        session_store=store,
+        session=capture_session,
+    )
+
+    second_store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    second_session = second_store.start_session()
+    second_store.record_event(second_session, "beans_added")
+    detector_runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio")),
+        audio_pipeline_factory=lambda _: FakeAudioPipeline((_audio_window(),)),
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            MockDetectorBackend(()),
+        ),
+    )
+
+    detector_runtime.start_for_session(second_session)
+    detector_fault = detector_runtime.process_available_windows(
+        session_store=second_store,
+        session=second_session,
+    )
+
+    assert capture_fault.status == "faulted"
+    assert capture_fault.reason == "Audio capture failed: device lost"
+    assert detector_fault.status == "faulted"
+    assert "First-crack detection failed" in (detector_fault.reason or "")
+
+
+def test_audio_runtime_stops_on_terminal_session_transition() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    pipeline = FakeAudioPipeline((_audio_window(),))
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio")),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            MockDetectorBackend((FirstCrackDetectorOutput(confirmed=False),)),
+        ),
+    )
+
+    runtime.start_for_session(session)
+    snapshot = runtime.stop_for_session(session.id, reason="beans dropped")
+
+    assert pipeline.stopped is True
+    assert snapshot.status == "pending"
+    assert snapshot.active is False
+    assert (
+        snapshot.reason == "Audio first-crack detection stopped before confirmation: beans dropped."
+    )
+
+
+def _audio_window(
+    *,
+    sequence_number: int = 0,
+    started_at_monotonic_seconds: float = 505.0,
+) -> AudioWindow:
+    return AudioWindow(
+        sequence_number=sequence_number,
+        input_device="fake-mic",
+        sample_rate=16_000,
+        started_at_monotonic_seconds=started_at_monotonic_seconds,
+        duration_seconds=1.0,
+        samples=(0.0,) * 16_000,
+    )
+
+
+def _resolved_detector_artifacts() -> ResolvedDetectorArtifacts:
+    return ResolvedDetectorArtifacts(
+        onnx_model=ResolvedArtifact(
+            repo_id="syamaner/coffee-first-crack-detection",
+            revision="v0.1.0",
+            filename="onnx/int8/model_quantized.onnx",
+            local_path=Path("/tmp/model_quantized.onnx"),
+        ),
+        feature_extractor_config=ResolvedArtifact(
+            repo_id="syamaner/coffee-first-crack-detection",
+            revision="v0.1.0",
+            filename="onnx/int8/preprocessor_config.json",
+            local_path=Path("/tmp/preprocessor_config.json"),
+        ),
+    )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -222,6 +222,82 @@ def test_get_roast_state_driver_read_failure_does_not_mutate_session(
     assert state.phase == "roasting"
 
 
+def test_get_roast_state_reads_driver_before_detector_side_effects(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "first_crack:",
+                "  mode: audio",
+                f"logging:\n  log_dir: {tmp_path / 'logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(fail_read=True)
+    runtime = FakeFirstCrackRuntime(record_first_crack_on_process=False)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    _set_first_crack_runtime(server_context, runtime)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "mark_beans_added", ctx)
+    runtime.record_first_crack_on_process = True
+
+    with pytest.raises(RuntimeError, match="Could not read current roaster state"):
+        _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+
+    failed_read_snapshot = server_context.session_store.get_session_snapshot(
+        session_id=start_result.session.session_id
+    )
+    assert failed_read_snapshot.first_crack_at_utc is None
+    assert runtime.processed_sessions == [start_result.session.session_id]
+
+    driver.fail_read = False
+    state = _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+
+    assert state.phase == "development"
+    assert state.first_crack_at_utc is not None
+    assert [event.kind for event in state.events] == [
+        "beans_added",
+        "first_crack_detected",
+    ]
+
+
+def test_mark_beans_added_returns_snapshot_after_immediate_detector_confirmation(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "first_crack:",
+                "  mode: audio",
+                f"logging:\n  log_dir: {tmp_path / 'logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server_context = build_server_context(config_path=config_path)
+    _set_first_crack_runtime(
+        server_context,
+        FakeFirstCrackRuntime(record_first_crack_on_process=True),
+    )
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    _call_tool(server, "start_roast_session", ctx)
+    beans_added = _call_tool(server, "mark_beans_added", ctx)
+
+    assert beans_added.event.kind == "beans_added"
+    assert beans_added.phase == "development"
+    assert beans_added.event_count == 2
+
+
 def test_get_roast_state_exposes_first_crack_statuses(tmp_path: Path) -> None:
     manual_config_path = tmp_path / "manual.yaml"
     manual_config_path.write_text(
@@ -756,9 +832,16 @@ class RecordingRoasterDriver:
 class FakeFirstCrackRuntime:
     """Runtime double that keeps audio-mode MCP tests network-free."""
 
-    def __init__(self, *, status: str = "pending", reason: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        status: str = "pending",
+        reason: str | None = None,
+        record_first_crack_on_process: bool = False,
+    ) -> None:
         self.status = status
         self.reason = reason
+        self.record_first_crack_on_process = record_first_crack_on_process
         self.active_session_id: str | None = None
         self.started_sessions: list[str] = []
         self.processed_sessions: list[str] = []
@@ -776,6 +859,9 @@ class FakeFirstCrackRuntime:
         session: RoastSession,
     ) -> FirstCrackRuntimeSnapshot:
         self.processed_sessions.append(session.id)
+        if self.record_first_crack_on_process and session.first_crack_at_utc is None:
+            session_store.record_event_snapshot(session, "first_crack_detected")
+            self.status = "detected"
         return self.snapshot()
 
     def stop_for_session(self, session_id: str, *, reason: str) -> FirstCrackRuntimeSnapshot:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6,14 +6,18 @@ import json
 from pathlib import Path
 from threading import Event, Thread
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from mcp.server.fastmcp import FastMCP
 
 from coffee_roaster_mcp.drivers import EmergencyStopResult, MockRoasterDriver, RoasterState
+from coffee_roaster_mcp.first_crack_runtime import (
+    FirstCrackRuntimeSnapshot,
+    FirstCrackRuntimeState,
+)
 from coffee_roaster_mcp.mcp_server import ServerContext, build_server_context, create_mcp_server
-from coffee_roaster_mcp.session import SessionLifecycleError
+from coffee_roaster_mcp.session import RoastSession, RoastSessionStore, SessionLifecycleError
 
 
 def test_in_process_mcp_tools_cover_mock_roast_and_export(tmp_path: Path) -> None:
@@ -96,6 +100,7 @@ def test_in_process_mcp_tools_surface_errors_and_audio_bootstrap_state(tmp_path:
         encoding="utf-8",
     )
     server_context = build_server_context(config_path=config_path)
+    _set_first_crack_runtime(server_context, FakeFirstCrackRuntime())
     server = create_mcp_server(config_path=config_path)
     ctx = _ctx(server_context)
 
@@ -287,6 +292,8 @@ def test_get_roast_state_exposes_first_crack_statuses(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     audio_context = build_server_context(config_path=audio_config_path)
+    audio_runtime = FakeFirstCrackRuntime()
+    _set_first_crack_runtime(audio_context, audio_runtime)
     audio_server = create_mcp_server(config_path=audio_config_path)
     audio_ctx = _ctx(audio_context)
     audio_start = _call_tool(audio_server, "start_roast_session", audio_ctx)
@@ -312,6 +319,39 @@ def test_get_roast_state_exposes_first_crack_statuses(tmp_path: Path) -> None:
         detected_state.first_crack_status.detected_monotonic_seconds
         == detected.event.monotonic_seconds
     )
+    assert audio_runtime.stopped_sessions == [audio_start.session.session_id]
+
+    audio_unavailable_config_path = tmp_path / "audio-unavailable.yaml"
+    audio_unavailable_config_path.write_text(
+        "\n".join(
+            [
+                "first_crack:",
+                "  mode: audio",
+                f"logging:\n  log_dir: {tmp_path / 'audio-unavailable-logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    audio_unavailable_context = build_server_context(config_path=audio_unavailable_config_path)
+    _set_first_crack_runtime(
+        audio_unavailable_context,
+        FakeFirstCrackRuntime(status="unavailable", reason="missing detector artifacts"),
+    )
+    audio_unavailable_server = create_mcp_server(config_path=audio_unavailable_config_path)
+    audio_unavailable_ctx = _ctx(audio_unavailable_context)
+    audio_unavailable_start = _call_tool(
+        audio_unavailable_server,
+        "start_roast_session",
+        audio_unavailable_ctx,
+    )
+    audio_unavailable_state = _call_tool(
+        audio_unavailable_server,
+        "get_roast_state",
+        audio_unavailable_ctx,
+        session_id=audio_unavailable_start.session.session_id,
+    )
+    assert audio_unavailable_state.first_crack_status.status == "unavailable"
+    assert audio_unavailable_state.first_crack_status.reason == "missing detector artifacts"
 
     fault_config_path = tmp_path / "fault.yaml"
     fault_config_path.write_text(
@@ -325,6 +365,7 @@ def test_get_roast_state_exposes_first_crack_statuses(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     fault_context = build_server_context(config_path=fault_config_path)
+    _set_first_crack_runtime(fault_context, FakeFirstCrackRuntime())
     fault_server = create_mcp_server(config_path=fault_config_path)
     fault_ctx = _ctx(fault_context)
     fault_start = _call_tool(fault_server, "start_roast_session", fault_ctx)
@@ -712,9 +753,58 @@ class RecordingRoasterDriver:
         )
 
 
+class FakeFirstCrackRuntime:
+    """Runtime double that keeps audio-mode MCP tests network-free."""
+
+    def __init__(self, *, status: str = "pending", reason: str | None = None) -> None:
+        self.status = status
+        self.reason = reason
+        self.active_session_id: str | None = None
+        self.started_sessions: list[str] = []
+        self.processed_sessions: list[str] = []
+        self.stopped_sessions: list[str] = []
+
+    def start_for_session(self, session: RoastSession) -> FirstCrackRuntimeSnapshot:
+        self.active_session_id = session.id
+        self.started_sessions.append(session.id)
+        return self.snapshot()
+
+    def process_available_windows(
+        self,
+        *,
+        session_store: RoastSessionStore,
+        session: RoastSession,
+    ) -> FirstCrackRuntimeSnapshot:
+        self.processed_sessions.append(session.id)
+        return self.snapshot()
+
+    def stop_for_session(self, session_id: str, *, reason: str) -> FirstCrackRuntimeSnapshot:
+        self.stopped_sessions.append(session_id)
+        self.reason = reason
+        return self.snapshot()
+
+    def shutdown(self) -> FirstCrackRuntimeSnapshot:
+        return self.snapshot()
+
+    def snapshot(self) -> FirstCrackRuntimeSnapshot:
+        return FirstCrackRuntimeSnapshot(
+            status=cast(FirstCrackRuntimeState, self.status),
+            active_session_id=self.active_session_id,
+            active=self.active_session_id is not None,
+            reason=self.reason,
+        )
+
+
 def _ctx(server_context: ServerContext) -> Any:
     """Build the minimal context shape used by FastMCP tool functions."""
     return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=server_context))
+
+
+def _set_first_crack_runtime(
+    server_context: ServerContext,
+    runtime: FakeFirstCrackRuntime,
+) -> None:
+    object.__setattr__(server_context, "first_crack_runtime", runtime)
 
 
 def _record_tool_error(


### PR DESCRIPTION
## Summary
- Add a session-owned first-crack runtime that prepares the configured audio pipeline and released ONNX detector adapter in `first_crack.mode: audio`.
- Process queued detector windows only for the owning active roast after T0, recording confirmed first crack once through the existing `RoastSessionStore` integration path.
- Surface audio/artifact/detector runtime states through `get_roast_state.first_crack_status` and stop the runtime on first crack, manual override, drop, cooling completion, emergency stop, and process shutdown.
- Update README and durable epic state for E4.1-S4.

## Validation
- `./.venv/bin/python -m pytest tests/test_first_crack_runtime.py tests/test_mcp_server.py tests/test_first_crack_integration.py`
- `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov` (278 passed, 90.20% coverage)
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`

Closes #107