### PR TITLE
E4.1-S6: Add automatic T0 runtime path

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ The mock-safe Claude/operator flow is:
 3. Call `get_roast_state` to read both the authoritative session state and the
    current configured-device state. The response includes driver id, connected
    status, bean/environment temperatures when available, heat/fan levels,
-   cooling state, safe raw diagnostics, first-crack status, and lifecycle
-   timestamps for beans added, first crack, bean drop, cooling started, and
-   cooling stopped.
+   cooling state, safe raw diagnostics, T0 status, first-crack status, and
+   lifecycle timestamps for beans added, first crack, bean drop, cooling
+   started, and cooling stopped.
 4. Use `drop_beans` as the normal drop command. For the mock path and the
    Hottop compound drop path, this records `beans_dropped`, records
    `cooling_started` when the driver reports cooling active, turns heat off,
@@ -146,9 +146,17 @@ The mock-safe Claude/operator flow is:
 
 `mark_beans_added` and `mark_first_crack` are explicit override tools. They are
 kept available for operator recovery and controlled manual runs. The primary
-automatic runtime paths are internal: automatic T0 detection is owned by
-E4.1-S6, and audio-mode first-crack confirmation is owned by the session-owned
-first-crack runtime when `first_crack.mode: audio` is deliberately configured.
+automatic runtime paths are internal: automatic T0 detection can record
+`beans_added` when `session.auto_t0_detection_enabled` is enabled, and
+audio-mode first-crack confirmation is owned by the session-owned first-crack
+runtime when `first_crack.mode: audio` is deliberately configured.
+
+Automatic T0 is disabled by default. When enabled, `get_roast_state` reads the
+configured driver, tracks the max preheat bean temperature before T0, and
+records `beans_added` when the current bean temperature drops from that max by
+`session.auto_t0_drop_threshold_c`. `get_roast_state.t0_status` exposes the
+configured threshold, tracked charge temperature, current drop, and detected
+bean temperature when automatic T0 records the event.
 
 `get_roast_state.first_crack_status.status` is one of:
 
@@ -269,6 +277,7 @@ logging:
 
 session:
   auto_t0_detection_enabled: false
+  auto_t0_drop_threshold_c: 25.0
   ror_window_seconds: 60
   ror_min_sample_seconds: 10
 ```
@@ -290,6 +299,7 @@ Supported environment overrides:
 - `COFFEE_AUDIO_SAMPLE_RATE`
 - `COFFEE_AUDIO_WAV_PATH`
 - `COFFEE_ROAST_LOG_DIR`
+- `COFFEE_AUTO_T0_DROP_THRESHOLD_C`
 - `HF_HOME`
 
 `audio.source` can be `microphone` or `wav`. Microphone capture uses a

--- a/docs/session-summaries/2026-05-18-e4-1-s6-automatic-t0-runtime-path.md
+++ b/docs/session-summaries/2026-05-18-e4-1-s6-automatic-t0-runtime-path.md
@@ -15,14 +15,14 @@ mock-safe CI, and MCP state diagnostics.
 
 ## Context Usage
 
-Final context snapshot supplied by the operator after implementation and PR
+Latest context snapshot supplied by the operator after implementation and PR
 review fixes:
 
-- Context window: `33% left (177K used / 258K)`
-- 5h limit: `92% left`, resets `01:10 on 19 May`
+- Context window: `20% left (209K used / 258K)`
+- 5h limit: `90% left`, resets `01:10 on 19 May`
 - Weekly limit: `92% left`, resets `12:12 on 24 May`
-- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `03:17 on 19 May`
-- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `22:17 on 25 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `03:33 on 19 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `22:33 on 25 May`
 
 ## Pre-Story Verification
 
@@ -41,7 +41,7 @@ Before starting E4.1-S6:
 
 ## Implementation
 
-Updated:
+Initial implementation updated:
 
 - `src/coffee_roaster_mcp/config.py`
 - `src/coffee_roaster_mcp/session.py`
@@ -80,7 +80,7 @@ Out of scope kept out:
 
 ## Review Fixes
 
-Two actionable PR review comments were addressed:
+Four actionable PR review comments were addressed:
 
 - `7876ae2` - `fix: align auto t0 drop diagnostics with threshold`
   - Removed rounding from the stored `auto_t0_current_drop_c` diagnostic so a
@@ -93,6 +93,16 @@ Two actionable PR review comments were addressed:
     or stale driver readings cannot record `beans_added`.
   - Added an MCP regression proving a disconnected driver with a large stale
     temperature drop leaves the session in `pre_roast` with no events.
+- `b181710` - `fix: harden auto t0 audio and threshold handling`
+  - Rejected non-finite automatic T0 thresholds (`nan`, `inf`, `-inf`) during
+    config load, including YAML and `COFFEE_AUTO_T0_DROP_THRESHOLD_C`.
+  - Added first-crack runtime support for discarding queued audio windows at a
+    runtime boundary.
+  - Wired `get_roast_state` to discard queued pre-T0 detector windows when
+    automatic T0 records `beans_added`, before normal first-crack detector
+    processing resumes.
+  - Added config, runtime, and MCP regressions for the non-finite threshold and
+    queued pre-T0 audio-window cases.
 
 ## Validation
 
@@ -126,8 +136,18 @@ After the disconnected-driver review fix:
 - Ran `./.venv/bin/python -m ruff format --check .`: passed.
 - Ran `./.venv/bin/python -m pyright`: `0 errors`.
 
+After the non-finite threshold and queued pre-T0 audio-window review fixes:
+
+- Ran `./.venv/bin/python -m pytest tests/test_config.py tests/test_first_crack_runtime.py tests/test_mcp_server.py`:
+  `48 passed`.
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `298 passed`, required coverage `90.0%` reached, total coverage `90.06%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
+
 GitHub CI for `PR #117` on head
-`261916d78ba8ca4234312bbc1302bc9710a56f5d` passed:
+`b18171099e7171bb32fdea290af06f1d05e3024c` passed:
 
 - `Build Package`: passed.
 - `Checks`: passed.
@@ -141,7 +161,7 @@ GitHub CI for `PR #117` on head
 - Merge state: mergeable.
 - Branch: `feature/111-add-automatic-t0-runtime-path`.
 - Latest commit:
-  - `261916d` - `fix: skip auto t0 on disconnected driver state`
+  - `b181710` - `fix: harden auto t0 audio and threshold handling`
 
 ## Handoff
 

--- a/docs/session-summaries/2026-05-18-e4-1-s6-automatic-t0-runtime-path.md
+++ b/docs/session-summaries/2026-05-18-e4-1-s6-automatic-t0-runtime-path.md
@@ -1,0 +1,150 @@
+# E4.1-S6 Automatic T0 Runtime Path Session
+
+## Scope
+
+This session resumed after `PR #116` for `E4.1-S5` was squashed and
+merged, and issue `#108` was closed. Work started from updated `main` on
+branch `feature/111-add-automatic-t0-runtime-path` for issue `#111`,
+`E4.1-S6: Add automatic T0 runtime path`.
+
+The story goal was to add the internal automatic T0 path so an agent-driven
+roast can record authoritative `beans_added` without using `mark_beans_added`
+as the primary runtime path. Scope stayed bounded to configured-driver
+temperature reads, the one-session `RoastSessionStore` mutation boundary,
+mock-safe CI, and MCP state diagnostics.
+
+## Context Usage
+
+Final context snapshot supplied by the operator after implementation and PR
+review fixes:
+
+- Context window: `33% left (177K used / 258K)`
+- 5h limit: `92% left`, resets `01:10 on 19 May`
+- Weekly limit: `92% left`, resets `12:12 on 24 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `03:17 on 19 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `22:17 on 25 May`
+
+## Pre-Story Verification
+
+Before starting E4.1-S6:
+
+- Verified `PR #116` was merged and issue `#108` was closed.
+- Ran `git checkout main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding through merged
+  E4.1-S5 changes.
+- Read `AGENTS.md`, `docs/state/registry.md`,
+  `docs/state/github-issues.md`,
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+  `docs/session-summaries/2026-05-18-e4-1-s5-mcp-operational-readiness.md`,
+  and GitHub issue `#111`.
+- Created branch `feature/111-add-automatic-t0-runtime-path`.
+
+## Implementation
+
+Updated:
+
+- `src/coffee_roaster_mcp/config.py`
+- `src/coffee_roaster_mcp/session.py`
+- `src/coffee_roaster_mcp/mcp_server.py`
+- `tests/test_config.py`
+- `tests/test_session.py`
+- `tests/test_mcp_server.py`
+- `tests/test_package.py`
+- `README.md`
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+
+Behavior added:
+
+- Added `session.auto_t0_drop_threshold_c`, defaulting to `25.0`, while
+  keeping `session.auto_t0_detection_enabled` disabled by default.
+- Added `RoastSessionStore.process_auto_t0_reading_snapshot(...)` to track the
+  max preheat/charge bean temperature before T0 and record `beans_added` when
+  current bean temperature drops from that max by the configured threshold.
+- Preserved charge temperature, detected bean temperature, drop, threshold, and
+  `auto_t0` source in the automatic `beans_added` event payload.
+- Wired `get_roast_state` to process automatic T0 only after a successful
+  `RoasterDriver.read_state()` call and before first-crack runtime window
+  processing.
+- Added `get_roast_state.t0_status` with automatic T0 enabled/disabled status,
+  pending/detected state, charge temperature, current drop, threshold, and
+  detected bean-temperature diagnostics.
+- Preserved `mark_beans_added` as an explicit idempotent override.
+
+Out of scope kept out:
+
+- Rolling telemetry metrics and final log schemas.
+- Model training, ONNX export, Hugging Face sync.
+- Real microphone validation, live Hottop validation, end-to-end agent roast
+  validation, or broad release validation.
+
+## Review Fixes
+
+Two actionable PR review comments were addressed:
+
+- `7876ae2` - `fix: align auto t0 drop diagnostics with threshold`
+  - Removed rounding from the stored `auto_t0_current_drop_c` diagnostic so a
+    true drop such as `24.9996` against a `25.0` threshold does not display as
+    `25.0` while automatic T0 remains pending.
+  - Added session-store and MCP regressions for the near-threshold pending
+    case.
+- `261916d` - `fix: skip auto t0 on disconnected driver state`
+  - Gated automatic T0 processing on `device_state.connected`, so disconnected
+    or stale driver readings cannot record `beans_added`.
+  - Added an MCP regression proving a disconnected driver with a large stale
+    temperature drop leaves the session in `pre_roast` with no events.
+
+## Validation
+
+Initial implementation validation:
+
+- Ran `./.venv/bin/python -m pytest tests/test_config.py tests/test_session.py tests/test_mcp_server.py`:
+  `76 passed`.
+- Ran `./.venv/bin/python -m pytest tests/test_package.py`: `15 passed`.
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `289 passed`, required coverage `90.0%` reached, total coverage `90.06%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
+
+After the near-threshold review fix:
+
+- Ran `./.venv/bin/python -m pytest tests/test_session.py tests/test_mcp_server.py`:
+  `64 passed`.
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `291 passed`, required coverage `90.0%` reached, total coverage `90.06%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
+
+After the disconnected-driver review fix:
+
+- Ran `./.venv/bin/python -m pytest tests/test_mcp_server.py`: `22 passed`.
+- Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+  `292 passed`, required coverage `90.0%` reached, total coverage `90.06%`.
+- Ran `./.venv/bin/python -m ruff check .`: passed.
+- Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Ran `./.venv/bin/python -m pyright`: `0 errors`.
+
+GitHub CI for `PR #117` on head
+`261916d78ba8ca4234312bbc1302bc9710a56f5d` passed:
+
+- `Build Package`: passed.
+- `Checks`: passed.
+
+## Pull Request Status
+
+`PR #117` is open at
+<https://github.com/syamaner/coffee-roaster-mcp/pull/117>. At summary time:
+
+- PR state: open.
+- Merge state: mergeable.
+- Branch: `feature/111-add-automatic-t0-runtime-path`.
+- Latest commit:
+  - `261916d` - `fix: skip auto t0 on disconnected driver state`
+
+## Handoff
+
+Durable state now points to `E5-S1`, issue `#40`, for the rolling telemetry
+buffer. Continue to preserve normal CI as mock-safe: no Hottop hardware,
+microphone, model download, real ONNX file, or network should be required.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E4.1-S6`
-- Current target: Add automatic T0 runtime path
+- Active story: `E5-S1`
+- Current target: Implement rolling telemetry buffer
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -186,15 +186,22 @@ The first implementation milestone is a mock vertical slice that requires no roa
   shape drift. README docs now explain the operational flow, first-crack status
   meanings, explicit override semantics, and gated optional live Hottop/real
   microphone validation evidence.
-- Auto-T0 detection is disabled by default. `mark_beans_added` is authoritative.
+- `E4.1-S6` adds the automatic T0 runtime path. Auto-T0 detection is disabled by
+  default, but when `session.auto_t0_detection_enabled` is configured,
+  successful `get_roast_state` driver reads process the current bean
+  temperature before first-crack runtime windows. The session store tracks max
+  preheat/charge bean temperature before T0, records the authoritative
+  `beans_added` event when current bean temperature drops from that max by
+  `session.auto_t0_drop_threshold_c`, and preserves charge temperature,
+  detected bean temperature, drop, and threshold diagnostics in the event
+  payload and `get_roast_state.t0_status`. `mark_beans_added` remains an
+  explicit idempotent override.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
 
 ## Current Risks
 
-- Automatic T0 detection remains to be wired in E4.1-S6 before the fully
-  agent-driven roast path can avoid `mark_beans_added` as its primary T0 path.
 - MCP Registry publishing is preview and needs verification before release.
 - First-crack event integration must preserve one authoritative session timeline.
 - Log schema changes need compatibility discipline once users start collecting roast logs.
@@ -421,7 +428,7 @@ first crack has happened through MCP tools.
     documented as the normal drop/cooling command, and optional live
     Hottop/real microphone validation docs remain explicitly gated.
 
-- [ ] `E4.1-S6` Add automatic T0 runtime path.
+- [x] `E4.1-S6` Add automatic T0 runtime path.
   - Done when `session.auto_t0_detection_enabled` can record the authoritative
     `beans_added` event internally through `RoastSessionStore` without using
     `mark_beans_added` as the primary path, tracks max preheat/charge bean
@@ -1217,6 +1224,33 @@ After completing a story:
     31 passed.
   - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
     280 passed, required coverage `90.0%` reached, total coverage `90.15%`.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E4.1-S6:
+  - Added `session.auto_t0_drop_threshold_c`, defaulting to `25.0`, while
+    keeping `session.auto_t0_detection_enabled` disabled by default.
+  - Added session-store automatic T0 processing that tracks max preheat/charge
+    bean temperature before T0, requires at least one prior valid baseline
+    reading, records `beans_added` when the current bean temperature drops from
+    that max by the configured threshold, and stores charge temperature,
+    detected bean temperature, drop, threshold, and `auto_t0` source in the
+    event payload.
+  - Wired `get_roast_state` to process automatic T0 only after a successful
+    configured-driver `read_state()` call and before first-crack runtime window
+    processing, preserving driver-read failure no-mutation behavior.
+  - Added `get_roast_state.t0_status` with enabled/disabled status, pending or
+    detected state, charge temperature, current drop, threshold, and detected
+    bean-temperature diagnostics.
+  - Preserved `mark_beans_added` as an explicit idempotent override and kept
+    rolling telemetry metrics, final log schemas, model training/export/sync,
+    real microphone validation, live Hottop validation, end-to-end agent roast
+    validation, and broad release validation out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_config.py tests/test_session.py tests/test_mcp_server.py`:
+    76 passed.
+  - Ran `./.venv/bin/python -m pytest tests/test_package.py`: 15 passed.
+  - Ran `./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov`:
+    289 passed, required coverage `90.0%` reached, total coverage `90.06%`.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -82,8 +82,8 @@ hardware, or network access. E4-S10 did not wire live Hottop command behavior
 or automatic first-crack detector startup into the MCP runtime; those gaps moved
 into Epic 4.1.
 
-Epic 4.1 is now active before Epic 5 to close operational MCP runtime gaps.
-The target user flow is: install the MCP server locally in Claude, start a
+Epic 4.1 is now complete and closed the operational MCP runtime gaps before
+Epic 5. The target user flow is: install the MCP server locally in Claude, start a
 roast, adjust the configured roaster through MCP tools, read current device and
 session state, and know whether first crack has happened. E4.1 covers
 driver-backed MCP control tools, current roaster state exposure, released ONNX
@@ -148,13 +148,25 @@ explicit override semantics for `mark_beans_added` and `mark_first_crack`,
 `drop_beans` as the normal cooling transition, and gated optional live
 Hottop/real microphone validation evidence. Normal CI remains mock-safe.
 
+E4.1-S6 added the automatic T0 runtime path. Automatic T0 remains disabled by
+default, but when `session.auto_t0_detection_enabled` is configured, successful
+`get_roast_state` driver reads process the current bean temperature before
+first-crack runtime windows. The session store tracks the max preheat/charge
+bean temperature before T0, records the authoritative `beans_added` event when
+the current bean temperature drops from that max by
+`session.auto_t0_drop_threshold_c`, and preserves charge temperature,
+detected bean temperature, drop, and threshold diagnostics in the event payload
+and `get_roast_state.t0_status`. The explicit `mark_beans_added` override
+remains available and idempotent. Driver read failures still surface without
+session mutation, and normal CI remains mock-safe.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E4.1-S6: add automatic T0 runtime path.
+The next story is E5-S1: implement rolling telemetry buffer.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/config.py
+++ b/src/coffee_roaster_mcp/config.py
@@ -73,6 +73,7 @@ class SessionConfig:
     """Roast session metric configuration."""
 
     auto_t0_detection_enabled: bool = False
+    auto_t0_drop_threshold_c: float = 25.0
     ror_window_seconds: int = 60
     ror_min_sample_seconds: int = 10
 
@@ -261,6 +262,12 @@ def _session_from_mapping(raw: Mapping[str, Any]) -> SessionConfig:
             False,
             label="session.auto_t0_detection_enabled",
         ),
+        auto_t0_drop_threshold_c=_positive_float(
+            raw,
+            "auto_t0_drop_threshold_c",
+            25.0,
+            label="session.auto_t0_drop_threshold_c",
+        ),
         ror_window_seconds=_integer(
             raw,
             "ror_window_seconds",
@@ -366,6 +373,16 @@ def _apply_env_overrides(config: AppConfig, environ: Mapping[str, str]) -> AppCo
             logging,
             log_dir=Path(_required_string(environ["COFFEE_ROAST_LOG_DIR"], "COFFEE_ROAST_LOG_DIR")),
         )
+    if "COFFEE_AUTO_T0_DROP_THRESHOLD_C" in environ:
+        session = replace(
+            config.session,
+            auto_t0_drop_threshold_c=_parse_positive_float(
+                environ["COFFEE_AUTO_T0_DROP_THRESHOLD_C"],
+                "COFFEE_AUTO_T0_DROP_THRESHOLD_C",
+            ),
+        )
+    else:
+        session = config.session
 
     return replace(
         config,
@@ -373,6 +390,7 @@ def _apply_env_overrides(config: AppConfig, environ: Mapping[str, str]) -> AppCo
         first_crack=first_crack,
         audio=audio,
         logging=logging,
+        session=session,
     )
 
 
@@ -465,6 +483,36 @@ def _float(raw: Mapping[str, Any], key: str, default: float, label: str | None =
         except ValueError as exc:
             raise ConfigError(f"{error_key} must be a number.") from exc
     raise ConfigError(f"{error_key} must be a number.")
+
+
+def _positive_float(
+    raw: Mapping[str, Any],
+    key: str,
+    default: float,
+    label: str | None = None,
+) -> float:
+    error_key = label or key
+    return _parse_positive_float(raw.get(key, default), error_key)
+
+
+def _parse_positive_float(value: object, key: str) -> float:
+    parsed = _parse_float(value, key)
+    if parsed <= 0:
+        raise ConfigError(f"{key} must be greater than 0.")
+    return parsed
+
+
+def _parse_float(value: object, key: str) -> float:
+    if isinstance(value, bool):
+        raise ConfigError(f"{key} must be a number.")
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError as exc:
+            raise ConfigError(f"{key} must be a number.") from exc
+    raise ConfigError(f"{key} must be a number.")
 
 
 def _temperature_unit(value: str, label: str = "temperature_unit") -> TemperatureUnit:

--- a/src/coffee_roaster_mcp/config.py
+++ b/src/coffee_roaster_mcp/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
@@ -497,7 +498,7 @@ def _positive_float(
 
 def _parse_positive_float(value: object, key: str) -> float:
     parsed = _parse_float(value, key)
-    if parsed <= 0:
+    if not math.isfinite(parsed) or parsed <= 0:
         raise ConfigError(f"{key} must be greater than 0.")
     return parsed
 

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -220,6 +220,22 @@ class FirstCrackSessionRuntime:
             self._stop_locked(reason=reason)
             return self.snapshot()
 
+    def discard_queued_windows_for_session(
+        self,
+        session_id: str,
+        *,
+        reason: str,
+    ) -> FirstCrackRuntimeSnapshot:
+        """Drop queued detector windows that were captured before a runtime boundary."""
+        with self._lock:
+            if self._active_session_id != session_id:
+                return self.snapshot()
+            if self._pipeline is not None:
+                self._pipeline.drain_windows()
+            if self._status == "pending":
+                self._reason = reason
+            return self.snapshot()
+
     def shutdown(self) -> FirstCrackRuntimeSnapshot:
         """Stop any active detector runtime for process shutdown."""
         with self._lock:

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -706,7 +706,7 @@ def _process_auto_t0_for_active_session(
         return
     if active_session.phase != "pre_roast" or active_session.beans_added_at_utc is not None:
         return
-    if device_state.bean_temp_c is None:
+    if not device_state.connected or device_state.bean_temp_c is None:
         return
     server_context.session_store.process_auto_t0_reading_snapshot(
         active_session,

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -104,6 +104,7 @@ class RuntimeConfigSnapshot:
         log_dir: Configured log directory.
         sample_interval_seconds: Telemetry sample interval in seconds.
         auto_t0_detection_enabled: Whether automatic T0 detection is enabled.
+        auto_t0_drop_threshold_c: Bean-temperature drop threshold for automatic T0.
     """
 
     config_source: str | None
@@ -119,6 +120,7 @@ class RuntimeConfigSnapshot:
     log_dir: str
     sample_interval_seconds: float
     auto_t0_detection_enabled: bool
+    auto_t0_drop_threshold_c: float
 
 
 @dataclass(frozen=True)
@@ -187,6 +189,32 @@ class FirstCrackStatus:
     reason: str | None = None
 
 
+T0RuntimeStatus = Literal["disabled", "pending", "detected", "unavailable"]
+
+
+@dataclass(frozen=True)
+class T0Status:
+    """Serializable automatic T0 status for operator decisions.
+
+    Attributes:
+        auto_detection_enabled: Whether automatic T0 detection is enabled.
+        status: Current automatic T0 detection status.
+        charge_temperature_c: Max preheat/charge bean temperature seen before T0.
+        current_drop_c: Current drop from charge temperature when available.
+        drop_threshold_c: Configured bean-temperature drop threshold.
+        detected_bean_temperature_c: Bean temperature at the detected T0 reading.
+        reason: Human-readable reason when status needs extra context.
+    """
+
+    auto_detection_enabled: bool
+    status: T0RuntimeStatus
+    charge_temperature_c: float | None
+    current_drop_c: float | None
+    drop_threshold_c: float
+    detected_bean_temperature_c: float | None
+    reason: str | None = None
+
+
 @dataclass(frozen=True)
 class RoastSessionState:
     """Serializable roast session state returned by MCP tools."""
@@ -216,6 +244,7 @@ class RoastSessionState:
     development_time_seconds: float | None
     development_percent: float | None
     device_state: RoasterDeviceState | None
+    t0_status: T0Status
     first_crack_status: FirstCrackStatus
     events: tuple[EventSnapshot, ...]
     log_dir: str | None
@@ -386,6 +415,7 @@ def create_mcp_server(
             log_dir=str(config.logging.log_dir),
             sample_interval_seconds=config.logging.sample_interval_seconds,
             auto_t0_detection_enabled=config.session.auto_t0_detection_enabled,
+            auto_t0_drop_threshold_c=config.session.auto_t0_drop_threshold_c,
         )
 
     @mcp.tool()
@@ -419,6 +449,11 @@ def create_mcp_server(
         server_context = ctx.request_context.lifespan_context
         session = _resolve_session(server_context, session_id=session_id)
         device_state = _read_current_device_state(server_context)
+        _process_auto_t0_for_active_session(
+            server_context,
+            session_id=session_id,
+            device_state=device_state,
+        )
         _process_first_crack_runtime_for_active_session(server_context, session_id=session_id)
         session = _resolve_session(server_context, session_id=session_id)
         return _serialize_session_state(
@@ -655,6 +690,31 @@ def _process_first_crack_runtime_for_active_session(
     )
 
 
+def _process_auto_t0_for_active_session(
+    server_context: ServerContext,
+    *,
+    session_id: str | None,
+    device_state: RoasterDeviceState,
+) -> None:
+    """Process automatic T0 after a successful configured-driver state read."""
+    if not server_context.config.session.auto_t0_detection_enabled:
+        return
+    active_session = server_context.session_store.get_active_session()
+    if active_session is None:
+        return
+    if session_id is not None and session_id != active_session.id:
+        return
+    if active_session.phase != "pre_roast" or active_session.beans_added_at_utc is not None:
+        return
+    if device_state.bean_temp_c is None:
+        return
+    server_context.session_store.process_auto_t0_reading_snapshot(
+        active_session,
+        bean_temp_c=device_state.bean_temp_c,
+        drop_threshold_c=server_context.config.session.auto_t0_drop_threshold_c,
+    )
+
+
 def _run_reserved_driver_control(
     server_context: ServerContext,
     session: RoastSession,
@@ -877,6 +937,7 @@ def _serialize_session_state(
         development_time_seconds=metrics.development_time_seconds,
         development_percent=metrics.development_percent,
         device_state=device_state,
+        t0_status=_serialize_t0_status(session, config=config),
         first_crack_status=_serialize_first_crack_status(
             session,
             config=config,
@@ -984,6 +1045,76 @@ def _serialize_first_crack_status(
         allow_manual_override=config.first_crack.allow_manual_override,
         reason=reason,
     )
+
+
+def _serialize_t0_status(session: RoastSession, *, config: AppConfig) -> T0Status:
+    """Derive automatic T0 status from config and the session timeline."""
+    beans_added_event = next(
+        (event for event in session.event_timeline if event.kind == "beans_added"),
+        None,
+    )
+    detected_temp = None
+    if beans_added_event is not None:
+        payload_value = beans_added_event.payload.get("detected_bean_temperature_c")
+        if isinstance(payload_value, (int, float)) and not isinstance(payload_value, bool):
+            detected_temp = float(payload_value)
+    if session.beans_added_at_utc is not None:
+        return T0Status(
+            auto_detection_enabled=config.session.auto_t0_detection_enabled,
+            status="detected",
+            charge_temperature_c=_event_or_session_charge_temperature(
+                beans_added_event,
+                session,
+            ),
+            current_drop_c=session.auto_t0_current_drop_c,
+            drop_threshold_c=config.session.auto_t0_drop_threshold_c,
+            detected_bean_temperature_c=detected_temp,
+        )
+    if not config.session.auto_t0_detection_enabled:
+        return T0Status(
+            auto_detection_enabled=False,
+            status="disabled",
+            charge_temperature_c=session.auto_t0_charge_temperature_c,
+            current_drop_c=session.auto_t0_current_drop_c,
+            drop_threshold_c=config.session.auto_t0_drop_threshold_c,
+            detected_bean_temperature_c=None,
+            reason="Automatic T0 detection is disabled by configuration.",
+        )
+    if session.phase != "pre_roast":
+        return T0Status(
+            auto_detection_enabled=True,
+            status="unavailable",
+            charge_temperature_c=session.auto_t0_charge_temperature_c,
+            current_drop_c=session.auto_t0_current_drop_c,
+            drop_threshold_c=config.session.auto_t0_drop_threshold_c,
+            detected_bean_temperature_c=None,
+            reason=f"Automatic T0 is unavailable while phase is {session.phase}.",
+        )
+    reason = "Waiting for bean temperature to drop from tracked charge temperature."
+    if session.auto_t0_preheat_sample_count == 0:
+        reason = "Waiting for a valid preheat bean-temperature reading."
+    elif session.auto_t0_preheat_sample_count == 1:
+        reason = "Waiting for a second valid bean-temperature reading before detecting T0."
+    return T0Status(
+        auto_detection_enabled=True,
+        status="pending",
+        charge_temperature_c=session.auto_t0_charge_temperature_c,
+        current_drop_c=session.auto_t0_current_drop_c,
+        drop_threshold_c=config.session.auto_t0_drop_threshold_c,
+        detected_bean_temperature_c=None,
+        reason=reason,
+    )
+
+
+def _event_or_session_charge_temperature(
+    event: RoastEvent | None,
+    session: RoastSession,
+) -> float | None:
+    if event is not None:
+        value = event.payload.get("charge_temperature_c")
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    return session.auto_t0_charge_temperature_c
 
 
 def _serialize_control_result(session: RoastSession) -> ControlCommandResult:

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -449,11 +449,16 @@ def create_mcp_server(
         server_context = ctx.request_context.lifespan_context
         session = _resolve_session(server_context, session_id=session_id)
         device_state = _read_current_device_state(server_context)
-        _process_auto_t0_for_active_session(
+        auto_t0_recorded = _process_auto_t0_for_active_session(
             server_context,
             session_id=session_id,
             device_state=device_state,
         )
+        if auto_t0_recorded:
+            server_context.first_crack_runtime.discard_queued_windows_for_session(
+                session.id,
+                reason="Dropped queued pre-T0 detector windows after automatic T0.",
+            )
         _process_first_crack_runtime_for_active_session(server_context, session_id=session_id)
         session = _resolve_session(server_context, session_id=session_id)
         return _serialize_session_state(
@@ -695,24 +700,25 @@ def _process_auto_t0_for_active_session(
     *,
     session_id: str | None,
     device_state: RoasterDeviceState,
-) -> None:
+) -> bool:
     """Process automatic T0 after a successful configured-driver state read."""
     if not server_context.config.session.auto_t0_detection_enabled:
-        return
+        return False
     active_session = server_context.session_store.get_active_session()
     if active_session is None:
-        return
+        return False
     if session_id is not None and session_id != active_session.id:
-        return
+        return False
     if active_session.phase != "pre_roast" or active_session.beans_added_at_utc is not None:
-        return
+        return False
     if not device_state.connected or device_state.bean_temp_c is None:
-        return
-    server_context.session_store.process_auto_t0_reading_snapshot(
+        return False
+    event, _ = server_context.session_store.process_auto_t0_reading_snapshot(
         active_session,
         bean_temp_c=device_state.bean_temp_c,
         drop_threshold_c=server_context.config.session.auto_t0_drop_threshold_c,
     )
+    return event is not None
 
 
 def _run_reserved_driver_control(

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -247,6 +247,9 @@ class RoastSession:
         heat_level_percent: Latest in-memory heat setting for the active mock path.
         fan_level_percent: Latest in-memory fan setting for the active mock path.
         cooling_on: Whether cooling is currently active in the session state.
+        auto_t0_charge_temperature_c: Max preheat/charge bean temperature before T0.
+        auto_t0_current_drop_c: Current drop from the tracked charge temperature.
+        auto_t0_preheat_sample_count: Number of valid pre-T0 bean-temperature samples.
         event_timeline: Shared ordered event timeline for future runtime stories.
         telemetry_buffer: Rolling telemetry sample buffer.
         log_writer: Append-only log writer reference when available.
@@ -273,6 +276,9 @@ class RoastSession:
     heat_level_percent: int = 0
     fan_level_percent: int = 0
     cooling_on: bool = False
+    auto_t0_charge_temperature_c: float | None = None
+    auto_t0_current_drop_c: float | None = None
+    auto_t0_preheat_sample_count: int = 0
     event_timeline: list[RoastEvent] = field(default_factory=_event_timeline_default)
     telemetry_buffer: deque[TelemetrySample] = field(default_factory=_telemetry_buffer_default)
     log_writer: LogWriterReference | None = None
@@ -888,6 +894,66 @@ class RoastSessionStore:
             event = self.record_event(session, kind, payload=payload)
             return event, _copy_session_for_read(session)
 
+    def process_auto_t0_reading_snapshot(
+        self,
+        session: RoastSession,
+        *,
+        bean_temp_c: float,
+        drop_threshold_c: float,
+    ) -> tuple[RoastEvent | None, RoastSession]:
+        """Process one bean-temperature reading for automatic T0 detection.
+
+        Args:
+            session: Session to mutate.
+            bean_temp_c: Current bean temperature from the configured driver.
+            drop_threshold_c: Required drop from max preheat temperature.
+
+        Returns:
+            The recorded beans-added event when this reading crosses the
+            threshold, otherwise `None`, plus an atomic session snapshot.
+
+        Raises:
+            SessionLifecycleError: If called outside the pre-T0 active phase or
+                with non-finite inputs.
+        """
+        with self._lock:
+            self._assert_latest_active_session(session)
+            if session.beans_added_at_utc is not None:
+                return self._get_existing_singleton_event(session, "beans_added"), (
+                    _copy_session_for_read(session)
+                )
+            _validate_event_transition(session, "beans_added")
+            current_temp = float(bean_temp_c)
+            threshold = float(drop_threshold_c)
+            if not math.isfinite(current_temp):
+                raise SessionLifecycleError("Automatic T0 bean temperature must be finite.")
+            if not math.isfinite(threshold) or threshold <= 0:
+                raise SessionLifecycleError("Automatic T0 threshold must be greater than 0.")
+
+            previous_max = session.auto_t0_charge_temperature_c
+            if previous_max is None or current_temp > previous_max:
+                session.auto_t0_charge_temperature_c = current_temp
+                previous_max = current_temp
+
+            session.auto_t0_preheat_sample_count += 1
+            drop_c = previous_max - current_temp
+            session.auto_t0_current_drop_c = round(max(0.0, drop_c), 3)
+            if session.auto_t0_preheat_sample_count < 2 or drop_c < threshold:
+                return None, _copy_session_for_read(session)
+
+            event = self.record_event(
+                session,
+                "beans_added",
+                payload={
+                    "source": "auto_t0",
+                    "charge_temperature_c": round(previous_max, 3),
+                    "detected_bean_temperature_c": round(current_temp, 3),
+                    "drop_c": round(drop_c, 3),
+                    "drop_threshold_c": round(threshold, 3),
+                },
+            )
+            return event, _copy_session_for_read(session)
+
     def record_first_crack_detection_snapshot(
         self,
         session: RoastSession,
@@ -1381,6 +1447,9 @@ def _copy_session_for_read(session: RoastSession) -> RoastSession:
         heat_level_percent=session.heat_level_percent,
         fan_level_percent=session.fan_level_percent,
         cooling_on=session.cooling_on,
+        auto_t0_charge_temperature_c=session.auto_t0_charge_temperature_c,
+        auto_t0_current_drop_c=session.auto_t0_current_drop_c,
+        auto_t0_preheat_sample_count=session.auto_t0_preheat_sample_count,
         event_timeline=deepcopy(session.event_timeline),
         telemetry_buffer=deque(),
         log_writer=session.log_writer,

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -937,7 +937,7 @@ class RoastSessionStore:
 
             session.auto_t0_preheat_sample_count += 1
             drop_c = previous_max - current_temp
-            session.auto_t0_current_drop_c = round(max(0.0, drop_c), 3)
+            session.auto_t0_current_drop_c = max(0.0, drop_c)
             if session.auto_t0_preheat_sample_count < 2 or drop_c < threshold:
                 return None, _copy_session_for_read(session)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -193,6 +193,26 @@ def test_invalid_auto_t0_threshold_fails(tmp_path: Path) -> None:
         load_config(config_path, environ={})
 
 
+@pytest.mark.parametrize("threshold", ["nan", "inf", "-inf"])
+def test_non_finite_auto_t0_threshold_fails(tmp_path: Path, threshold: str) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        f"session:\n  auto_t0_drop_threshold_c: {threshold}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigError, match="session.auto_t0_drop_threshold_c"):
+        load_config(config_path, environ={})
+
+
+def test_non_finite_auto_t0_threshold_environment_override_fails(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("roaster:\n  driver: mock\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="COFFEE_AUTO_T0_DROP_THRESHOLD_C"):
+        load_config(config_path, environ={"COFFEE_AUTO_T0_DROP_THRESHOLD_C": "nan"})
+
+
 def test_error_messages_include_section_context(tmp_path: Path) -> None:
     config_path = tmp_path / "coffee-roaster-mcp.yaml"
     config_path.write_text("roaster:\n  baudrate: invalid\n", encoding="utf-8")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ def test_default_config_allows_mock_run_without_file(
     assert config.logging.log_dir == Path("./logs")
     assert config.logging.export_formats == ("jsonl", "csv", "summary")
     assert config.session.auto_t0_detection_enabled is False
+    assert config.session.auto_t0_drop_threshold_c == 25.0
 
 
 def test_missing_explicit_config_file_fails(tmp_path: Path) -> None:
@@ -65,6 +66,7 @@ logging:
     - summary
 session:
   auto_t0_detection_enabled: true
+  auto_t0_drop_threshold_c: 20.5
   ror_window_seconds: 45
   ror_min_sample_seconds: 12
 """,
@@ -94,6 +96,7 @@ session:
     assert config.logging.sample_interval_seconds == 0.5
     assert config.logging.export_formats == ("jsonl", "summary")
     assert config.session.auto_t0_detection_enabled is True
+    assert config.session.auto_t0_drop_threshold_c == 20.5
     assert config.session.ror_window_seconds == 45
     assert config.session.ror_min_sample_seconds == 12
 
@@ -135,6 +138,7 @@ logging:
             "COFFEE_AUDIO_SAMPLE_RATE": "16000",
             "COFFEE_AUDIO_WAV_PATH": "",
             "COFFEE_ROAST_LOG_DIR": "/tmp/roasts",
+            "COFFEE_AUTO_T0_DROP_THRESHOLD_C": "30",
         },
     )
 
@@ -152,6 +156,7 @@ logging:
     assert config.audio.sample_rate == 16_000
     assert config.audio.wav_path is None
     assert config.logging.log_dir == Path("/tmp/roasts")
+    assert config.session.auto_t0_drop_threshold_c == 30.0
 
 
 def test_environment_config_path_is_supported(tmp_path: Path) -> None:
@@ -177,6 +182,14 @@ def test_invalid_audio_source_fails(tmp_path: Path) -> None:
     config_path.write_text("audio:\n  source: bluetooth\n", encoding="utf-8")
 
     with pytest.raises(ConfigError, match="audio.source"):
+        load_config(config_path, environ={})
+
+
+def test_invalid_auto_t0_threshold_fails(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("session:\n  auto_t0_drop_threshold_c: 0\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="session.auto_t0_drop_threshold_c"):
         load_config(config_path, environ={})
 
 

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -73,6 +73,9 @@ class FakeAudioPipeline:
         del self._windows[:max_windows]
         return drained
 
+    def add_window(self, window: AudioWindow) -> None:
+        self._windows.append(window)
+
     def snapshot(self) -> AudioCaptureSnapshot:
         return AudioCaptureSnapshot(
             running=self.started and not self.stopped,
@@ -169,6 +172,56 @@ def test_audio_runtime_processes_after_beans_added_and_records_once() -> None:
         "first_crack_detected",
     ]
     assert session.first_crack_monotonic_seconds == 6.0
+
+
+def test_audio_runtime_can_discard_queued_pre_t0_windows() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(
+                confirmed=True,
+                confidence=0.94,
+                detected_at_monotonic_seconds=506.0,
+            ),
+        )
+    )
+    pipeline = FakeAudioPipeline(
+        (
+            _audio_window(sequence_number=1, started_at_monotonic_seconds=501.0),
+            _audio_window(sequence_number=2, started_at_monotonic_seconds=502.0),
+        )
+    )
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio", revision="v0.1.0")),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            backend,
+        ),
+    )
+
+    runtime.start_for_session(session)
+    discarded = runtime.discard_queued_windows_for_session(
+        session.id,
+        reason="automatic T0 boundary",
+    )
+    pipeline.add_window(_audio_window(sequence_number=3, started_at_monotonic_seconds=506.0))
+    clock.monotonic_value = 505.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 510.0
+    detected = runtime.process_available_windows(session_store=store, session=session)
+
+    assert discarded.queued_window_count == 0
+    assert discarded.reason == "automatic T0 boundary"
+    assert detected.status == "detected"
+    assert [window.sequence_number for window in backend.windows] == [3]
+    assert [event.kind for event in session.event_timeline] == [
+        "beans_added",
+        "first_crack_detected",
+    ]
 
 
 def test_audio_runtime_keeps_pending_status_when_detector_does_not_confirm() -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -312,6 +312,45 @@ def test_get_roast_state_records_automatic_t0_after_configured_drop(
     }
 
 
+def test_get_roast_state_discards_queued_first_crack_windows_after_auto_t0(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "first_crack:",
+                "  mode: audio",
+                "session:",
+                "  auto_t0_detection_enabled: true",
+                "  auto_t0_drop_threshold_c: 25",
+                f"logging:\n  log_dir: {tmp_path / 'logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(bean_temp_c=170.0)
+    runtime = FakeFirstCrackRuntime(record_first_crack_on_process=True)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    _set_first_crack_runtime(server_context, runtime)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "get_roast_state", ctx)
+    driver.bean_temp_c = 145.0
+    state = _call_tool(server, "get_roast_state", ctx)
+
+    assert state.phase == "development"
+    assert [event.kind for event in state.events] == [
+        "beans_added",
+        "first_crack_detected",
+    ]
+    assert runtime.discarded_sessions == [state.session_id]
+    assert runtime.processed_sessions == [state.session_id, state.session_id]
+
+
 def test_get_roast_state_auto_t0_uses_max_preheat_and_ignores_small_drops(
     tmp_path: Path,
 ) -> None:
@@ -1081,6 +1120,7 @@ class FakeFirstCrackRuntime:
         self.started_sessions: list[str] = []
         self.processed_sessions: list[str] = []
         self.stopped_sessions: list[str] = []
+        self.discarded_sessions: list[str] = []
 
     def start_for_session(self, session: RoastSession) -> FirstCrackRuntimeSnapshot:
         self.active_session_id = session.id
@@ -1094,13 +1134,27 @@ class FakeFirstCrackRuntime:
         session: RoastSession,
     ) -> FirstCrackRuntimeSnapshot:
         self.processed_sessions.append(session.id)
-        if self.record_first_crack_on_process and session.first_crack_at_utc is None:
+        if (
+            self.record_first_crack_on_process
+            and session.phase == "roasting"
+            and session.first_crack_at_utc is None
+        ):
             session_store.record_event_snapshot(session, "first_crack_detected")
             self.status = "detected"
         return self.snapshot()
 
     def stop_for_session(self, session_id: str, *, reason: str) -> FirstCrackRuntimeSnapshot:
         self.stopped_sessions.append(session_id)
+        self.reason = reason
+        return self.snapshot()
+
+    def discard_queued_windows_for_session(
+        self,
+        session_id: str,
+        *,
+        reason: str,
+    ) -> FirstCrackRuntimeSnapshot:
+        self.discarded_sessions.append(session_id)
         self.reason = reason
         return self.snapshot()
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -342,14 +342,49 @@ def test_get_roast_state_auto_t0_uses_max_preheat_and_ignores_small_drops(
     assert small_drop_state.phase == "pre_roast"
     assert small_drop_state.t0_status.status == "pending"
     assert small_drop_state.t0_status.charge_temperature_c == 175.0
-    assert small_drop_state.t0_status.current_drop_c == 24.9
+    assert small_drop_state.t0_status.current_drop_c is not None
+    assert abs(small_drop_state.t0_status.current_drop_c - 24.9) < 0.000001
 
     driver.bean_temp_c = 144.9
     detected_state = _call_tool(server, "get_roast_state", ctx)
     assert detected_state.phase == "roasting"
     assert detected_state.t0_status.status == "detected"
     assert detected_state.t0_status.charge_temperature_c == 175.0
-    assert detected_state.t0_status.current_drop_c == 30.1
+    assert detected_state.t0_status.current_drop_c is not None
+    assert abs(detected_state.t0_status.current_drop_c - 30.1) < 0.000001
+
+
+def test_get_roast_state_auto_t0_pending_drop_does_not_round_to_threshold(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "session:",
+                "  auto_t0_detection_enabled: true",
+                "  auto_t0_drop_threshold_c: 25",
+                f"logging:\n  log_dir: {tmp_path / 'logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(bean_temp_c=170.0)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "get_roast_state", ctx)
+    driver.bean_temp_c = 145.0004
+    state = _call_tool(server, "get_roast_state", ctx)
+
+    assert state.phase == "pre_roast"
+    assert state.t0_status.status == "pending"
+    assert state.t0_status.current_drop_c is not None
+    assert abs(state.t0_status.current_drop_c - 24.9996) < 0.000001
+    assert state.t0_status.current_drop_c < state.t0_status.drop_threshold_c
 
 
 def test_get_roast_state_auto_t0_waits_for_valid_baseline(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -354,6 +354,42 @@ def test_get_roast_state_auto_t0_uses_max_preheat_and_ignores_small_drops(
     assert abs(detected_state.t0_status.current_drop_c - 30.1) < 0.000001
 
 
+def test_get_roast_state_auto_t0_ignores_disconnected_driver_readings(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "session:",
+                "  auto_t0_detection_enabled: true",
+                "  auto_t0_drop_threshold_c: 25",
+                f"logging:\n  log_dir: {tmp_path / 'logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(bean_temp_c=170.0)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "get_roast_state", ctx)
+    driver.connected = False
+    driver.bean_temp_c = 140.0
+    disconnected_state = _call_tool(server, "get_roast_state", ctx)
+
+    assert disconnected_state.phase == "pre_roast"
+    assert disconnected_state.events == ()
+    assert disconnected_state.device_state is not None
+    assert disconnected_state.device_state.connected is False
+    assert disconnected_state.t0_status.status == "pending"
+    assert disconnected_state.t0_status.charge_temperature_c == 170.0
+    assert disconnected_state.t0_status.current_drop_c == 0.0
+
+
 def test_get_roast_state_auto_t0_pending_drop_does_not_round_to_threshold(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -197,6 +197,8 @@ def test_get_roast_state_exposes_current_driver_state_and_event_timestamps(
     assert state.first_crack_status.mode == "disabled"
     assert state.first_crack_status.detected_at_utc is None
     assert state.first_crack_status.detected_monotonic_seconds is None
+    assert state.t0_status.status == "detected"
+    assert state.t0_status.auto_detection_enabled is False
 
 
 def test_get_roast_state_driver_read_failure_does_not_mutate_session(
@@ -220,6 +222,168 @@ def test_get_roast_state_driver_read_failure_does_not_mutate_session(
     state = _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
     assert [event.kind for event in state.events] == ["beans_added"]
     assert state.phase == "roasting"
+
+
+def test_get_roast_state_auto_t0_driver_read_failure_does_not_mutate_session(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "session:",
+                "  auto_t0_detection_enabled: true",
+                f"logging:\n  log_dir: {tmp_path / 'logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(fail_read=True, bean_temp_c=170.0)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    with pytest.raises(RuntimeError, match="Could not read current roaster state"):
+        _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+
+    driver.fail_read = False
+    driver.bean_temp_c = 145.0
+    state = _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+    assert state.phase == "pre_roast"
+    assert state.events == ()
+    assert state.t0_status.status == "pending"
+    assert state.t0_status.charge_temperature_c == 145.0
+    assert state.t0_status.current_drop_c == 0.0
+
+
+def test_get_roast_state_records_automatic_t0_after_configured_drop(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "session:",
+                "  auto_t0_detection_enabled: true",
+                "  auto_t0_drop_threshold_c: 25",
+                f"logging:\n  log_dir: {tmp_path / 'logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(bean_temp_c=170.0)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    first_state = _call_tool(server, "get_roast_state", ctx)
+    assert first_state.phase == "pre_roast"
+    assert first_state.beans_added_at_utc is None
+    assert first_state.t0_status.status == "pending"
+    assert first_state.t0_status.charge_temperature_c == 170.0
+    assert first_state.t0_status.current_drop_c == 0.0
+
+    driver.bean_temp_c = 145.0
+    threshold_state = _call_tool(
+        server,
+        "get_roast_state",
+        ctx,
+        session_id=start_result.session.session_id,
+    )
+    assert threshold_state.phase == "roasting"
+    assert threshold_state.beans_added_at_utc is not None
+    assert threshold_state.t0_status.status == "detected"
+    assert threshold_state.t0_status.auto_detection_enabled is True
+    assert threshold_state.t0_status.charge_temperature_c == 170.0
+    assert threshold_state.t0_status.current_drop_c == 25.0
+    assert threshold_state.t0_status.drop_threshold_c == 25.0
+    assert threshold_state.t0_status.detected_bean_temperature_c == 145.0
+    assert [event.kind for event in threshold_state.events] == ["beans_added"]
+    assert threshold_state.events[0].payload == {
+        "source": "auto_t0",
+        "charge_temperature_c": 170.0,
+        "detected_bean_temperature_c": 145.0,
+        "drop_c": 25.0,
+        "drop_threshold_c": 25.0,
+    }
+
+
+def test_get_roast_state_auto_t0_uses_max_preheat_and_ignores_small_drops(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "session:",
+                "  auto_t0_detection_enabled: true",
+                "  auto_t0_drop_threshold_c: 30",
+                f"logging:\n  log_dir: {tmp_path / 'logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(bean_temp_c=160.0)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "get_roast_state", ctx)
+    driver.bean_temp_c = 175.0
+    _call_tool(server, "get_roast_state", ctx)
+    driver.bean_temp_c = 150.1
+    small_drop_state = _call_tool(server, "get_roast_state", ctx)
+    assert small_drop_state.phase == "pre_roast"
+    assert small_drop_state.t0_status.status == "pending"
+    assert small_drop_state.t0_status.charge_temperature_c == 175.0
+    assert small_drop_state.t0_status.current_drop_c == 24.9
+
+    driver.bean_temp_c = 144.9
+    detected_state = _call_tool(server, "get_roast_state", ctx)
+    assert detected_state.phase == "roasting"
+    assert detected_state.t0_status.status == "detected"
+    assert detected_state.t0_status.charge_temperature_c == 175.0
+    assert detected_state.t0_status.current_drop_c == 30.1
+
+
+def test_get_roast_state_auto_t0_waits_for_valid_baseline(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "session:",
+                "  auto_t0_detection_enabled: true",
+                f"logging:\n  log_dir: {tmp_path / 'logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(bean_temp_c=None)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    _call_tool(server, "start_roast_session", ctx)
+    no_temp_state = _call_tool(server, "get_roast_state", ctx)
+    assert no_temp_state.phase == "pre_roast"
+    assert no_temp_state.t0_status.status == "pending"
+    assert no_temp_state.t0_status.charge_temperature_c is None
+
+    driver.bean_temp_c = 125.0
+    first_temp_state = _call_tool(server, "get_roast_state", ctx)
+    assert first_temp_state.phase == "pre_roast"
+    assert first_temp_state.t0_status.status == "pending"
+    assert first_temp_state.t0_status.charge_temperature_c == 125.0
+    assert first_temp_state.t0_status.current_drop_c == 0.0
 
 
 def test_get_roast_state_reads_driver_before_detector_side_effects(

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -50,6 +50,7 @@ _EXPECTED_ROAST_STATE_KEYS = {
     "roast_elapsed_seconds",
     "session_id",
     "stopped_at_utc",
+    "t0_status",
 }
 _EXPECTED_DEVICE_STATE_KEYS = {
     "bean_temp_c",
@@ -66,6 +67,15 @@ _EXPECTED_FIRST_CRACK_STATUS_KEYS = {
     "detected_at_utc",
     "detected_monotonic_seconds",
     "mode",
+    "reason",
+    "status",
+}
+_EXPECTED_T0_STATUS_KEYS = {
+    "auto_detection_enabled",
+    "charge_temperature_c",
+    "current_drop_c",
+    "detected_bean_temperature_c",
+    "drop_threshold_c",
     "reason",
     "status",
 }
@@ -300,6 +310,15 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         )
         assert first_crack_status["allow_manual_override"] is True
         assert first_crack_status["reason"] is None
+
+        t0_status = state_content["t0_status"]
+        assert set(t0_status) == _EXPECTED_T0_STATUS_KEYS
+        assert t0_status["auto_detection_enabled"] is False
+        assert t0_status["status"] == "detected"
+        assert t0_status["drop_threshold_c"] == 25.0
+        assert t0_status["charge_temperature_c"] is None
+        assert t0_status["detected_bean_temperature_c"] is None
+        assert t0_status["reason"] is None
 
         assert state_content["beans_added_at_utc"] is not None
         assert state_content["beans_added_monotonic_seconds"] is not None

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -283,6 +283,120 @@ def test_record_event_allows_drop_directly_from_roasting_phase() -> None:
     assert session.first_crack_at_utc is None
 
 
+def test_auto_t0_records_beans_added_from_drop_against_preheat_max() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    event, first_snapshot = store.process_auto_t0_reading_snapshot(
+        session,
+        bean_temp_c=170.0,
+        drop_threshold_c=25.0,
+    )
+    assert event is None
+    assert first_snapshot.phase == "pre_roast"
+    assert first_snapshot.auto_t0_charge_temperature_c == 170.0
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    clock.monotonic_value = 105.0
+    event, snapshot = store.process_auto_t0_reading_snapshot(
+        session,
+        bean_temp_c=143.5,
+        drop_threshold_c=25.0,
+    )
+
+    assert event is not None
+    assert event.kind == "beans_added"
+    assert event.recorded_at_utc == clock.utc_value
+    assert event.monotonic_seconds == 5.0
+    assert event.payload == {
+        "source": "auto_t0",
+        "charge_temperature_c": 170.0,
+        "detected_bean_temperature_c": 143.5,
+        "drop_c": 26.5,
+        "drop_threshold_c": 25.0,
+    }
+    assert snapshot.phase == "roasting"
+    assert snapshot.beans_added_at_utc == clock.utc_value
+    assert snapshot.auto_t0_charge_temperature_c == 170.0
+    assert snapshot.auto_t0_current_drop_c == 26.5
+
+
+def test_auto_t0_uses_max_preheat_for_gradual_drop() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    for bean_temp_c in (160.0, 170.0, 162.0, 151.0):
+        event, _ = store.process_auto_t0_reading_snapshot(
+            session,
+            bean_temp_c=bean_temp_c,
+            drop_threshold_c=25.0,
+        )
+        assert event is None
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 2, tzinfo=UTC)
+    clock.monotonic_value = 112.0
+    event, snapshot = store.process_auto_t0_reading_snapshot(
+        session,
+        bean_temp_c=144.9,
+        drop_threshold_c=25.0,
+    )
+
+    assert event is not None
+    assert event.kind == "beans_added"
+    assert event.payload["charge_temperature_c"] == 170.0
+    assert event.payload["drop_c"] == 25.1
+    assert snapshot.phase == "roasting"
+
+
+def test_auto_t0_does_not_guess_without_preheat_baseline() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    event, snapshot = store.process_auto_t0_reading_snapshot(
+        session,
+        bean_temp_c=120.0,
+        drop_threshold_c=25.0,
+    )
+
+    assert event is None
+    assert snapshot.phase == "pre_roast"
+    assert snapshot.beans_added_at_utc is None
+    assert snapshot.auto_t0_charge_temperature_c == 120.0
+    assert snapshot.auto_t0_current_drop_c == 0.0
+
+
+def test_auto_t0_rejects_invalid_phase_after_manual_override() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+    manual_event = store.record_event(session, "beans_added")
+
+    event, snapshot = store.process_auto_t0_reading_snapshot(
+        session,
+        bean_temp_c=140.0,
+        drop_threshold_c=25.0,
+    )
+
+    assert event == manual_event
+    assert snapshot.phase == "roasting"
+    assert len(snapshot.event_timeline) == 1
+
+
 def test_record_event_keeps_later_phase_when_singleton_event_is_repeated() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -356,6 +356,32 @@ def test_auto_t0_uses_max_preheat_for_gradual_drop() -> None:
     assert snapshot.phase == "roasting"
 
 
+def test_auto_t0_pending_status_does_not_round_drop_to_threshold() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    store.process_auto_t0_reading_snapshot(
+        session,
+        bean_temp_c=170.0,
+        drop_threshold_c=25.0,
+    )
+    event, snapshot = store.process_auto_t0_reading_snapshot(
+        session,
+        bean_temp_c=145.0004,
+        drop_threshold_c=25.0,
+    )
+
+    assert event is None
+    assert snapshot.phase == "pre_roast"
+    assert snapshot.auto_t0_current_drop_c is not None
+    assert abs(snapshot.auto_t0_current_drop_c - 24.9996) < 0.000001
+    assert snapshot.auto_t0_current_drop_c < 25.0
+
+
 def test_auto_t0_does_not_guess_without_preheat_baseline() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(


### PR DESCRIPTION
## Summary
- add configurable automatic T0 drop-threshold support while keeping auto-T0 disabled by default
- record internal beans_added/T0 from get_roast_state driver reads when bean temperature drops from tracked max preheat/charge temperature
- expose t0_status diagnostics through MCP state and document the operational flow

## Validation
- ./.venv/bin/python -m pytest tests/test_config.py tests/test_session.py tests/test_mcp_server.py
- ./.venv/bin/python -m pytest tests/test_package.py
- ./.venv/bin/python -m pytest --cov=coffee_roaster_mcp --cov-report=term-missing:skip-covered --cov-report=json:coverage.json --cov-report=html:htmlcov
- ./.venv/bin/python -m ruff check .
- ./.venv/bin/python -m ruff format --check .
- ./.venv/bin/python -m pyright

Closes #111