### PR TITLE
E5-S4: Compute 60s bean/env deltas

### DIFF
--- a/docs/session-summaries/2026-05-23-e5-s4-60s-bean-env-deltas.md
+++ b/docs/session-summaries/2026-05-23-e5-s4-60s-bean-env-deltas.md
@@ -1,0 +1,73 @@
+# E5-S4 60s Bean And Environment Deltas
+
+This summary captures the E5-S4 implementation, validation state, and restart
+context.
+
+## Scope
+
+Story: `E5-S4` / issue `#43`, compute 60-second bean and environment
+temperature deltas.
+
+Branch: `feature/43-compute-60s-bean-env-deltas`
+
+The implementation stayed inside the E5-S4 boundary:
+
+- compute `bean_temp_delta_60s_c` from the E5-S1 rolling telemetry buffer
+- compute `env_temp_delta_60s_c` from the E5-S1 rolling telemetry buffer
+- anchor the inclusive 60-second window at the latest retained telemetry sample
+- return latest minus oldest retained temperature value in that window
+- skip missing temperature values per sensor
+- return `None` when a sensor has no retained temperature value in the window
+- preserve E5-S2 roast elapsed and E5-S3 development metric helpers
+- preserve one-session `RoastSessionStore` ownership and mock-safe CI
+
+No RoR, append-only telemetry log files, final JSONL/CSV/summary schemas, model
+training, ONNX export, Hugging Face sync, real microphone validation, live
+Hottop validation, end-to-end agent roast validation, or broad release
+validation were added.
+
+## Implementation Summary
+
+E5-S4 added `compute_bean_temp_delta_60s_c(...)` and
+`compute_env_temp_delta_60s_c(...)` in `src/coffee_roaster_mcp/session.py`.
+
+Both helpers use the latest retained telemetry sample as the window anchor. The
+oldest eligible sample is the first retained sample whose monotonic timestamp is
+greater than or equal to `latest_sample.monotonic_seconds - 60.0` and has a
+temperature value for that sensor. The latest eligible sample is the latest
+retained sample in that same window with a temperature value for that sensor.
+
+`compute_roast_metrics(...)` now includes the two delta fields so existing
+`get_roast_state` and snapshot summary metric surfaces can return them without
+adding a new logging pipeline or final schema work.
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E5-S4` complete.
+- `docs/state/registry.md` says the next story is `E5-S5: compute bean/env
+  RoR`.
+
+## Validation
+
+Local validation:
+
+- `./.venv/bin/python -m pytest tests/test_session.py tests/test_package.py tests/test_exports.py`:
+  72 passed
+- `./.venv/bin/python -m pytest`: 312 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+## Restart Prompt
+
+Resume in `/Users/sertanyamaner/git/coffee-roaster-mcp`. PR for E5-S4 should be
+checked first. If it has merged, verify issue #43 is closed, check out `main`,
+run `git pull --ff-only origin main`, then begin E5-S5 from updated main on the
+appropriate `feature/44-...` branch. Keep E5-S5 scoped to bean/environment RoR
+normalization from the existing rolling telemetry/delta surface and preserve
+the E5-S1 telemetry buffer, E5-S2 elapsed-time helper, E5-S3 development metric
+helpers, E5-S4 60-second delta helpers, one-session store boundary,
+mock-safe CI, Hottop validation boundary, first-crack runtime boundaries, and
+no final log schema work.

--- a/docs/session-summaries/2026-05-23-e5-s4-60s-bean-env-deltas.md
+++ b/docs/session-summaries/2026-05-23-e5-s4-60s-bean-env-deltas.md
@@ -10,6 +10,8 @@ temperature deltas.
 
 Branch: `feature/43-compute-60s-bean-env-deltas`
 
+Pull request: <https://github.com/syamaner/coffee-roaster-mcp/pull/121>
+
 The implementation stayed inside the E5-S4 boundary:
 
 - compute `bean_temp_delta_60s_c` from the E5-S1 rolling telemetry buffer
@@ -17,7 +19,8 @@ The implementation stayed inside the E5-S4 boundary:
 - anchor the inclusive 60-second window at the latest retained telemetry sample
 - return latest minus oldest retained temperature value in that window
 - skip missing temperature values per sensor
-- return `None` when a sensor has no retained temperature value in the window
+- return `None` when a sensor has fewer than two retained temperature values in
+  the window
 - preserve E5-S2 roast elapsed and E5-S3 development metric helpers
 - preserve one-session `RoastSessionStore` ownership and mock-safe CI
 
@@ -36,6 +39,9 @@ oldest eligible sample is the first retained sample whose monotonic timestamp is
 greater than or equal to `latest_sample.monotonic_seconds - 60.0` and has a
 temperature value for that sensor. The latest eligible sample is the latest
 retained sample in that same window with a temperature value for that sensor.
+After PR review, the helpers require at least two valid samples for the sensor
+before returning a delta, so a single retained value returns `None` instead of
+`0.0`.
 
 `compute_roast_metrics(...)` now includes the two delta fields so existing
 `get_roast_state` and snapshot summary metric surfaces can return them without
@@ -47,13 +53,52 @@ Durable state updates:
 - `docs/state/registry.md` says the next story is `E5-S5: compute bean/env
   RoR`.
 
+## Usage Snapshot
+
+Operator-provided context snapshot after PR #121 review and fix turn:
+
+- Context window: `50% left (136K used / 258K)`
+- 5h limit: `96% left`, resets `02:17 on 24 May`
+- Weekly limit: `99% left`, resets `21:17 on 30 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `03:47 on 24 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `22:47 on 30 May`
+
+## Review And Fix Turns
+
+Review state checked on PR #121:
+
+- PR #121 is open and mergeable.
+- Issue #43 remains open and will close through the PR `Closes #43` footer when
+  the PR merges.
+- CodeRabbit first review `4351471501` posted one actionable inline comment.
+- Thread-aware review lookup showed the inline thread on
+  `src/coffee_roaster_mcp/session.py` as resolved after the fix.
+- CodeRabbit's follow-up review on commit `d6b42fa` reported no actionable
+  comments.
+
+Actionable review finding:
+
+- The original delta helper returned `0.0` when only one valid sensor sample was
+  present in the latest 60-second window, because oldest and latest values were
+  the same sample.
+- The accepted fix tracks the number of valid samples per sensor and returns
+  `None` when fewer than two valid samples are available.
+- Regression coverage was added with
+  `test_compute_temperature_deltas_60s_return_none_for_single_valid_sample`.
+
+Non-blocking review notes:
+
+- CodeRabbit continued to show a docstring coverage warning from its own
+  pre-merge checks. The repo's required `ruff`, `pyright`, `pytest`, and CLI
+  gates passed, so no broad docstring-only cleanup was taken in this story.
+
 ## Validation
 
 Local validation:
 
 - `./.venv/bin/python -m pytest tests/test_session.py tests/test_package.py tests/test_exports.py`:
-  72 passed
-- `./.venv/bin/python -m pytest`: 312 passed
+  73 passed
+- `./.venv/bin/python -m pytest`: 313 passed
 - `./.venv/bin/python -m ruff check .`: passed
 - `./.venv/bin/python -m ruff format --check .`: passed
 - `./.venv/bin/python -m pyright`: 0 errors

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E5-S4`
-- Current target: Compute 60s bean/env deltas
+- Active story: `E5-S5`
+- Current target: Compute bean/env RoR
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -224,6 +224,15 @@ The first implementation milestone is a mock vertical slice that requires no roa
   `get_roast_state` and snapshot summary metrics use these helpers through
   `compute_roast_metrics(...)`. 60-second deltas, RoR, append-only telemetry
   writers, and final log schemas remain later Epic 5 work.
+- `E5-S4` makes 60-second bean and environment temperature deltas explicit
+  through `compute_bean_temp_delta_60s_c(...)` and
+  `compute_env_temp_delta_60s_c(...)`. The helpers use the E5-S1 rolling
+  telemetry buffer, anchor the inclusive 60-second window at the latest
+  retained telemetry sample, skip missing sensor values per sensor, and return
+  latest minus oldest retained temperature in that window. Existing
+  `get_roast_state` and snapshot summary metric surfaces use these helpers
+  through `compute_roast_metrics(...)`. RoR, append-only telemetry writers, and
+  final log schemas remain later Epic 5 work.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -510,7 +519,7 @@ Goal: compute roast metrics from one session clock and export durable logs.
 - [x] `E5-S3` Compute development time and percent.
   - Done when development time starts at first crack and development percent is `development_time_seconds / roast_elapsed_seconds * 100`.
 
-- [ ] `E5-S4` Compute 60s bean/env deltas.
+- [x] `E5-S4` Compute 60s bean/env deltas.
   - Done when latest minus oldest sample in rolling 60s window is returned for bean and environment temps.
 
 - [ ] `E5-S5` Compute bean/env RoR.
@@ -1349,6 +1358,28 @@ After completing a story:
     broad release validation out of scope.
   - Ran `./.venv/bin/python -m pytest tests/test_session.py`: 53 passed.
   - Ran `./.venv/bin/python -m pytest`: 309 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E5-S4:
+  - Added `compute_bean_temp_delta_60s_c(...)` and
+    `compute_env_temp_delta_60s_c(...)` as explicit helpers for 60-second
+    temperature deltas from the E5-S1 rolling telemetry buffer.
+  - Wired `compute_roast_metrics(...)` to expose `bean_temp_delta_60s_c` and
+    `env_temp_delta_60s_c` through the existing `get_roast_state` and snapshot
+    summary metric surfaces.
+  - Added delta tests for regular 60-second sample intervals, irregular sample
+    intervals anchored to the latest retained sample, and per-sensor missing
+    temperature values.
+  - Kept RoR, append-only telemetry log files, final JSONL/CSV/summary schemas,
+    model training/export/sync, real microphone validation, live Hottop
+    validation, end-to-end agent roast validation, and broad release validation
+    out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_session.py tests/test_package.py tests/test_exports.py`:
+    72 passed.
+  - Ran `./.venv/bin/python -m pytest`: 312 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -187,8 +187,17 @@ drop, and freezes at authoritative drop time after `beans_dropped`.
 as `development_time_seconds / roast_elapsed_seconds * 100`, using the E5-S2
 roast elapsed helper for the denominator. Existing MCP state and snapshot
 summary metrics use these helpers through `compute_roast_metrics(...)`.
-60-second deltas, RoR, append-only telemetry writers, final JSONL/CSV/summary
-schemas, and broad release validation remain later Epic 5/E7 work.
+
+E5-S4 added explicit 60-second bean and environment temperature deltas from the
+E5-S1 rolling telemetry buffer. `bean_temp_delta_60s_c` and
+`env_temp_delta_60s_c` are computed as latest minus oldest retained
+temperature sample inside the inclusive 60-second window ending at the latest
+telemetry sample. Missing sensor values are skipped per sensor, and the metric
+returns `None` when no retained temperature value is available for that sensor.
+Existing MCP state and snapshot summary metric surfaces use these helpers
+through `compute_roast_metrics(...)`. RoR, append-only telemetry writers, final
+JSONL/CSV/summary schemas, and broad release validation remain later Epic 5/E7
+work.
 
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
@@ -196,7 +205,7 @@ first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E5-S4: compute 60s bean/env deltas.
+The next story is E5-S5: compute bean/env RoR.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/exports.py
+++ b/src/coffee_roaster_mcp/exports.py
@@ -135,6 +135,8 @@ def _write_summary_json(path: Path, *, session: RoastSession) -> None:
             "roast_elapsed_seconds": metrics.roast_elapsed_seconds,
             "development_time_seconds": metrics.development_time_seconds,
             "development_percent": metrics.development_percent,
+            "bean_temp_delta_60s_c": metrics.bean_temp_delta_60s_c,
+            "env_temp_delta_60s_c": metrics.env_temp_delta_60s_c,
         },
     }
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -243,6 +243,8 @@ class RoastSessionState:
     roast_elapsed_seconds: float | None
     development_time_seconds: float | None
     development_percent: float | None
+    bean_temp_delta_60s_c: float | None
+    env_temp_delta_60s_c: float | None
     device_state: RoasterDeviceState | None
     t0_status: T0Status
     first_crack_status: FirstCrackStatus
@@ -967,6 +969,8 @@ def _serialize_session_state(
         roast_elapsed_seconds=metrics.roast_elapsed_seconds,
         development_time_seconds=metrics.development_time_seconds,
         development_percent=metrics.development_percent,
+        bean_temp_delta_60s_c=metrics.bean_temp_delta_60s_c,
+        env_temp_delta_60s_c=metrics.env_temp_delta_60s_c,
         device_state=device_state,
         t0_status=_serialize_t0_status(session, config=config),
         first_crack_status=_serialize_first_crack_status(

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -217,11 +217,15 @@ class RoastMetrics:
         roast_elapsed_seconds: Seconds from beans added to drop or now.
         development_time_seconds: Seconds from first crack to drop, stop, or now.
         development_percent: Development time as a percentage of roast elapsed time.
+        bean_temp_delta_60s_c: Bean-temperature delta across the rolling 60s window.
+        env_temp_delta_60s_c: Environment-temperature delta across the rolling 60s window.
     """
 
     roast_elapsed_seconds: float | None
     development_time_seconds: float | None
     development_percent: float | None
+    bean_temp_delta_60s_c: float | None
+    env_temp_delta_60s_c: float | None
 
 
 @dataclass
@@ -365,6 +369,8 @@ def compute_roast_metrics(
             roast_elapsed_seconds=roast_elapsed_seconds,
             development_time_seconds=development_time_seconds,
         ),
+        bean_temp_delta_60s_c=compute_bean_temp_delta_60s_c(session),
+        env_temp_delta_60s_c=compute_env_temp_delta_60s_c(session),
     )
 
 
@@ -454,6 +460,40 @@ def compute_development_percent(
     )
 
 
+def compute_bean_temp_delta_60s_c(session: RoastSession) -> float | None:
+    """Compute bean-temperature delta across the latest rolling 60-second window.
+
+    Args:
+        session: Session snapshot with retained telemetry samples.
+
+    Returns:
+        Latest minus oldest bean temperature in the 60-second window ending at
+        the latest retained telemetry sample, or `None` when no bean
+        temperature sample is available in that window.
+    """
+    return _compute_temperature_delta_60s_c(
+        session,
+        temperature_field="bean_temp_c",
+    )
+
+
+def compute_env_temp_delta_60s_c(session: RoastSession) -> float | None:
+    """Compute environment-temperature delta across the latest rolling 60-second window.
+
+    Args:
+        session: Session snapshot with retained telemetry samples.
+
+    Returns:
+        Latest minus oldest environment temperature in the 60-second window
+        ending at the latest retained telemetry sample, or `None` when no
+        environment temperature sample is available in that window.
+    """
+    return _compute_temperature_delta_60s_c(
+        session,
+        temperature_field="env_temp_c",
+    )
+
+
 def _compute_development_percent_from_values(
     *,
     roast_elapsed_seconds: float | None,
@@ -467,6 +507,32 @@ def _compute_development_percent_from_values(
     ):
         return None
     return round((development_time_seconds / roast_elapsed_seconds) * 100, 3)
+
+
+def _compute_temperature_delta_60s_c(
+    session: RoastSession,
+    *,
+    temperature_field: Literal["bean_temp_c", "env_temp_c"],
+) -> float | None:
+    """Return latest minus oldest temperature in the retained 60s sample window."""
+    if not session.telemetry_buffer:
+        return None
+    latest_sample_seconds = session.telemetry_buffer[-1].monotonic_seconds
+    window_start_seconds = latest_sample_seconds - 60.0
+    oldest_temp_c: float | None = None
+    latest_temp_c: float | None = None
+    for sample in session.telemetry_buffer:
+        if sample.monotonic_seconds < window_start_seconds:
+            continue
+        temp_c = getattr(sample, temperature_field)
+        if temp_c is None:
+            continue
+        if oldest_temp_c is None:
+            oldest_temp_c = temp_c
+        latest_temp_c = temp_c
+    if oldest_temp_c is None or latest_temp_c is None:
+        return None
+    return round(latest_temp_c - oldest_temp_c, 3)
 
 
 class SessionLifecycleError(RuntimeError):

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -521,16 +521,18 @@ def _compute_temperature_delta_60s_c(
     window_start_seconds = latest_sample_seconds - 60.0
     oldest_temp_c: float | None = None
     latest_temp_c: float | None = None
+    valid_sample_count = 0
     for sample in session.telemetry_buffer:
         if sample.monotonic_seconds < window_start_seconds:
             continue
         temp_c = getattr(sample, temperature_field)
         if temp_c is None:
             continue
+        valid_sample_count += 1
         if oldest_temp_c is None:
             oldest_temp_c = temp_c
         latest_temp_c = temp_c
-    if oldest_temp_c is None or latest_temp_c is None:
+    if oldest_temp_c is None or latest_temp_c is None or valid_sample_count < 2:
         return None
     return round(latest_temp_c - oldest_temp_c, 3)
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -23,6 +23,7 @@ _T = TypeVar("_T")
 
 _EXPECTED_ROAST_STATE_KEYS = {
     "active",
+    "bean_temp_delta_60s_c",
     "beans_added_at_utc",
     "beans_added_monotonic_seconds",
     "beans_dropped_at_utc",
@@ -37,6 +38,7 @@ _EXPECTED_ROAST_STATE_KEYS = {
     "development_time_seconds",
     "device_state",
     "elapsed_monotonic_seconds",
+    "env_temp_delta_60s_c",
     "events",
     "fan_level_percent",
     "faulted_at_utc",

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1075,6 +1075,37 @@ def test_compute_temperature_deltas_60s_skip_missing_sensor_values() -> None:
     assert compute_env_temp_delta_60s_c(session) == 15.0
 
 
+def test_compute_temperature_deltas_60s_return_none_for_single_valid_sample() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    store.append_telemetry(
+        session,
+        TelemetrySample(
+            recorded_at_utc=clock.utc_now(),
+            monotonic_seconds=1.0,
+            bean_temp_c=150.0,
+            env_temp_c=None,
+        ),
+    )
+    store.append_telemetry(
+        session,
+        TelemetrySample(
+            recorded_at_utc=clock.utc_now(),
+            monotonic_seconds=10.0,
+            bean_temp_c=None,
+            env_temp_c=200.0,
+        ),
+    )
+
+    assert compute_bean_temp_delta_60s_c(session) is None
+    assert compute_env_temp_delta_60s_c(session) is None
+
+
 def test_compute_development_time_seconds_returns_none_before_first_crack() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,8 +11,10 @@ from coffee_roaster_mcp.session import (
     RoastSessionStore,
     SessionLifecycleError,
     TelemetrySample,
+    compute_bean_temp_delta_60s_c,
     compute_development_percent,
     compute_development_time_seconds,
+    compute_env_temp_delta_60s_c,
     compute_roast_elapsed_seconds,
     compute_roast_metrics,
 )
@@ -940,6 +942,8 @@ def test_compute_roast_metrics_from_event_timestamps() -> None:
     assert metrics.roast_elapsed_seconds == 50.0
     assert metrics.development_time_seconds == 15.0
     assert metrics.development_percent == 30.0
+    assert metrics.bean_temp_delta_60s_c is None
+    assert metrics.env_temp_delta_60s_c is None
 
 
 def test_compute_roast_metrics_returns_none_before_beans_added() -> None:
@@ -955,6 +959,8 @@ def test_compute_roast_metrics_returns_none_before_beans_added() -> None:
     assert metrics.roast_elapsed_seconds is None
     assert metrics.development_time_seconds is None
     assert metrics.development_percent is None
+    assert metrics.bean_temp_delta_60s_c is None
+    assert metrics.env_temp_delta_60s_c is None
 
 
 def test_compute_roast_metrics_uses_clock_for_active_session() -> None:
@@ -978,6 +984,95 @@ def test_compute_roast_metrics_uses_clock_for_active_session() -> None:
     assert metrics.roast_elapsed_seconds == 45.0
     assert metrics.development_time_seconds == 30.0
     assert metrics.development_percent == 66.667
+    assert metrics.bean_temp_delta_60s_c is None
+    assert metrics.env_temp_delta_60s_c is None
+
+
+def test_compute_temperature_deltas_60s_uses_regular_sample_window() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    for monotonic_seconds, bean_temp_c, env_temp_c in (
+        (0.0, 150.0, 180.0),
+        (30.0, 160.0, 195.0),
+        (60.0, 171.25, 211.5),
+    ):
+        store.append_telemetry(
+            session,
+            TelemetrySample(
+                recorded_at_utc=clock.utc_now(),
+                monotonic_seconds=monotonic_seconds,
+                bean_temp_c=bean_temp_c,
+                env_temp_c=env_temp_c,
+            ),
+        )
+
+    metrics = compute_roast_metrics(session, monotonic_now=clock.monotonic_now)
+
+    assert compute_bean_temp_delta_60s_c(session) == 21.25
+    assert compute_env_temp_delta_60s_c(session) == 31.5
+    assert metrics.bean_temp_delta_60s_c == 21.25
+    assert metrics.env_temp_delta_60s_c == 31.5
+
+
+def test_compute_temperature_deltas_60s_uses_irregular_latest_window() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    for monotonic_seconds, bean_temp_c, env_temp_c in (
+        (3.0, 140.0, 180.0),
+        (12.0, 145.0, 188.0),
+        (64.0, 171.0, 218.0),
+        (71.25, 178.0, 225.5),
+    ):
+        store.append_telemetry(
+            session,
+            TelemetrySample(
+                recorded_at_utc=clock.utc_now(),
+                monotonic_seconds=monotonic_seconds,
+                bean_temp_c=bean_temp_c,
+                env_temp_c=env_temp_c,
+            ),
+        )
+
+    assert compute_bean_temp_delta_60s_c(session) == 33.0
+    assert compute_env_temp_delta_60s_c(session) == 37.5
+
+
+def test_compute_temperature_deltas_60s_skip_missing_sensor_values() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    for monotonic_seconds, bean_temp_c, env_temp_c in (
+        (1.0, 150.0, None),
+        (4.0, None, 200.0),
+        (20.0, 158.0, None),
+        (40.0, None, 215.0),
+    ):
+        store.append_telemetry(
+            session,
+            TelemetrySample(
+                recorded_at_utc=clock.utc_now(),
+                monotonic_seconds=monotonic_seconds,
+                bean_temp_c=bean_temp_c,
+                env_temp_c=env_temp_c,
+            ),
+        )
+
+    assert compute_bean_temp_delta_60s_c(session) == 8.0
+    assert compute_env_temp_delta_60s_c(session) == 15.0
 
 
 def test_compute_development_time_seconds_returns_none_before_first_crack() -> None:


### PR DESCRIPTION
## Summary
- Add explicit `compute_bean_temp_delta_60s_c(...)` and `compute_env_temp_delta_60s_c(...)` helpers using the E5-S1 rolling telemetry buffer.
- Compute latest minus oldest retained temperature value in the inclusive 60-second window anchored at the latest telemetry sample, skipping missing sensor values per sensor.
- Wire the new fields through existing `compute_roast_metrics(...)`, `get_roast_state`, and snapshot summary metric surfaces while updating durable state docs for E5-S4 and the next E5-S5 pointer.

## Tests
- `./.venv/bin/python -m pytest tests/test_session.py tests/test_package.py tests/test_exports.py`
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`
- `./.venv/bin/coffee-roaster-mcp --help`
- `./.venv/bin/coffee-roaster-mcp --version`

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 60‑second bean and environment temperature deltas are computed and exposed in roast state, session telemetry, and exported session summaries.

* **Documentation**
  * Docs and epic/registry notes updated to describe the new 60s delta metrics and rollout status.

* **Tests**
  * Test coverage expanded for delta calculations, windowing behavior, missing readings, and single-sample edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->