### PR TITLE
E5-S1: Implement rolling telemetry buffer

### DIFF
--- a/docs/session-summaries/2026-05-23-e5-s1-rolling-telemetry-buffer-review-cycle.md
+++ b/docs/session-summaries/2026-05-23-e5-s1-rolling-telemetry-buffer-review-cycle.md
@@ -1,0 +1,89 @@
+# E5-S1 Rolling Telemetry Buffer Review Cycle
+
+This summary captures the E5-S1 implementation, PR #118 review feedback, follow-up fix, validation state, and current restart context.
+
+## Scope
+
+Story: `E5-S1` / issue `#40`, implement rolling telemetry buffer.
+
+Branch: `feature/40-implement-rolling-telemetry-buffer`
+
+Pull request: <https://github.com/syamaner/coffee-roaster-mcp/pull/118>
+
+The implementation stayed inside the current story boundary:
+
+- capture normalized telemetry samples from configured `RoasterDriver.read_state()` during operational `get_roast_state` polling
+- keep mutation owned by the authoritative one-session `RoastSessionStore`
+- retain samples in the existing rolling per-session buffer
+- preserve timestamp ordering for later Epic 5 metric stories
+- keep normal CI mock-safe with no Hottop hardware, microphone, model download, ONNX file, or network requirement
+
+No RoR calculations, development percent changes, append-only telemetry writers, final log schemas, CSV or summary schema changes, model training, ONNX export, Hugging Face sync, real microphone validation, live Hottop validation, or end-to-end agent roast validation were added.
+
+## Usage Snapshot
+
+Operator-provided context snapshot after the PR review fix:
+
+- Context window: `55% left (123K used / 258K)`
+- 5h limit: `99% left`, resets `02:17 on 24 May`
+- Weekly limit: `100% left`, resets `21:17 on 30 May`
+
+## Implementation Summary
+
+The first E5-S1 commit added store-owned normalized telemetry capture:
+
+- `RoastSessionStore.record_telemetry_sample(...)` creates samples with the session store's UTC and monotonic clocks.
+- `_append_telemetry_with_limit(...)` now rejects out-of-order monotonic timestamps.
+- Session read snapshots retain the current telemetry buffer so later Epic 5 metric work can compute from snapshots.
+- `get_roast_state` reads the configured driver once, serializes the same state for MCP output, and records one telemetry sample for the active session after successful polling.
+
+The durable state was updated:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E5-S1` complete.
+- `docs/state/registry.md` says the next story is `E5-S2: compute elapsed roast time`.
+
+## Review Summary
+
+Codex review `4351398664` on PR #118 found one actionable issue:
+
+- `src/coffee_roaster_mcp/mcp_server.py`
+- Finding: `_record_polling_telemetry_for_active_session` first read the active session and then called `record_telemetry_sample(...)` under a separate lock. If another tool stopped or replaced the active session between those steps, `record_telemetry_sample(...)` could raise `SessionLifecycleError`, making `get_roast_state` fail even though it should remain a read path.
+
+The fix was pushed in amended commit `84812fb` before this summary commit:
+
+- Added `RoastSessionStore.record_active_telemetry_sample(...)`.
+- The active-session match and telemetry append now happen under the same store lock.
+- If the requested session is stale, stopped, or replaced before append, the method returns `None`.
+- `get_roast_state` keeps returning the original read snapshot when telemetry append is skipped because the session became stale.
+- Added regression coverage for the stale-session replacement case.
+
+The review thread is outdated after the fix and has a reply with validation evidence. It was not manually resolved.
+
+## Validation
+
+Local validation after the review fix:
+
+- `./.venv/bin/python -m pytest tests/test_session.py tests/test_mcp_server.py`: 70 passed
+- `./.venv/bin/python -m pytest`: 302 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+
+GitHub Actions after the review-fix push:
+
+- `Build Package`: passed
+- `Checks`: passed
+
+## Current State
+
+Current branch before this summary commit:
+
+- `feature/40-implement-rolling-telemetry-buffer`
+- PR #118 is open and mergeable.
+- CI is passing.
+- Issue #40 has a PR and validation comment.
+- The only known review thread is outdated after the fix.
+
+## Restart Prompt
+
+Resume in `/Users/sertanyamaner/git/coffee-roaster-mcp`. PR #118 for E5-S1 is open on `feature/40-implement-rolling-telemetry-buffer` with CI passing. Read `docs/state/registry.md`, `docs/state/epics/coffee-roaster-mcp-v0.1.md`, and this summary. If PR #118 has new review comments, inspect unresolved review threads first and address only actionable feedback. If PR #118 has merged, verify issue #40 is closed, check out `main`, run `git pull --ff-only origin main`, then begin E5-S2 from updated main on the appropriate `feature/41-...` branch. Keep E5-S2 scoped to elapsed roast time and preserve the E5-S1 telemetry buffer, one-session store boundary, mock-safe CI, Hottop validation boundary, first-crack runtime boundaries, and no final log schema or RoR work.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E5-S1`
-- Current target: Implement rolling telemetry buffer
+- Active story: `E5-S2`
+- Current target: Compute elapsed roast time
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -196,6 +196,15 @@ The first implementation milestone is a mock vertical slice that requires no roa
   detected bean temperature, drop, and threshold diagnostics in the event
   payload and `get_roast_state.t0_status`. `mark_beans_added` remains an
   explicit idempotent override.
+- `E5-S1` implements the rolling telemetry buffer capture path owned by the
+  authoritative `RoastSessionStore`. Successful operational `get_roast_state`
+  polling now appends normalized samples from the configured
+  `RoasterDriver.read_state()` result for the latest active session, preserving
+  UTC and monotonic timestamp order, bean/environment temperatures, heat/fan
+  levels, and cooling state for later Epic 5 derived metrics. Driver read
+  failures still do not mutate session state, stopped or non-latest sessions do
+  not receive new samples, and final log schemas/RoR/development metrics remain
+  later Epic 5 work.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -473,7 +482,7 @@ Goal: compute roast metrics from one session clock and export durable logs.
 
 ### Stories
 
-- [ ] `E5-S1` Implement rolling telemetry buffer.
+- [x] `E5-S1` Implement rolling telemetry buffer.
   - Done when bean/env samples are retained for rolling metric calculations.
 
 - [ ] `E5-S2` Compute elapsed roast time.
@@ -699,6 +708,8 @@ After completing a story:
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
 - Validation run for E2-S3:
   - Extended `src/coffee_roaster_mcp/session.py` with authoritative per-event timestamp fields and store-owned `record_event(...)`.
   - Kept singleton event writes idempotent for `beans_added`, `first_crack_detected`, `beans_dropped`, `cooling_started`, and `cooling_stopped` while allowing `fault` timeline rows.
@@ -1254,3 +1265,27 @@ After completing a story:
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.
+- Validation run for E5-S1:
+  - Added store-owned normalized telemetry capture through
+    `RoastSessionStore.record_telemetry_sample(...)`, using the authoritative
+    session UTC and monotonic clocks and preserving retained samples in read
+    snapshots for later Epic 5 metrics.
+  - Wired successful operational `get_roast_state` driver reads to append one
+    telemetry sample for the latest active session while keeping driver-read
+    failures, stopped sessions, and non-latest sessions from mutating the
+    telemetry buffer.
+  - Enforced monotonic timestamp ordering for appended telemetry samples and
+    retained the existing per-session rolling buffer limit.
+  - Kept RoR calculations, development percent changes, final log schemas,
+    append-only telemetry log files, CSV/summary schema changes, model
+    training/export/sync, real microphone validation, live Hottop validation,
+    end-to-end agent roast validation, and broad release validation out of
+    scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_session.py tests/test_mcp_server.py`:
+    69 passed.
+  - Ran `./.venv/bin/python -m pytest`: 301 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -160,13 +160,23 @@ and `get_roast_state.t0_status`. The explicit `mark_beans_added` override
 remains available and idempotent. Driver read failures still surface without
 session mutation, and normal CI remains mock-safe.
 
+E5-S1 added rolling telemetry capture owned by the authoritative
+`RoastSessionStore`. Successful operational `get_roast_state` polling now
+appends normalized samples from the configured `RoasterDriver.read_state()` for
+the latest active session, retaining ordered UTC/monotonic timestamps,
+bean/environment temperatures, heat/fan levels, and cooling state for later
+Epic 5 metrics. Driver read failures, stopped sessions, and non-latest sessions
+do not mutate the telemetry buffer. RoR, development percent, final log
+schemas, append-only telemetry writers, CSV/summary schema changes, and broad
+release validation remain later Epic 5/E7 work.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E5-S1: implement rolling telemetry buffer.
+The next story is E5-S2: compute elapsed roast time.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -448,7 +448,14 @@ def create_mcp_server(
         """Return the current authoritative roast session state."""
         server_context = ctx.request_context.lifespan_context
         session = _resolve_session(server_context, session_id=session_id)
-        device_state = _read_current_device_state(server_context)
+        driver_state = _read_current_driver_state(server_context)
+        device_state = _serialize_device_state(driver_state)
+        session = _record_polling_telemetry_for_active_session(
+            server_context,
+            session=session,
+            requested_session_id=session_id,
+            driver_state=driver_state,
+        )
         auto_t0_recorded = _process_auto_t0_for_active_session(
             server_context,
             session_id=session_id,
@@ -895,17 +902,35 @@ def _snapshot_session(
         raise ValueError(str(exc)) from exc
 
 
-def _read_current_device_state(server_context: ServerContext) -> RoasterDeviceState:
-    """Read and serialize the configured driver state for MCP output."""
+def _read_current_driver_state(server_context: ServerContext) -> RoasterState:
+    """Read the configured driver state for MCP output and telemetry capture."""
     try:
-        driver_state = server_context.roaster_driver.read_state()
+        return server_context.roaster_driver.read_state()
     except Exception as exc:
         driver_name = server_context.config.roaster.driver
         raise RuntimeError(
             f"Could not read current roaster state from driver {driver_name}: "
             f"{type(exc).__name__}: {exc}"
         ) from exc
-    return _serialize_device_state(driver_state)
+
+
+def _record_polling_telemetry_for_active_session(
+    server_context: ServerContext,
+    *,
+    session: RoastSession,
+    requested_session_id: str | None,
+    driver_state: RoasterState,
+) -> RoastSession:
+    """Append one driver-state telemetry sample when polling the active session."""
+    snapshot = server_context.session_store.record_active_telemetry_sample(
+        session_id=requested_session_id,
+        bean_temp_c=driver_state.bean_temp_c,
+        env_temp_c=driver_state.env_temp_c,
+        heat_level_percent=driver_state.heat_level_percent,
+        fan_level_percent=driver_state.fan_level_percent,
+        cooling_on=driver_state.cooling_on,
+    )
+    return session if snapshot is None else snapshot
 
 
 def _serialize_session_state(

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -100,6 +100,11 @@ def _append_telemetry_with_limit(
     """Append telemetry to one session with an explicit retention limit."""
     if max_samples < 0:
         raise ValueError("max_samples must be >= 0.")
+    if (
+        session.telemetry_buffer
+        and sample.monotonic_seconds < session.telemetry_buffer[-1].monotonic_seconds
+    ):
+        raise SessionLifecycleError("Telemetry samples must be appended in timestamp order.")
     session.telemetry_buffer.append(sample)
     while len(session.telemetry_buffer) > max_samples:
         session.telemetry_buffer.popleft()
@@ -517,6 +522,97 @@ class RoastSessionStore:
                 sample,
                 max_samples=self._telemetry_buffer_limit,
             )
+
+    def record_telemetry_sample(
+        self,
+        session: RoastSession,
+        *,
+        bean_temp_c: float | None,
+        env_temp_c: float | None,
+        heat_level_percent: int,
+        fan_level_percent: int,
+        cooling_on: bool,
+    ) -> RoastSession:
+        """Record one normalized telemetry sample using the session clock.
+
+        Args:
+            session: Latest active session that owns the sample.
+            bean_temp_c: Normalized bean temperature in Celsius, when available.
+            env_temp_c: Normalized environment temperature in Celsius, when available.
+            heat_level_percent: Current heat control level.
+            fan_level_percent: Current fan control level.
+            cooling_on: Current cooling state.
+
+        Returns:
+            A lightweight read snapshot after appending the sample.
+
+        Raises:
+            SessionLifecycleError: If the session is not the latest active session.
+        """
+        with self._lock:
+            self._assert_latest_active_session(session)
+            sample = TelemetrySample(
+                recorded_at_utc=self._utc_now(),
+                monotonic_seconds=session.elapsed_monotonic_seconds(self._monotonic_now),
+                bean_temp_c=bean_temp_c,
+                env_temp_c=env_temp_c,
+                heat_level_percent=heat_level_percent,
+                fan_level_percent=fan_level_percent,
+                cooling_on=cooling_on,
+            )
+            _append_telemetry_with_limit(
+                session,
+                sample,
+                max_samples=self._telemetry_buffer_limit,
+            )
+            return _copy_session_for_read(session)
+
+    def record_active_telemetry_sample(
+        self,
+        *,
+        session_id: str | None,
+        bean_temp_c: float | None,
+        env_temp_c: float | None,
+        heat_level_percent: int,
+        fan_level_percent: int,
+        cooling_on: bool,
+    ) -> RoastSession | None:
+        """Record telemetry for the latest active session when it still matches.
+
+        Args:
+            session_id: Requested session id, or `None` for the active session.
+            bean_temp_c: Normalized bean temperature in Celsius, when available.
+            env_temp_c: Normalized environment temperature in Celsius, when available.
+            heat_level_percent: Current heat control level.
+            fan_level_percent: Current fan control level.
+            cooling_on: Current cooling state.
+
+        Returns:
+            A lightweight read snapshot after appending the sample, or `None`
+            when no matching active session still exists.
+        """
+        with self._lock:
+            if self._latest_session is None or not self._latest_session.active:
+                return None
+            if session_id is not None and self._latest_session.id != session_id:
+                return None
+            sample = TelemetrySample(
+                recorded_at_utc=self._utc_now(),
+                monotonic_seconds=self._latest_session.elapsed_monotonic_seconds(
+                    self._monotonic_now
+                ),
+                bean_temp_c=bean_temp_c,
+                env_temp_c=env_temp_c,
+                heat_level_percent=heat_level_percent,
+                fan_level_percent=fan_level_percent,
+                cooling_on=cooling_on,
+            )
+            _append_telemetry_with_limit(
+                self._latest_session,
+                sample,
+                max_samples=self._telemetry_buffer_limit,
+            )
+            return _copy_session_for_read(self._latest_session)
 
     def set_heat(
         self,
@@ -1426,7 +1522,7 @@ def _payload_control_percent(
 
 
 def _copy_session_for_read(session: RoastSession) -> RoastSession:
-    """Return a lightweight read snapshot without telemetry buffer retention."""
+    """Return a lightweight read snapshot with retained telemetry samples."""
     return RoastSession(
         id=session.id,
         created_at_utc=session.created_at_utc,
@@ -1451,7 +1547,7 @@ def _copy_session_for_read(session: RoastSession) -> RoastSession:
         auto_t0_current_drop_c=session.auto_t0_current_drop_c,
         auto_t0_preheat_sample_count=session.auto_t0_preheat_sample_count,
         event_timeline=deepcopy(session.event_timeline),
-        telemetry_buffer=deque(),
+        telemetry_buffer=deque(session.telemetry_buffer),
         log_writer=session.log_writer,
         stopped_at_utc=session.stopped_at_utc,
         monotonic_stop=session.monotonic_stop,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -201,6 +201,39 @@ def test_get_roast_state_exposes_current_driver_state_and_event_timestamps(
     assert state.t0_status.auto_detection_enabled is False
 
 
+def test_get_roast_state_appends_normalized_driver_telemetry_samples(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(bean_temp_c=151.25, env_temp_c=204.5)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+    driver.bean_temp_c = 152.0
+    driver.env_temp_c = 205.25
+    driver.heat_level_percent = 45
+    driver.fan_level_percent = 25
+    driver.cooling_on = True
+    _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+
+    session = server_context.session_store.get_session_snapshot(
+        session_id=start_result.session.session_id
+    )
+    samples = list(session.telemetry_buffer)
+    assert len(samples) == 2
+    assert [sample.bean_temp_c for sample in samples] == [151.25, 152.0]
+    assert [sample.env_temp_c for sample in samples] == [204.5, 205.25]
+    assert samples[1].heat_level_percent == 45
+    assert samples[1].fan_level_percent == 25
+    assert samples[1].cooling_on is True
+    assert samples[0].monotonic_seconds <= samples[1].monotonic_seconds
+
+
 def test_get_roast_state_driver_read_failure_does_not_mutate_session(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -146,6 +146,82 @@ def test_session_telemetry_buffer_retains_only_recent_samples() -> None:
     assert [sample.monotonic_seconds for sample in samples] == [2.0, 3.0]
 
 
+def test_record_telemetry_sample_uses_session_clock_and_snapshot_retains_buffer() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 0, 5, tzinfo=UTC)
+    clock.monotonic_value = 105.5
+    snapshot = store.record_telemetry_sample(
+        session,
+        bean_temp_c=151.25,
+        env_temp_c=204.5,
+        heat_level_percent=55,
+        fan_level_percent=35,
+        cooling_on=False,
+    )
+
+    samples = list(snapshot.telemetry_buffer)
+    assert len(samples) == 1
+    assert samples[0].recorded_at_utc == datetime(2026, 5, 4, 12, 0, 5, tzinfo=UTC)
+    assert samples[0].monotonic_seconds == 5.5
+    assert samples[0].bean_temp_c == 151.25
+    assert samples[0].env_temp_c == 204.5
+    assert samples[0].heat_level_percent == 55
+    assert samples[0].fan_level_percent == 35
+    assert samples[0].cooling_on is False
+    assert list(store.get_session_snapshot().telemetry_buffer) == samples
+
+
+def test_record_active_telemetry_sample_returns_none_when_session_is_stale() -> None:
+    clock = ClockHarness()
+    issued_ids = iter(["session-001", "session-002"])
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        session_id_factory=lambda: next(issued_ids),
+    )
+    first_session = store.start_session()
+    store.stop_session()
+    second_session = store.start_session()
+
+    assert (
+        store.record_active_telemetry_sample(
+            session_id=first_session.id,
+            bean_temp_c=151.25,
+            env_temp_c=204.5,
+            heat_level_percent=55,
+            fan_level_percent=35,
+            cooling_on=False,
+        )
+        is None
+    )
+    assert list(second_session.telemetry_buffer) == []
+
+
+def test_append_telemetry_rejects_out_of_order_samples() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    store.append_telemetry(
+        session,
+        TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=2.0),
+    )
+    with pytest.raises(SessionLifecycleError, match="timestamp order"):
+        store.append_telemetry(
+            session,
+            TelemetrySample(recorded_at_utc=clock.utc_now(), monotonic_seconds=1.0),
+        )
+
+
 def test_start_session_allows_new_session_after_previous_stop() -> None:
     clock = ClockHarness()
     issued_ids = iter(["session-001", "session-002"])


### PR DESCRIPTION
## Summary
- Capture normalized telemetry samples from successful operational `get_roast_state` driver reads into the authoritative `RoastSessionStore`.
- Preserve retained telemetry in session read snapshots and enforce monotonic timestamp ordering for appended samples.
- Update durable state docs to mark E5-S1 complete and move the next-story pointer to E5-S2.

## Tests
- `./.venv/bin/python -m pytest tests/test_session.py tests/test_mcp_server.py`
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`
- `./.venv/bin/coffee-roaster-mcp --help`
- `./.venv/bin/coffee-roaster-mcp --version`

Closes #40