### PR TITLE
E5-S3: Compute development time and percent

### DIFF
--- a/docs/session-summaries/2026-05-23-e5-s3-development-time-percent.md
+++ b/docs/session-summaries/2026-05-23-e5-s3-development-time-percent.md
@@ -1,0 +1,78 @@
+# E5-S3 Development Time And Percent
+
+This summary captures the E5-S3 implementation, validation state, and restart
+context.
+
+## Scope
+
+Story: `E5-S3` / issue `#42`, compute development time and percent.
+
+Branch: `feature/42-compute-development-time-percent`
+
+The implementation stayed inside the E5-S3 boundary:
+
+- compute `development_time_seconds` from authoritative first crack
+- use the current session clock before drop
+- freeze development time at authoritative `beans_dropped` after drop
+- compute `development_percent` as
+  `development_time_seconds / roast_elapsed_seconds * 100`
+- use the E5-S2 `compute_roast_elapsed_seconds(...)` helper for the denominator
+- preserve existing MCP metric surfaces through `compute_roast_metrics(...)`
+- keep the E5-S1 rolling telemetry buffer and one-session `RoastSessionStore`
+  boundary intact
+- keep normal CI mock-safe with no Hottop hardware, microphone, model download,
+  ONNX file, or network requirement
+
+No 60-second deltas, RoR, append-only telemetry log files, final
+JSONL/CSV/summary schemas, model training, ONNX export, Hugging Face sync, real
+microphone validation, live Hottop validation, end-to-end agent roast
+validation, or broad release validation were added.
+
+## Implementation Summary
+
+E5-S3 added `compute_development_time_seconds(...)` and
+`compute_development_percent(...)` in
+`src/coffee_roaster_mcp/session.py`.
+
+The development-time helper behavior is:
+
+- returns `None` before first crack
+- computes from `first_crack_monotonic_seconds` to the current session clock
+  before drop
+- computes from `first_crack_monotonic_seconds` to
+  `beans_dropped_monotonic_seconds` after drop
+- rounds to three decimals, matching the existing timestamp-derived metrics
+  convention
+
+The development-percent helper uses `compute_roast_elapsed_seconds(...)` as the
+roast elapsed denominator and returns `None` until both values are available and
+the denominator is positive.
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E5-S3` complete.
+- `docs/state/registry.md` says the next story is `E5-S4: compute 60s bean/env
+  deltas`.
+
+## Validation
+
+Local validation:
+
+- `./.venv/bin/python -m pytest tests/test_session.py`: 53 passed
+- `./.venv/bin/python -m pytest`: 309 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+## Restart Prompt
+
+Resume in `/Users/sertanyamaner/git/coffee-roaster-mcp`. PR for E5-S3 should be
+checked first; if it has merged, verify issue #42 is closed, check out `main`,
+run `git pull --ff-only origin main`, then begin E5-S4 from updated main on the
+appropriate `feature/43-...` branch. Keep E5-S4 scoped to 60-second bean/env
+deltas and preserve the E5-S1 telemetry buffer, E5-S2 elapsed-time helper,
+E5-S3 development metric helpers, one-session store boundary, mock-safe CI,
+Hottop validation boundary, first-crack runtime boundaries, and no final log
+schema or RoR work.

--- a/docs/session-summaries/2026-05-23-e5-s3-development-time-percent.md
+++ b/docs/session-summaries/2026-05-23-e5-s3-development-time-percent.md
@@ -9,6 +9,8 @@ Story: `E5-S3` / issue `#42`, compute development time and percent.
 
 Branch: `feature/42-compute-development-time-percent`
 
+Pull request: <https://github.com/syamaner/coffee-roaster-mcp/pull/120>
+
 The implementation stayed inside the E5-S3 boundary:
 
 - compute `development_time_seconds` from authoritative first crack
@@ -66,11 +68,60 @@ Local validation:
 - `./.venv/bin/coffee-roaster-mcp --help`: passed
 - `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
 
+## Usage Snapshot
+
+Operator-provided context snapshot after PR #120 opened and review comments were
+checked:
+
+- Context window: `70% left (87K used / 258K)`
+- 5h limit: `97% left`, resets `02:17 on 24 May`
+- Weekly limit: `99% left`, resets `21:17 on 30 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `03:22 on 24 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `22:22 on 30 May`
+
+## Review Comparison
+
+Review state checked on PR #120:
+
+- PR #120 is open and mergeable.
+- Issue #42 remains open and will close through the PR `Closes #42` footer when
+  the PR merges.
+- CodeRabbit posted one review with two nitpick comments.
+- Thread-aware review lookup returned no unresolved inline review threads.
+
+CodeRabbit feedback:
+
+- Nitpick 1: In `src/coffee_roaster_mcp/session.py`, prefer explicit
+  `monotonic_now is None` branching over `monotonic_now or time.monotonic` for
+  optional clock injection in the two new helper functions.
+- Nitpick 2: In `tests/test_session.py`, add docstrings to the four newly added
+  test functions.
+
+Codex code-review pass:
+
+- No blocking correctness, safety, or scope issues found in the E5-S3 diff.
+- The development-time helper follows the existing `_elapsed_since(...)`
+  behavior and freezes at authoritative drop time.
+- The development-percent helper uses the E5-S2 roast elapsed helper for its
+  denominator and returns `None` until both values are available and the
+  denominator is positive.
+- The new tests cover the issue #42 acceptance criteria: before first crack,
+  active development time, frozen-after-drop behavior, and percent denominator
+  behavior.
+
+Decision:
+
+- Do not fix the two CodeRabbit nitpicks in this review round. They are style
+  suggestions, not required changes, and the current implementation passed the
+  normal quality gates.
+
 ## Restart Prompt
 
 Resume in `/Users/sertanyamaner/git/coffee-roaster-mcp`. PR for E5-S3 should be
-checked first; if it has merged, verify issue #42 is closed, check out `main`,
-run `git pull --ff-only origin main`, then begin E5-S4 from updated main on the
+checked first. CodeRabbit has two nitpick comments on PR #120; the current
+decision is not to fix them. Codex review found no blocking issue. If PR #120
+has merged, verify issue #42 is closed, check out `main`, run
+`git pull --ff-only origin main`, then begin E5-S4 from updated main on the
 appropriate `feature/43-...` branch. Keep E5-S4 scoped to 60-second bean/env
 deltas and preserve the E5-S1 telemetry buffer, E5-S2 elapsed-time helper,
 E5-S3 development metric helpers, one-session store boundary, mock-safe CI,

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E5-S3`
-- Current target: Compute development time and percent
+- Active story: `E5-S4`
+- Current target: Compute 60s bean/env deltas
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -213,6 +213,17 @@ The first implementation milestone is a mock vertical slice that requires no roa
   this helper through `compute_roast_metrics(...)`. Development time/percent,
   60-second deltas, RoR, append-only telemetry writers, and final log schemas
   remain later Epic 5 work.
+- `E5-S3` makes development time and percent explicit through
+  `compute_development_time_seconds(...)` and
+  `compute_development_percent(...)`. Development time is `None` before first
+  crack, runs from authoritative `first_crack_detected` monotonic time to the
+  current session clock until drop, and freezes at authoritative
+  `beans_dropped` monotonic time after drop. Development percent uses the E5-S2
+  `compute_roast_elapsed_seconds(...)` helper as the denominator:
+  `development_time_seconds / roast_elapsed_seconds * 100`. Existing
+  `get_roast_state` and snapshot summary metrics use these helpers through
+  `compute_roast_metrics(...)`. 60-second deltas, RoR, append-only telemetry
+  writers, and final log schemas remain later Epic 5 work.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -496,7 +507,7 @@ Goal: compute roast metrics from one session clock and export durable logs.
 - [x] `E5-S2` Compute elapsed roast time.
   - Done when `roast_elapsed_seconds` is computed from `beans_added_at` to now or drop.
 
-- [ ] `E5-S3` Compute development time and percent.
+- [x] `E5-S3` Compute development time and percent.
   - Done when development time starts at first crack and development percent is `development_time_seconds / roast_elapsed_seconds * 100`.
 
 - [ ] `E5-S4` Compute 60s bean/env deltas.
@@ -1314,6 +1325,30 @@ After completing a story:
     scope.
   - Ran `./.venv/bin/python -m pytest tests/test_session.py`: 49 passed.
   - Ran `./.venv/bin/python -m pytest`: 305 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E5-S3:
+  - Added `compute_development_time_seconds(...)` as the explicit helper for
+    `development_time_seconds` from authoritative first crack to current
+    session clock or authoritative drop time.
+  - Added `compute_development_percent(...)` as the explicit helper for
+    `development_time_seconds / roast_elapsed_seconds * 100`, using the E5-S2
+    `compute_roast_elapsed_seconds(...)` helper for the denominator.
+  - Wired `compute_roast_metrics(...)` to use the explicit development helpers
+    so existing `get_roast_state` and snapshot summary metric surfaces keep the
+    same public metric fields with the E5-S3 contract pinned in code.
+  - Added development metric tests for `None` before first crack, active
+    development time before drop, frozen development time after drop even when
+    the current clock advances, and development percent denominator behavior.
+  - Kept 60-second deltas, RoR, append-only telemetry log files, final
+    JSONL/CSV/summary schemas, model training/export/sync, real microphone
+    validation, live Hottop validation, end-to-end agent roast validation, and
+    broad release validation out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_session.py`: 53 passed.
+  - Ran `./.venv/bin/python -m pytest`: 309 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -176,9 +176,19 @@ session clock. `roast_elapsed_seconds` is now computed through
 counts from authoritative T0 to the current session clock before drop, and
 freezes at authoritative drop time after `beans_dropped`. The existing MCP
 state and snapshot summary metrics use this helper through
-`compute_roast_metrics(...)`. Development time/percent, 60-second deltas, RoR,
-append-only telemetry writers, final JSONL/CSV/summary schemas, and broad
-release validation remain later Epic 5/E7 work.
+`compute_roast_metrics(...)`.
+
+E5-S3 added explicit development time and development percent computation from
+the authoritative session clock. `development_time_seconds` is now computed
+through `compute_development_time_seconds(...)`: it is `None` before first
+crack, counts from authoritative first crack to the current session clock before
+drop, and freezes at authoritative drop time after `beans_dropped`.
+`development_percent` is now computed through `compute_development_percent(...)`
+as `development_time_seconds / roast_elapsed_seconds * 100`, using the E5-S2
+roast elapsed helper for the denominator. Existing MCP state and snapshot
+summary metrics use these helpers through `compute_roast_metrics(...)`.
+60-second deltas, RoR, append-only telemetry writers, final JSONL/CSV/summary
+schemas, and broad release validation remain later Epic 5/E7 work.
 
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
@@ -186,7 +196,7 @@ first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E5-S3: compute development time and percent.
+The next story is E5-S4: compute 60s bean/env deltas.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -354,22 +354,17 @@ def compute_roast_metrics(
         session,
         monotonic_now=clock,
     )
-    development_time_seconds = _elapsed_since(
+    development_time_seconds = compute_development_time_seconds(
         session,
-        start_seconds=session.first_crack_monotonic_seconds,
         monotonic_now=clock,
     )
-    development_percent = None
-    if (
-        roast_elapsed_seconds is not None
-        and roast_elapsed_seconds > 0
-        and development_time_seconds is not None
-    ):
-        development_percent = round((development_time_seconds / roast_elapsed_seconds) * 100, 3)
     return RoastMetrics(
         roast_elapsed_seconds=roast_elapsed_seconds,
         development_time_seconds=development_time_seconds,
-        development_percent=development_percent,
+        development_percent=_compute_development_percent_from_values(
+            roast_elapsed_seconds=roast_elapsed_seconds,
+            development_time_seconds=development_time_seconds,
+        ),
     )
 
 
@@ -399,6 +394,79 @@ def compute_roast_elapsed_seconds(
     else:
         end_seconds = session.elapsed_monotonic_seconds(clock)
     return round(max(0.0, end_seconds - session.beans_added_monotonic_seconds), 3)
+
+
+def compute_development_time_seconds(
+    session: RoastSession,
+    *,
+    monotonic_now: Callable[[], float] | None = None,
+) -> float | None:
+    """Compute development seconds from first crack to drop or now.
+
+    Args:
+        session: Session snapshot to inspect.
+        monotonic_now: Optional monotonic clock supplier for active sessions.
+
+    Returns:
+        Seconds from `first_crack_detected` to `beans_dropped` when drop
+        exists, from `first_crack_detected` to the current session clock
+        otherwise, or `None` before first crack.
+    """
+    import time
+
+    clock = monotonic_now or time.monotonic
+    return _elapsed_since(
+        session,
+        start_seconds=session.first_crack_monotonic_seconds,
+        monotonic_now=clock,
+    )
+
+
+def compute_development_percent(
+    session: RoastSession,
+    *,
+    monotonic_now: Callable[[], float] | None = None,
+) -> float | None:
+    """Compute development time as a percentage of roast elapsed time.
+
+    Args:
+        session: Session snapshot to inspect.
+        monotonic_now: Optional monotonic clock supplier for active sessions.
+
+    Returns:
+        `development_time_seconds / roast_elapsed_seconds * 100`, rounded to
+        three decimal places, or `None` before both values are available.
+    """
+    import time
+
+    clock = monotonic_now or time.monotonic
+    roast_elapsed_seconds = compute_roast_elapsed_seconds(
+        session,
+        monotonic_now=clock,
+    )
+    development_time_seconds = compute_development_time_seconds(
+        session,
+        monotonic_now=clock,
+    )
+    return _compute_development_percent_from_values(
+        roast_elapsed_seconds=roast_elapsed_seconds,
+        development_time_seconds=development_time_seconds,
+    )
+
+
+def _compute_development_percent_from_values(
+    *,
+    roast_elapsed_seconds: float | None,
+    development_time_seconds: float | None,
+) -> float | None:
+    """Return development percent from precomputed elapsed values."""
+    if (
+        roast_elapsed_seconds is None
+        or roast_elapsed_seconds <= 0
+        or development_time_seconds is None
+    ):
+        return None
+    return round((development_time_seconds / roast_elapsed_seconds) * 100, 3)
 
 
 class SessionLifecycleError(RuntimeError):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,6 +11,8 @@ from coffee_roaster_mcp.session import (
     RoastSessionStore,
     SessionLifecycleError,
     TelemetrySample,
+    compute_development_percent,
+    compute_development_time_seconds,
     compute_roast_elapsed_seconds,
     compute_roast_metrics,
 )
@@ -976,6 +978,74 @@ def test_compute_roast_metrics_uses_clock_for_active_session() -> None:
     assert metrics.roast_elapsed_seconds == 45.0
     assert metrics.development_time_seconds == 30.0
     assert metrics.development_percent == 66.667
+
+
+def test_compute_development_time_seconds_returns_none_before_first_crack() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 130.0
+
+    assert compute_development_time_seconds(session, monotonic_now=clock.monotonic_now) is None
+
+
+def test_compute_development_time_seconds_uses_current_clock_before_drop() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 128.5
+    store.record_event(session, "first_crack_detected")
+    clock.monotonic_value = 151.75
+
+    assert compute_development_time_seconds(session, monotonic_now=clock.monotonic_now) == 23.25
+
+
+def test_compute_development_time_seconds_freezes_at_drop() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 130.0
+    store.record_event(session, "first_crack_detected")
+    clock.monotonic_value = 165.0
+    store.record_event(session, "beans_dropped")
+    clock.monotonic_value = 210.0
+
+    assert compute_development_time_seconds(session, monotonic_now=clock.monotonic_now) == 35.0
+
+
+def test_compute_development_percent_uses_roast_elapsed_denominator() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 145.0
+    store.record_event(session, "first_crack_detected")
+    clock.monotonic_value = 180.0
+
+    assert compute_development_percent(session, monotonic_now=clock.monotonic_now) == 46.667
 
 
 def test_compute_roast_elapsed_seconds_returns_none_before_beans_added() -> None:


### PR DESCRIPTION
## Summary
- Add explicit `compute_development_time_seconds(...)` for development time from authoritative first crack to current session clock or authoritative drop time.
- Add explicit `compute_development_percent(...)` using the E5-S2 `compute_roast_elapsed_seconds(...)` helper as the denominator.
- Keep existing MCP state and snapshot summary metric fields wired through `compute_roast_metrics(...)` while updating durable state docs for E5-S3 and the next E5-S4 pointer.

## Tests
- `./.venv/bin/python -m pytest tests/test_session.py`
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`
- `./.venv/bin/coffee-roaster-mcp --help`
- `./.venv/bin/coffee-roaster-mcp --version`

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added development time and development percent metrics to show roast progression from first crack through drop.

* **Documentation**
  * Added a session summary and updated epic/state docs describing metric definitions, boundaries, validation results, and next-story progression.

* **Tests**
  * Added unit tests covering development metric behavior across roasting scenarios (pre-crack, during roast, and after drop).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->