### PR TITLE
E4.1-S5: Add MCP operational readiness tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ The default local path is intentionally mock-safe:
 - no microphone required
 - no model download required
 
-RoastPilot now provides a real local stdio MCP server entrypoint plus the first mock-safe roast-session tool surface. Later Epic 2 stories still need to refine phase transitions, emergency-stop semantics, and the real log writers.
+RoastPilot now provides a local stdio MCP server entrypoint with a mock-safe
+roast-session tool surface. The default configuration lets an MCP client start
+a roast, adjust controls, read current device and session state, record explicit
+override events, drop beans into cooling, and export snapshot logs without
+roaster hardware, microphone input, model files, or network access.
 
 ### Start The Local MCP Server
 
@@ -116,6 +120,46 @@ The current MCP tool surface includes:
 - `emergency_stop`
 
 `export_roast_log` writes snapshot `roast.jsonl`, `roast.csv`, and `summary.json` files for the current in-process session. Append-only telemetry writers and final log schemas land in Epic 5.
+
+### Operational MCP Flow
+
+The mock-safe Claude/operator flow is:
+
+1. Call `start_roast_session` to create the one active roast session and connect
+   the configured driver.
+2. Call `set_heat` and `set_fan` as operational decisions require. These tools
+   go through the configured `RoasterDriver` boundary; the default mock driver
+   stays local and deterministic.
+3. Call `get_roast_state` to read both the authoritative session state and the
+   current configured-device state. The response includes driver id, connected
+   status, bean/environment temperatures when available, heat/fan levels,
+   cooling state, safe raw diagnostics, first-crack status, and lifecycle
+   timestamps for beans added, first crack, bean drop, cooling started, and
+   cooling stopped.
+4. Use `drop_beans` as the normal drop command. For the mock path and the
+   Hottop compound drop path, this records `beans_dropped`, records
+   `cooling_started` when the driver reports cooling active, turns heat off,
+   sets fan to `100%`, and enters the cooling phase.
+5. Use `stop_cooling` when cooling is complete. `start_cooling` remains
+   available as an explicit advanced/manual recovery tool, not as the normal
+   roast flow after `drop_beans`.
+
+`mark_beans_added` and `mark_first_crack` are explicit override tools. They are
+kept available for operator recovery and controlled manual runs. The primary
+automatic runtime paths are internal: automatic T0 detection is owned by
+E4.1-S6, and audio-mode first-crack confirmation is owned by the session-owned
+first-crack runtime when `first_crack.mode: audio` is deliberately configured.
+
+`get_roast_state.first_crack_status.status` is one of:
+
+- `disabled`: first-crack detection is disabled and no first-crack event exists.
+- `manual`: manual first-crack mode is configured and the override tool is
+  available.
+- `pending`: audio detection is configured and waiting for a confirmed event.
+- `detected`: the authoritative session timeline has a first-crack event.
+- `faulted`: the detector runtime or session has faulted.
+- `unavailable`: configuration, artifacts, audio capture, or manual-override
+  settings make first-crack detection unavailable.
 
 ### Mock-Safe Bootstrap Smoke
 
@@ -174,6 +218,16 @@ must be validated on a supervised roaster before the Hottop path is treated as
 release-ready. The current MCP roast-session tools call the configured driver
 boundary, so keep normal development on the mock driver unless a guarded Hottop
 validation run is explicitly intended.
+
+Optional live Hottop MCP validation is gated manual work. Run it only with a
+supervised roaster, an explicit `hottop_kn8828b_2k_plus` config, a known serial
+port, and a clear stop plan. Expected evidence for a pass is: the MCP client can
+start one session, set heat and fan, read connected device state with plausible
+temperatures, call `drop_beans` to trigger drop plus cooling, read
+`beans_dropped` and `cooling_started` timestamps from `get_roast_state`, stop
+cooling when the roaster reports cooling off, and preserve any failure as a
+fault event. Any serial, telemetry, command-loop, or safety uncertainty should
+be treated as a failed validation and should not be required by normal CI.
 
 ## Configuration
 
@@ -255,6 +309,17 @@ perform format conversion. On macOS, use the system sound settings or a
 are optional and should be run only when `first_crack.mode: audio` and
 `audio.source: microphone` are deliberately configured.
 
+Optional real microphone validation is gated manual work. Before running it,
+configure released Hugging Face ONNX artifacts or a validated
+`first_crack.local_model_dir`, select the intended microphone, and confirm the
+MCP process can start without artifact or audio-capture errors. Expected
+evidence for a pass is: `get_roast_state.first_crack_status` moves from
+`pending` to `detected` during a supervised roast or controlled replay, the
+recorded `first_crack_detected` event includes detector metadata, and normal
+roast controls continue to work. Missing artifacts, unavailable audio devices,
+and detector failures should surface as `unavailable` or `faulted` status and
+remain outside normal CI.
+
 `HF_HOME` is consumed by Hugging Face tooling directly rather than copied into the RoastPilot config object.
 
 ## Hugging Face Model Boundary
@@ -298,13 +363,16 @@ start audio capture or detector runtime.
 
 ## Log Export
 
-Roast log export is a planned v0.1 capability, not a completed runtime feature yet.
+RoastPilot currently supports snapshot export through `export_roast_log` for
+the active in-process session.
 
-The intended direction is:
+Current export files:
 
-- append-only JSONL during roast
-- CSV export for analysis
-- `summary.json` for session-level metadata
+- `roast.jsonl` with the current event timeline snapshot
+- `roast.csv` with the current event timeline snapshot
+- `summary.json` with current session-level metadata and timestamp-derived
+  metrics
 - output under `logs/roasts/{session_id}/`
 
-Those exports will be produced by the future MCP runtime once roast sessions, telemetry, and export flows are implemented in later epics. They are not available from the current bootstrap CLI yet.
+Append-only telemetry logging, rolling RoR metrics, development percentage
+hardening, and final log schemas land in Epic 5.

--- a/docs/session-summaries/2026-05-18-e4-1-s5-mcp-operational-readiness.md
+++ b/docs/session-summaries/2026-05-18-e4-1-s5-mcp-operational-readiness.md
@@ -1,0 +1,117 @@
+# E4.1-S5 MCP Operational Readiness Session
+
+## Scope
+
+This session resumed after `PR #115` for `E4.1-S4` was squashed and merged,
+and issue `#107` was closed. Work started from updated `main` on branch
+`feature/108-add-mcp-operational-readiness-tests-and-docs` for issue `#108`,
+`E4.1-S5: Add MCP operational readiness tests and docs`.
+
+The story goal was to prove the local Claude-installed MCP workflow is
+operational for the current release boundary before Epic 5 metrics/logging. The
+scope stayed on the mock-safe path where an MCP client can start a roast, adjust
+configured roaster controls, read current device/session state, understand
+first-crack status, use `drop_beans` as the normal drop/cooling transition
+command, and see that `mark_beans_added` and `mark_first_crack` are explicit
+override tools.
+
+## Context Usage
+
+Final context snapshot supplied by the operator after implementation and PR
+creation:
+
+- Context window: `59% left (114K used / 258K)`
+- 5h limit: `94% left`, resets `01:10 on 19 May`
+- Weekly limit: `93% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `02:37 on 19 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `21:37 on 25 May`
+
+## Pre-Story Verification
+
+Before starting E4.1-S5:
+
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding through the merged
+  E4.1-S4 changes.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/github-issues.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-18-e4-1-s4-start-first-crack-runtime.md`,
+  and GitHub issue `#108`.
+- Created branch
+  `feature/108-add-mcp-operational-readiness-tests-and-docs`.
+
+## Implementation
+
+Updated:
+
+- `tests/test_package.py`
+- `README.md`
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+Behavior and documentation covered:
+
+- Strengthened the public stdio MCP mock-roast test to assert the operational
+  Claude/operator flow through public tools:
+  `start_roast_session`, `set_heat`, `set_fan`, `mark_beans_added`,
+  `mark_first_crack`, `drop_beans`, `stop_cooling`, `get_roast_state`, and
+  `export_roast_log`.
+- Added schema assertions for `get_roast_state`, nested `device_state`, and
+  nested `first_crack_status` so accidental MCP response-shape drift is caught.
+- Asserted lifecycle timestamp fields for beans added, first crack, bean drop,
+  cooling started, and cooling stopped.
+- Documented the current operational MCP flow in `README.md`.
+- Documented first-crack status meanings: `disabled`, `manual`, `pending`,
+  `detected`, `faulted`, and `unavailable`.
+- Documented `mark_beans_added` and `mark_first_crack` as explicit override
+  tools, with automatic T0 and audio first-crack confirmation staying internal
+  runtime paths.
+- Documented `drop_beans` as the normal drop/cooling transition command and
+  `start_cooling` as an advanced/manual recovery control.
+- Added gated optional validation notes for live Hottop MCP use and real
+  microphone/audio validation, including expected evidence and failure behavior.
+- Updated durable state to mark `E4.1-S5` complete and point next to
+  `E4.1-S6`.
+
+Out of scope kept out:
+
+- Automatic T0 implementation.
+- Rolling telemetry metrics and final log schemas.
+- Model training, ONNX export, Hugging Face sync, real microphone validation,
+  live Hottop validation, or broad release validation.
+
+## Validation
+
+Local validation:
+
+- Ran `./.venv/bin/python -m pytest tests/test_package.py tests/test_mcp_server.py`:
+  `31 passed`.
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `280 passed`, required coverage `90.0%` reached, total coverage `90.15%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
+
+GitHub CI for `PR #116` passed before this summary commit:
+
+- `Checks`: passed.
+- `Build Package`: passed.
+
+## Pull Request Status
+
+`PR #116` is open at
+<https://github.com/syamaner/coffee-roaster-mcp/pull/116>. At summary time:
+
+- PR state: open.
+- Merge state: mergeable.
+- Branch:
+  `feature/108-add-mcp-operational-readiness-tests-and-docs`.
+- Implementation commit before this summary:
+  - `2243f48` - `test: add mcp operational readiness coverage`
+
+## Handoff
+
+Durable state now points to `E4.1-S6`, issue `#111`, for the automatic T0
+runtime path. Continue to preserve normal CI as mock-safe: no Hottop hardware,
+microphone, model download, real ONNX file, or network should be required.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4.1-S5`
-- Current target: Add MCP operational readiness tests and docs
+- Active story: `E4.1-S6`
+- Current target: Add automatic T0 runtime path
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -176,6 +176,16 @@ The first implementation milestone is a mock vertical slice that requires no roa
   confirmed first crack, explicit manual first-crack override, drop, cooling
   completion, emergency stop, and process shutdown. Disabled and manual modes do
   not start audio or detector runtime.
+- `E4.1-S5` adds operational MCP readiness coverage and docs before Epic 5.
+  The public stdio MCP test path now covers the mock-safe Claude/operator flow:
+  start a roast, set heat and fan, use explicit override tools when needed,
+  drop beans through the normal drop/cooling command, stop cooling, read current
+  device/session state, understand first-crack status, and export snapshot logs.
+  The same coverage asserts `get_roast_state` schemas for lifecycle timestamps,
+  configured-device state, and first-crack status to prevent accidental tool
+  shape drift. README docs now explain the operational flow, first-crack status
+  meanings, explicit override semantics, and gated optional live Hottop/real
+  microphone validation evidence.
 - Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
@@ -403,7 +413,7 @@ first crack has happened through MCP tools.
     `mark_first_crack` remains only the explicit manual override path when
     configuration allows it.
 
-- [ ] `E4.1-S5` Add MCP operational readiness tests and docs.
+- [x] `E4.1-S5` Add MCP operational readiness tests and docs.
   - Done when automated MCP tests cover the local Claude-installed operational
     flow on the mock-safe path, MCP response schemas for device state and
     first-crack status are asserted, override-tool semantics for
@@ -1182,6 +1192,29 @@ After completing a story:
     detector faults, and terminal runtime stop behavior.
   - Ran `./.venv/bin/python -m pytest tests/test_first_crack_runtime.py tests/test_mcp_server.py tests/test_first_crack_integration.py`:
     29 passed.
+  - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+    280 passed, required coverage `90.0%` reached, total coverage `90.15%`.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E4.1-S5:
+  - Strengthened the public stdio MCP mock-roast test to assert the operational
+    Claude/operator flow through public tools: start session, set heat and fan,
+    record explicit beans-added and first-crack overrides, use `drop_beans` as
+    the normal drop/cooling command, stop cooling, read state, export snapshot
+    logs, and start a later session after completion or fault.
+  - Added schema assertions for `get_roast_state`, nested `device_state`, and
+    nested `first_crack_status`, including lifecycle timestamp fields for beans
+    added, first crack, bean drop, cooling started, and cooling stopped.
+  - Updated README operator docs for the current MCP flow, first-crack status
+    values, override tool semantics, `drop_beans` as the normal cooling
+    transition, and gated optional live Hottop/real microphone validation
+    evidence.
+  - Kept automatic T0 implementation, rolling telemetry metrics, final log
+    schemas, model training/export/sync, real microphone validation, live
+    Hottop validation, and broad release validation out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_package.py tests/test_mcp_server.py`:
+    31 passed.
   - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
     280 passed, required coverage `90.0%` reached, total coverage `90.15%`.
   - Ran `./.venv/bin/python -m ruff check .`: passed.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -136,13 +136,25 @@ stops on first-crack confirmation, explicit manual first-crack override, drop,
 cooling completion, emergency stop, and process shutdown. Disabled and manual
 modes still do not start audio or detector runtime.
 
+E4.1-S5 added operational MCP readiness coverage and docs before Epic 5. The
+stdio MCP test path now asserts the public mock-safe Claude/operator flow:
+start a roast, set heat and fan, use explicit override tools when needed, drop
+beans through the normal drop/cooling command, stop cooling, read device/session
+state, and export current snapshot logs. The same test now pins
+`get_roast_state` response schemas for lifecycle timestamps, configured-device
+state, and first-crack status so accidental tool-shape drift is caught. README
+docs now explain the normal operational MCP flow, first-crack status meanings,
+explicit override semantics for `mark_beans_added` and `mark_first_crack`,
+`drop_beans` as the normal cooling transition, and gated optional live
+Hottop/real microphone validation evidence. Normal CI remains mock-safe.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E4.1-S5: add MCP operational readiness tests and docs.
+The next story is E4.1-S6: add automatic T0 runtime path.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -21,6 +21,55 @@ from coffee_roaster_mcp.mcp_server import build_server_context, run_driver_emerg
 REPO_ROOT = Path(__file__).resolve().parents[1]
 _T = TypeVar("_T")
 
+_EXPECTED_ROAST_STATE_KEYS = {
+    "active",
+    "beans_added_at_utc",
+    "beans_added_monotonic_seconds",
+    "beans_dropped_at_utc",
+    "beans_dropped_monotonic_seconds",
+    "cooling_on",
+    "cooling_started_at_utc",
+    "cooling_started_monotonic_seconds",
+    "cooling_stopped_at_utc",
+    "cooling_stopped_monotonic_seconds",
+    "created_at_utc",
+    "development_percent",
+    "development_time_seconds",
+    "device_state",
+    "elapsed_monotonic_seconds",
+    "events",
+    "fan_level_percent",
+    "faulted_at_utc",
+    "faulted_monotonic_seconds",
+    "first_crack_at_utc",
+    "first_crack_monotonic_seconds",
+    "first_crack_status",
+    "heat_level_percent",
+    "log_dir",
+    "phase",
+    "roast_elapsed_seconds",
+    "session_id",
+    "stopped_at_utc",
+}
+_EXPECTED_DEVICE_STATE_KEYS = {
+    "bean_temp_c",
+    "connected",
+    "cooling_on",
+    "driver",
+    "env_temp_c",
+    "fan_level_percent",
+    "heat_level_percent",
+    "raw_vendor_data",
+}
+_EXPECTED_FIRST_CRACK_STATUS_KEYS = {
+    "allow_manual_override",
+    "detected_at_utc",
+    "detected_monotonic_seconds",
+    "mode",
+    "reason",
+    "status",
+}
+
 
 def test_version_is_defined() -> None:
     assert __version__ == "0.1.0"
@@ -216,22 +265,62 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
                 session.call_tool("get_roast_state", {"session_id": session_id})
             ),
         )
-        assert state_result.structuredContent["session_id"] == session_id
-        assert state_result.structuredContent["active"] is False
-        assert state_result.structuredContent["heat_level_percent"] == 0
-        assert state_result.structuredContent["fan_level_percent"] == 100
-        assert state_result.structuredContent["cooling_on"] is False
-        assert state_result.structuredContent["roast_elapsed_seconds"] is not None
-        assert state_result.structuredContent["development_time_seconds"] is not None
-        assert state_result.structuredContent["development_percent"] is not None
-        assert [event["kind"] for event in state_result.structuredContent["events"]] == [
+        state_content = state_result.structuredContent
+        assert state_content is not None
+        assert set(state_content) == _EXPECTED_ROAST_STATE_KEYS
+        assert state_content["session_id"] == session_id
+        assert state_content["active"] is False
+        assert state_content["phase"] == "complete"
+        assert state_content["heat_level_percent"] == 0
+        assert state_content["fan_level_percent"] == 100
+        assert state_content["cooling_on"] is False
+        assert state_content["roast_elapsed_seconds"] is not None
+        assert state_content["development_time_seconds"] is not None
+        assert state_content["development_percent"] is not None
+
+        device_state = state_content["device_state"]
+        assert set(device_state) == _EXPECTED_DEVICE_STATE_KEYS
+        assert device_state["driver"] == "mock"
+        assert device_state["connected"] is True
+        assert device_state["bean_temp_c"] is not None
+        assert device_state["env_temp_c"] is not None
+        assert device_state["heat_level_percent"] == 0
+        assert device_state["fan_level_percent"] == 100
+        assert device_state["cooling_on"] is False
+        assert isinstance(device_state["raw_vendor_data"], dict)
+
+        first_crack_status = state_content["first_crack_status"]
+        assert set(first_crack_status) == _EXPECTED_FIRST_CRACK_STATUS_KEYS
+        assert first_crack_status["mode"] == "disabled"
+        assert first_crack_status["status"] == "detected"
+        assert first_crack_status["detected_at_utc"] == state_content["first_crack_at_utc"]
+        assert (
+            first_crack_status["detected_monotonic_seconds"]
+            == state_content["first_crack_monotonic_seconds"]
+        )
+        assert first_crack_status["allow_manual_override"] is True
+        assert first_crack_status["reason"] is None
+
+        assert state_content["beans_added_at_utc"] is not None
+        assert state_content["beans_added_monotonic_seconds"] is not None
+        assert state_content["first_crack_at_utc"] is not None
+        assert state_content["first_crack_monotonic_seconds"] is not None
+        assert state_content["beans_dropped_at_utc"] is not None
+        assert state_content["beans_dropped_monotonic_seconds"] is not None
+        assert state_content["cooling_started_at_utc"] is not None
+        assert state_content["cooling_started_monotonic_seconds"] is not None
+        assert state_content["cooling_stopped_at_utc"] is not None
+        assert state_content["cooling_stopped_monotonic_seconds"] is not None
+        assert state_content["faulted_at_utc"] is None
+        assert state_content["faulted_monotonic_seconds"] is None
+        assert [event["kind"] for event in state_content["events"]] == [
             "beans_added",
             "first_crack_detected",
             "beans_dropped",
             "cooling_started",
             "cooling_stopped",
         ]
-        assert state_result.structuredContent["events"][2]["payload"] == {}
+        assert state_content["events"][2]["payload"] == {}
 
         export_result = cast(
             Any,


### PR DESCRIPTION
## Summary
- strengthen the public stdio MCP mock-roast test to assert the local Claude/operator flow and get_roast_state schema shape
- document the operational MCP flow, first-crack status meanings, explicit override tools, and drop_beans as the normal drop/cooling command
- update durable state docs to mark E4.1-S5 complete and point to E4.1-S6 next

Closes #108

## Validation
- ./.venv/bin/python -m pytest tests/test_package.py tests/test_mcp_server.py
- ./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov
- ./.venv/bin/python -m ruff check .
- ./.venv/bin/python -m ruff format --check .
- ./.venv/bin/python -m pyright

Normal CI remains mock-safe: no Hottop hardware, microphone, model download, real ONNX file, or network is required.