### PR TITLE
E5-S2: Compute elapsed roast time

### DIFF
--- a/docs/session-summaries/2026-05-23-e5-s2-elapsed-roast-time.md
+++ b/docs/session-summaries/2026-05-23-e5-s2-elapsed-roast-time.md
@@ -1,0 +1,79 @@
+# E5-S2 Elapsed Roast Time
+
+This summary captures the E5-S2 implementation, validation state, current PR state, and restart context.
+
+## Scope
+
+Story: `E5-S2` / issue `#41`, compute elapsed roast time.
+
+Branch: `feature/41-compute-elapsed-roast-time`
+
+Pull request: <https://github.com/syamaner/coffee-roaster-mcp/pull/119>
+
+The implementation stayed inside the E5-S2 boundary:
+
+- compute `roast_elapsed_seconds` from authoritative `beans_added` T0
+- use the current session clock before drop
+- freeze elapsed time at authoritative `beans_dropped` after drop
+- keep the E5-S1 rolling telemetry buffer and one-session `RoastSessionStore` boundary intact
+- keep normal CI mock-safe with no Hottop hardware, microphone, model download, ONNX file, or network requirement
+
+No development percent changes, 60-second deltas, RoR, append-only telemetry log files, final JSONL/CSV/summary schemas, model training, ONNX export, Hugging Face sync, real microphone validation, live Hottop validation, end-to-end agent roast validation, or broad release validation were added.
+
+## Usage Snapshot
+
+Operator-provided context snapshot after PR #119 opened and CI passed:
+
+- Context window: `33% left (176K used / 258K)`
+- 5h limit: `97% left`, resets `02:17 on 24 May`
+- Weekly limit: `99% left`, resets `21:17 on 30 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `03:03 on 24 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `22:03 on 30 May`
+
+## Implementation Summary
+
+E5-S2 added `compute_roast_elapsed_seconds(...)` in `src/coffee_roaster_mcp/session.py`.
+
+The helper behavior is:
+
+- returns `None` before beans are added
+- computes from `beans_added_monotonic_seconds` to the current session clock before drop
+- computes from `beans_added_monotonic_seconds` to `beans_dropped_monotonic_seconds` after drop
+- rounds to three decimals, matching the existing timestamp-derived metrics convention
+
+`compute_roast_metrics(...)` now delegates the `roast_elapsed_seconds` field to this helper. That preserves the existing MCP `get_roast_state` and snapshot summary metric surfaces while making the E5-S2 elapsed-time contract explicit.
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E5-S2` complete.
+- `docs/state/registry.md` says the next story is `E5-S3: compute development time and percent`.
+
+## Validation
+
+Local validation:
+
+- `./.venv/bin/python -m pytest tests/test_session.py`: 49 passed
+- `./.venv/bin/python -m pytest`: 305 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+GitHub Actions on PR #119:
+
+- `Build Package`: passed
+- `Checks`: passed
+
+## Current State
+
+Current branch before this summary commit:
+
+- `feature/41-compute-elapsed-roast-time`
+- PR #119 is open, mergeable, and CI is passing.
+- Issue #41 has a PR and validation comment.
+- No PR review feedback had been addressed at the time this summary was written.
+
+## Restart Prompt
+
+Resume in `/Users/sertanyamaner/git/coffee-roaster-mcp`. PR #119 for E5-S2 is open on `feature/41-compute-elapsed-roast-time` with CI passing. Read `docs/state/registry.md`, `docs/state/epics/coffee-roaster-mcp-v0.1.md`, and this summary. If PR #119 has review comments, inspect unresolved review threads first and address only actionable feedback. If PR #119 has merged, verify issue #41 is closed, check out `main`, run `git pull --ff-only origin main`, then begin E5-S3 from updated main on the appropriate `feature/42-...` branch. Keep E5-S3 scoped to development time and percent and preserve the E5-S1 telemetry buffer, E5-S2 elapsed-time helper, one-session store boundary, mock-safe CI, Hottop validation boundary, first-crack runtime boundaries, and no final log schema, 60-second delta, or RoR work.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E5-S2`
-- Current target: Compute elapsed roast time
+- Active story: `E5-S3`
+- Current target: Compute development time and percent
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -205,6 +205,14 @@ The first implementation milestone is a mock vertical slice that requires no roa
   failures still do not mutate session state, stopped or non-latest sessions do
   not receive new samples, and final log schemas/RoR/development metrics remain
   later Epic 5 work.
+- `E5-S2` makes roast elapsed time explicit through
+  `compute_roast_elapsed_seconds(...)`. The value is `None` before T0, then
+  runs from authoritative `beans_added` monotonic time to the current session
+  clock until drop, and freezes at authoritative `beans_dropped` monotonic time
+  after drop. Existing `get_roast_state` and snapshot summary metrics now use
+  this helper through `compute_roast_metrics(...)`. Development time/percent,
+  60-second deltas, RoR, append-only telemetry writers, and final log schemas
+  remain later Epic 5 work.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -485,7 +493,7 @@ Goal: compute roast metrics from one session clock and export durable logs.
 - [x] `E5-S1` Implement rolling telemetry buffer.
   - Done when bean/env samples are retained for rolling metric calculations.
 
-- [ ] `E5-S2` Compute elapsed roast time.
+- [x] `E5-S2` Compute elapsed roast time.
   - Done when `roast_elapsed_seconds` is computed from `beans_added_at` to now or drop.
 
 - [ ] `E5-S3` Compute development time and percent.
@@ -1284,6 +1292,28 @@ After completing a story:
   - Ran `./.venv/bin/python -m pytest tests/test_session.py tests/test_mcp_server.py`:
     69 passed.
   - Ran `./.venv/bin/python -m pytest`: 301 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E5-S2:
+  - Added `compute_roast_elapsed_seconds(...)` as the explicit helper for
+    `roast_elapsed_seconds` from authoritative T0 to current session clock or
+    authoritative drop time.
+  - Wired `compute_roast_metrics(...)` to use the helper so existing
+    `get_roast_state` and snapshot summary metric surfaces share the E5-S2
+    elapsed-time contract.
+  - Added elapsed-time tests for `None` before beans are added, active elapsed
+    time before drop, and frozen elapsed time after drop even when the current
+    clock advances.
+  - Kept development time/percent behavior, 60-second deltas, RoR,
+    append-only telemetry log files, final JSONL/CSV/summary schemas, model
+    training/export/sync, real microphone validation, live Hottop validation,
+    end-to-end agent roast validation, and broad release validation out of
+    scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_session.py`: 49 passed.
+  - Ran `./.venv/bin/python -m pytest`: 305 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -170,13 +170,23 @@ do not mutate the telemetry buffer. RoR, development percent, final log
 schemas, append-only telemetry writers, CSV/summary schema changes, and broad
 release validation remain later Epic 5/E7 work.
 
+E5-S2 added explicit roast elapsed time computation from the authoritative
+session clock. `roast_elapsed_seconds` is now computed through
+`compute_roast_elapsed_seconds(...)`: it is `None` before beans are added,
+counts from authoritative T0 to the current session clock before drop, and
+freezes at authoritative drop time after `beans_dropped`. The existing MCP
+state and snapshot summary metrics use this helper through
+`compute_roast_metrics(...)`. Development time/percent, 60-second deltas, RoR,
+append-only telemetry writers, final JSONL/CSV/summary schemas, and broad
+release validation remain later Epic 5/E7 work.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E5-S2: compute elapsed roast time.
+The next story is E5-S3: compute development time and percent.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -214,7 +214,7 @@ class RoastMetrics:
     """Timestamp-derived roast metrics for the current session snapshot.
 
     Attributes:
-        roast_elapsed_seconds: Seconds from beans added to drop, stop, or now.
+        roast_elapsed_seconds: Seconds from beans added to drop or now.
         development_time_seconds: Seconds from first crack to drop, stop, or now.
         development_percent: Development time as a percentage of roast elapsed time.
     """
@@ -350,9 +350,8 @@ def compute_roast_metrics(
     import time
 
     clock = monotonic_now or time.monotonic
-    roast_elapsed_seconds = _elapsed_since(
+    roast_elapsed_seconds = compute_roast_elapsed_seconds(
         session,
-        start_seconds=session.beans_added_monotonic_seconds,
         monotonic_now=clock,
     )
     development_time_seconds = _elapsed_since(
@@ -372,6 +371,34 @@ def compute_roast_metrics(
         development_time_seconds=development_time_seconds,
         development_percent=development_percent,
     )
+
+
+def compute_roast_elapsed_seconds(
+    session: RoastSession,
+    *,
+    monotonic_now: Callable[[], float] | None = None,
+) -> float | None:
+    """Compute roast elapsed seconds from authoritative T0 to drop or now.
+
+    Args:
+        session: Session snapshot to inspect.
+        monotonic_now: Optional monotonic clock supplier for active sessions.
+
+    Returns:
+        Seconds from `beans_added` to `beans_dropped` when drop exists, from
+        `beans_added` to the current session clock otherwise, or `None` before
+        beans are added.
+    """
+    import time
+
+    clock = monotonic_now or time.monotonic
+    if session.beans_added_monotonic_seconds is None:
+        return None
+    if session.beans_dropped_monotonic_seconds is not None:
+        end_seconds = session.beans_dropped_monotonic_seconds
+    else:
+        end_seconds = session.elapsed_monotonic_seconds(clock)
+    return round(max(0.0, end_seconds - session.beans_added_monotonic_seconds), 3)
 
 
 class SessionLifecycleError(RuntimeError):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,6 +11,7 @@ from coffee_roaster_mcp.session import (
     RoastSessionStore,
     SessionLifecycleError,
     TelemetrySample,
+    compute_roast_elapsed_seconds,
     compute_roast_metrics,
 )
 
@@ -975,6 +976,49 @@ def test_compute_roast_metrics_uses_clock_for_active_session() -> None:
     assert metrics.roast_elapsed_seconds == 45.0
     assert metrics.development_time_seconds == 30.0
     assert metrics.development_percent == 66.667
+
+
+def test_compute_roast_elapsed_seconds_returns_none_before_beans_added() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    assert compute_roast_elapsed_seconds(session, monotonic_now=clock.monotonic_now) is None
+
+
+def test_compute_roast_elapsed_seconds_uses_current_clock_before_drop() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 142.25
+
+    assert compute_roast_elapsed_seconds(session, monotonic_now=clock.monotonic_now) == 37.25
+
+
+def test_compute_roast_elapsed_seconds_freezes_at_drop() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 155.0
+    store.record_event(session, "beans_dropped")
+    clock.monotonic_value = 210.0
+
+    assert compute_roast_elapsed_seconds(session, monotonic_now=clock.monotonic_now) == 50.0
 
 
 def test_record_event_is_idempotent_for_singleton_event_kinds() -> None:


### PR DESCRIPTION
## Summary
- Add explicit `compute_roast_elapsed_seconds(...)` helper for roast elapsed time from authoritative T0 to current session clock or authoritative drop time.
- Wire `compute_roast_metrics(...)` through the helper so existing MCP state and snapshot summary metric surfaces share the same elapsed-time contract.
- Update durable state docs to mark E5-S2 complete and move the next-story pointer to E5-S3.

## Tests
- `./.venv/bin/python -m pytest tests/test_session.py`
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`
- `./.venv/bin/coffee-roaster-mcp --help`
- `./.venv/bin/coffee-roaster-mcp --version`

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added elapsed roast time tracking that measures roasting duration from when beans are added until dropped, with the timer freezing at bean drop.

* **Tests**
  * Added comprehensive test coverage for elapsed roast time computation, validating behavior before bean addition, during active roasting, and after drop.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->