### PR TITLE
E5-S5: Compute bean/env RoR

### DIFF
--- a/docs/session-summaries/2026-05-23-e5-s5-bean-env-ror.md
+++ b/docs/session-summaries/2026-05-23-e5-s5-bean-env-ror.md
@@ -56,6 +56,47 @@ Durable state updates:
 - `docs/state/registry.md` says the next story is `E5-S6: write append-only
   JSONL roast log`.
 
+## Usage Snapshot
+
+Operator-provided context snapshot after PR #122 review and fix turn:
+
+- Context window: `41% left (158K used / 258K)`
+- 5h limit: `94% left`, resets `02:17 on 24 May`
+- Weekly limit: `99% left`, resets `21:17 on 30 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `04:20 on 24 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `23:20 on 30 May`
+
+## Review And Fix Turns
+
+Review state checked on PR #122:
+
+- PR #122 is open and mergeable.
+- Issue #44 remains open and will close through the PR `Closes #44` footer when
+  the PR merges.
+- Codex review `4351492259` posted one actionable inline comment on
+  `src/coffee_roaster_mcp/exports.py`.
+- CodeRabbit review `4351493716` posted one outside-diff finding on the same
+  behavior.
+- CodeRabbit's follow-up review on commit `220f5ee` reported no actionable
+  comments.
+
+Actionable review finding:
+
+- The initial summary export path computed RoR through `compute_roast_metrics`
+  with default RoR parameters, while MCP `get_roast_state` used the configured
+  `session.ror_window_seconds` and `session.ror_min_sample_seconds` values.
+- The accepted fix passes runtime RoR config through
+  `export_roast_log -> export_roast_snapshot(...) -> _write_summary_json(...)`,
+  so `summary.json` and `get_roast_state` use the same RoR settings.
+- Regression coverage was added with
+  `test_snapshot_export_uses_configured_ror_parameters`.
+
+Non-blocking review notes:
+
+- CodeRabbit continued to show a docstring coverage warning from its own
+  pre-merge checks. The repo's required `ruff`, `pyright`, `pytest`, and CLI
+  gates passed, so no broad docstring-only cleanup was taken in this story.
+
 ## Validation
 
 Local validation:

--- a/docs/session-summaries/2026-05-23-e5-s5-bean-env-ror.md
+++ b/docs/session-summaries/2026-05-23-e5-s5-bean-env-ror.md
@@ -1,0 +1,74 @@
+# E5-S5 Bean And Environment RoR
+
+This summary captures the E5-S5 implementation, validation state, and restart
+context.
+
+## Scope
+
+Story: `E5-S5` / issue `#44`, compute bean and environment rate of rise.
+
+Branch: `feature/44-compute-bean-env-ror`
+
+The implementation stayed inside the E5-S5 boundary:
+
+- compute `bean_ror_c_per_min` from the E5-S1 rolling telemetry buffer
+- compute `env_ror_c_per_min` from the E5-S1 rolling telemetry buffer
+- anchor the rolling RoR window at the latest retained telemetry sample
+- normalize latest minus oldest retained temperature by the actual valid sample
+  span to Celsius per minute
+- skip missing temperature values per sensor
+- return `None` until the relevant sensor has at least the configured minimum
+  sample span, defaulting to 10 seconds
+- preserve E5-S2 roast elapsed, E5-S3 development metric, and E5-S4 60-second
+  delta helpers
+- preserve one-session `RoastSessionStore` ownership and mock-safe CI
+
+No append-only telemetry log files, final JSONL/CSV/summary schemas, model
+training, ONNX export, Hugging Face sync, real microphone validation, live
+Hottop validation, end-to-end agent roast validation, or broad release
+validation were added.
+
+## Implementation Summary
+
+E5-S5 added `compute_bean_ror_c_per_min(...)` and
+`compute_env_ror_c_per_min(...)` in `src/coffee_roaster_mcp/session.py`.
+
+Both helpers use the latest retained telemetry sample as the rolling window
+anchor. The oldest eligible sample is the first retained sample inside the
+window with a temperature value for that sensor. The latest eligible sample is
+the latest retained sample in that same window with a temperature value for
+that sensor. The metric returns `None` if the elapsed span between those valid
+sensor samples is less than the configured minimum sample span.
+
+`compute_roast_metrics(...)` now includes the two RoR fields so existing
+`get_roast_state` and snapshot summary metric surfaces can return them without
+adding a new logging pipeline or final schema work.
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E5-S5` complete.
+- `docs/state/registry.md` says the next story is `E5-S6: write append-only
+  JSONL roast log`.
+
+## Validation
+
+Local validation:
+
+- `./.venv/bin/python -m pytest`: 318 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+## Restart Prompt
+
+Resume in `/Users/sertanyamaner/git/coffee-roaster-mcp`. PR for E5-S5 should be
+checked first. If it has merged, verify issue #44 is closed, check out `main`,
+run `git pull --ff-only origin main`, then begin E5-S6 from updated main on the
+appropriate `feature/45-...` branch. Keep E5-S6 scoped to append-only JSONL
+roast logging and preserve the E5-S1 rolling telemetry buffer, E5-S2 elapsed
+helper, E5-S3 development metric helpers, E5-S4 delta helpers, E5-S5 RoR
+helpers, one-session store boundary, mock-safe CI, Hottop validation boundary,
+first-crack runtime boundaries, and no final CSV/summary schema work unless
+issue #45 explicitly requires it.

--- a/docs/session-summaries/2026-05-23-e5-s5-bean-env-ror.md
+++ b/docs/session-summaries/2026-05-23-e5-s5-bean-env-ror.md
@@ -44,6 +44,12 @@ sensor samples is less than the configured minimum sample span.
 `get_roast_state` and snapshot summary metric surfaces can return them without
 adding a new logging pipeline or final schema work.
 
+After review, the snapshot export path now accepts the same RoR window and
+minimum sample-span settings used by MCP session state, and `export_roast_log`
+passes the runtime config into `export_roast_snapshot(...)`. This keeps
+`summary.json` RoR values consistent with `get_roast_state` when operators tune
+`session.ror_window_seconds` or `session.ror_min_sample_seconds`.
+
 Durable state updates:
 
 - `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E5-S5` complete.
@@ -54,7 +60,9 @@ Durable state updates:
 
 Local validation:
 
-- `./.venv/bin/python -m pytest`: 318 passed
+- `./.venv/bin/python -m pytest tests/test_exports.py tests/test_package.py tests/test_session.py`:
+  79 passed
+- `./.venv/bin/python -m pytest`: 319 passed
 - `./.venv/bin/python -m ruff check .`: passed
 - `./.venv/bin/python -m ruff format --check .`: passed
 - `./.venv/bin/python -m pyright`: 0 errors

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E5-S5`
-- Current target: Compute bean/env RoR
+- Active story: `E5-S6`
+- Current target: Write append-only JSONL roast log
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -233,6 +233,16 @@ The first implementation milestone is a mock vertical slice that requires no roa
   `get_roast_state` and snapshot summary metric surfaces use these helpers
   through `compute_roast_metrics(...)`. RoR, append-only telemetry writers, and
   final log schemas remain later Epic 5 work.
+- `E5-S5` makes bean and environment rate-of-rise metrics explicit through
+  `compute_bean_ror_c_per_min(...)` and `compute_env_ror_c_per_min(...)`. The
+  helpers use the E5-S1 rolling telemetry buffer, anchor the rolling RoR window
+  at the latest retained telemetry sample, skip missing sensor values per
+  sensor, normalize the latest-minus-oldest retained temperature slope to
+  Celsius per minute using the actual valid sample span, and return `None`
+  until the relevant sensor has at least the configured minimum sample span,
+  defaulting to 10 seconds. Existing `get_roast_state` and snapshot summary
+  metric surfaces use these helpers through `compute_roast_metrics(...)`.
+  Append-only telemetry writers and final log schemas remain later Epic 5 work.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -522,7 +532,7 @@ Goal: compute roast metrics from one session clock and export durable logs.
 - [x] `E5-S4` Compute 60s bean/env deltas.
   - Done when latest minus oldest sample in rolling 60s window is returned for bean and environment temps.
 
-- [ ] `E5-S5` Compute bean/env RoR.
+- [x] `E5-S5` Compute bean/env RoR.
   - Done when RoR is normalized to C/min and returns null before 10 seconds of samples.
 
 - [ ] `E5-S6` Write append-only JSONL roast log.
@@ -1380,6 +1390,27 @@ After completing a story:
   - Ran `./.venv/bin/python -m pytest tests/test_session.py tests/test_package.py tests/test_exports.py`:
     72 passed.
   - Ran `./.venv/bin/python -m pytest`: 312 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E5-S5:
+  - Added `compute_bean_ror_c_per_min(...)` and
+    `compute_env_ror_c_per_min(...)` as explicit helpers for bean and
+    environment rate of rise from the E5-S1 rolling telemetry buffer.
+  - Wired `compute_roast_metrics(...)` to expose `bean_ror_c_per_min` and
+    `env_ror_c_per_min` through the existing `get_roast_state` and snapshot
+    summary metric surfaces.
+  - Added RoR tests for regular 60-second sample intervals, irregular sample
+    spans normalized to C/min, per-sensor missing temperature values, the
+    minimum 10-second sample-span guard, and configured window/minimum span
+    values.
+  - Kept append-only telemetry log files, final JSONL/CSV/summary schemas,
+    model training/export/sync, real microphone validation, live Hottop
+    validation, end-to-end agent roast validation, and broad release validation
+    out of scope.
+  - Ran `./.venv/bin/python -m pytest`: 318 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -199,13 +199,24 @@ through `compute_roast_metrics(...)`. RoR, append-only telemetry writers, final
 JSONL/CSV/summary schemas, and broad release validation remain later Epic 5/E7
 work.
 
+E5-S5 added explicit bean and environment rate-of-rise metrics from the E5-S1
+rolling telemetry buffer. `bean_ror_c_per_min` and `env_ror_c_per_min` compute
+latest minus oldest retained temperature sample in the rolling RoR window,
+normalized by the actual valid sample span to Celsius per minute. The helpers
+skip missing sensor values per sensor and return `None` until the relevant
+sensor has at least the configured minimum sample span, defaulting to 10
+seconds. Existing MCP state and snapshot summary metric surfaces use these
+helpers through `compute_roast_metrics(...)`. Append-only telemetry writers,
+final JSONL/CSV/summary schemas, and broad release validation remain later Epic
+5/E7 work.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E5-S5: compute bean/env RoR.
+The next story is E5-S6: write append-only JSONL roast log.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/exports.py
+++ b/src/coffee_roaster_mcp/exports.py
@@ -35,7 +35,12 @@ class RoastLogExport:
     note: str
 
 
-def export_roast_snapshot(session: RoastSession) -> RoastLogExport:
+def export_roast_snapshot(
+    session: RoastSession,
+    *,
+    ror_window_seconds: float = 60.0,
+    ror_min_sample_seconds: float = 10.0,
+) -> RoastLogExport:
     """Write a deterministic snapshot export for one roast session.
 
     Epic 2 exports the current session snapshot so the one-process mock flow can
@@ -44,6 +49,8 @@ def export_roast_snapshot(session: RoastSession) -> RoastLogExport:
 
     Args:
         session: Copied session snapshot to export.
+        ror_window_seconds: Rolling telemetry window for RoR calculations.
+        ror_min_sample_seconds: Minimum valid sensor sample span required for RoR.
 
     Returns:
         Export file paths and readiness metadata.
@@ -62,7 +69,12 @@ def export_roast_snapshot(session: RoastSession) -> RoastLogExport:
     log_dir.mkdir(parents=True, exist_ok=True)
     _write_event_jsonl(jsonl_path, session=session)
     _write_event_csv(csv_path, session=session)
-    _write_summary_json(summary_path, session=session)
+    _write_summary_json(
+        summary_path,
+        session=session,
+        ror_window_seconds=ror_window_seconds,
+        ror_min_sample_seconds=ror_min_sample_seconds,
+    )
 
     return RoastLogExport(
         session_id=session.id,
@@ -112,9 +124,19 @@ def _write_event_csv(path: Path, *, session: RoastSession) -> None:
             )
 
 
-def _write_summary_json(path: Path, *, session: RoastSession) -> None:
+def _write_summary_json(
+    path: Path,
+    *,
+    session: RoastSession,
+    ror_window_seconds: float = 60.0,
+    ror_min_sample_seconds: float = 10.0,
+) -> None:
     """Write a compact summary for the exported session snapshot."""
-    metrics = compute_roast_metrics(session)
+    metrics = compute_roast_metrics(
+        session,
+        ror_window_seconds=ror_window_seconds,
+        ror_min_sample_seconds=ror_min_sample_seconds,
+    )
     payload: dict[str, Any] = {
         "session_id": session.id,
         "active": session.active,

--- a/src/coffee_roaster_mcp/exports.py
+++ b/src/coffee_roaster_mcp/exports.py
@@ -137,6 +137,8 @@ def _write_summary_json(path: Path, *, session: RoastSession) -> None:
             "development_percent": metrics.development_percent,
             "bean_temp_delta_60s_c": metrics.bean_temp_delta_60s_c,
             "env_temp_delta_60s_c": metrics.env_temp_delta_60s_c,
+            "bean_ror_c_per_min": metrics.bean_ror_c_per_min,
+            "env_ror_c_per_min": metrics.env_ror_c_per_min,
         },
     }
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -595,7 +595,11 @@ def create_mcp_server(
         """Write a snapshot export for one roast session."""
         server_context = ctx.request_context.lifespan_context
         session = _resolve_session(server_context, session_id=session_id)
-        export = export_roast_snapshot(session)
+        export = export_roast_snapshot(
+            session,
+            ror_window_seconds=server_context.config.session.ror_window_seconds,
+            ror_min_sample_seconds=server_context.config.session.ror_min_sample_seconds,
+        )
         return ExportRoastLogResult(
             session_id=export.session_id,
             log_dir=str(export.log_dir),

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -245,6 +245,8 @@ class RoastSessionState:
     development_percent: float | None
     bean_temp_delta_60s_c: float | None
     env_temp_delta_60s_c: float | None
+    bean_ror_c_per_min: float | None
+    env_ror_c_per_min: float | None
     device_state: RoasterDeviceState | None
     t0_status: T0Status
     first_crack_status: FirstCrackStatus
@@ -943,7 +945,11 @@ def _serialize_session_state(
     first_crack_runtime: FirstCrackRuntimeSnapshot | None = None,
 ) -> RoastSessionState:
     """Convert one in-memory session into an MCP-safe snapshot."""
-    metrics = compute_roast_metrics(session)
+    metrics = compute_roast_metrics(
+        session,
+        ror_window_seconds=config.session.ror_window_seconds,
+        ror_min_sample_seconds=config.session.ror_min_sample_seconds,
+    )
     return RoastSessionState(
         session_id=session.id,
         active=session.active,
@@ -971,6 +977,8 @@ def _serialize_session_state(
         development_percent=metrics.development_percent,
         bean_temp_delta_60s_c=metrics.bean_temp_delta_60s_c,
         env_temp_delta_60s_c=metrics.env_temp_delta_60s_c,
+        bean_ror_c_per_min=metrics.bean_ror_c_per_min,
+        env_ror_c_per_min=metrics.env_ror_c_per_min,
         device_state=device_state,
         t0_status=_serialize_t0_status(session, config=config),
         first_crack_status=_serialize_first_crack_status(

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -219,6 +219,8 @@ class RoastMetrics:
         development_percent: Development time as a percentage of roast elapsed time.
         bean_temp_delta_60s_c: Bean-temperature delta across the rolling 60s window.
         env_temp_delta_60s_c: Environment-temperature delta across the rolling 60s window.
+        bean_ror_c_per_min: Bean-temperature rate of rise in Celsius per minute.
+        env_ror_c_per_min: Environment-temperature rate of rise in Celsius per minute.
     """
 
     roast_elapsed_seconds: float | None
@@ -226,6 +228,8 @@ class RoastMetrics:
     development_percent: float | None
     bean_temp_delta_60s_c: float | None
     env_temp_delta_60s_c: float | None
+    bean_ror_c_per_min: float | None
+    env_ror_c_per_min: float | None
 
 
 @dataclass
@@ -341,12 +345,16 @@ def compute_roast_metrics(
     session: RoastSession,
     *,
     monotonic_now: Callable[[], float] | None = None,
+    ror_window_seconds: float = 60.0,
+    ror_min_sample_seconds: float = 10.0,
 ) -> RoastMetrics:
     """Compute timestamp-derived metrics for one session snapshot.
 
     Args:
         session: Session snapshot to inspect.
         monotonic_now: Optional monotonic clock supplier for active sessions.
+        ror_window_seconds: Rolling telemetry window for RoR calculations.
+        ror_min_sample_seconds: Minimum valid sensor sample span required for RoR.
 
     Returns:
         Minimal roast metrics available from the current event timestamps.
@@ -371,6 +379,16 @@ def compute_roast_metrics(
         ),
         bean_temp_delta_60s_c=compute_bean_temp_delta_60s_c(session),
         env_temp_delta_60s_c=compute_env_temp_delta_60s_c(session),
+        bean_ror_c_per_min=compute_bean_ror_c_per_min(
+            session,
+            window_seconds=ror_window_seconds,
+            min_sample_seconds=ror_min_sample_seconds,
+        ),
+        env_ror_c_per_min=compute_env_ror_c_per_min(
+            session,
+            window_seconds=ror_window_seconds,
+            min_sample_seconds=ror_min_sample_seconds,
+        ),
     )
 
 
@@ -494,6 +512,56 @@ def compute_env_temp_delta_60s_c(session: RoastSession) -> float | None:
     )
 
 
+def compute_bean_ror_c_per_min(
+    session: RoastSession,
+    *,
+    window_seconds: float = 60.0,
+    min_sample_seconds: float = 10.0,
+) -> float | None:
+    """Compute bean-temperature rate of rise in Celsius per minute.
+
+    Args:
+        session: Session snapshot with retained telemetry samples.
+        window_seconds: Rolling telemetry window ending at the latest sample.
+        min_sample_seconds: Minimum valid bean sample span required for a value.
+
+    Returns:
+        Bean-temperature slope over the latest valid rolling sample span,
+        normalized to Celsius per minute, or `None` before enough samples exist.
+    """
+    return _compute_temperature_ror_c_per_min(
+        session,
+        temperature_field="bean_temp_c",
+        window_seconds=window_seconds,
+        min_sample_seconds=min_sample_seconds,
+    )
+
+
+def compute_env_ror_c_per_min(
+    session: RoastSession,
+    *,
+    window_seconds: float = 60.0,
+    min_sample_seconds: float = 10.0,
+) -> float | None:
+    """Compute environment-temperature rate of rise in Celsius per minute.
+
+    Args:
+        session: Session snapshot with retained telemetry samples.
+        window_seconds: Rolling telemetry window ending at the latest sample.
+        min_sample_seconds: Minimum valid environment sample span required for a value.
+
+    Returns:
+        Environment-temperature slope over the latest valid rolling sample span,
+        normalized to Celsius per minute, or `None` before enough samples exist.
+    """
+    return _compute_temperature_ror_c_per_min(
+        session,
+        temperature_field="env_temp_c",
+        window_seconds=window_seconds,
+        min_sample_seconds=min_sample_seconds,
+    )
+
+
 def _compute_development_percent_from_values(
     *,
     roast_elapsed_seconds: float | None,
@@ -535,6 +603,46 @@ def _compute_temperature_delta_60s_c(
     if oldest_temp_c is None or latest_temp_c is None or valid_sample_count < 2:
         return None
     return round(latest_temp_c - oldest_temp_c, 3)
+
+
+def _compute_temperature_ror_c_per_min(
+    session: RoastSession,
+    *,
+    temperature_field: Literal["bean_temp_c", "env_temp_c"],
+    window_seconds: float,
+    min_sample_seconds: float,
+) -> float | None:
+    """Return temperature slope over the latest rolling window as C/min."""
+    if not session.telemetry_buffer:
+        return None
+    latest_sample_seconds = session.telemetry_buffer[-1].monotonic_seconds
+    window_start_seconds = latest_sample_seconds - window_seconds
+    oldest_temp_c: float | None = None
+    oldest_sample_seconds: float | None = None
+    latest_temp_c: float | None = None
+    latest_temp_seconds: float | None = None
+    for sample in session.telemetry_buffer:
+        if sample.monotonic_seconds < window_start_seconds:
+            continue
+        temp_c = getattr(sample, temperature_field)
+        if temp_c is None:
+            continue
+        if oldest_temp_c is None:
+            oldest_temp_c = temp_c
+            oldest_sample_seconds = sample.monotonic_seconds
+        latest_temp_c = temp_c
+        latest_temp_seconds = sample.monotonic_seconds
+    if (
+        oldest_temp_c is None
+        or oldest_sample_seconds is None
+        or latest_temp_c is None
+        or latest_temp_seconds is None
+    ):
+        return None
+    sample_span_seconds = latest_temp_seconds - oldest_sample_seconds
+    if sample_span_seconds < min_sample_seconds or sample_span_seconds <= 0:
+        return None
+    return round(((latest_temp_c - oldest_temp_c) / sample_span_seconds) * 60.0, 3)
 
 
 class SessionLifecycleError(RuntimeError):

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from coffee_roaster_mcp.exports import export_roast_snapshot
-from coffee_roaster_mcp.session import EventPayloadValue, RoastSessionStore
+from coffee_roaster_mcp.session import EventPayloadValue, RoastSessionStore, TelemetrySample
 
 
 class ClockHarness:
@@ -78,5 +78,38 @@ def test_snapshot_export_preserves_first_crack_detector_metadata(tmp_path: Path)
     assert summary["first_crack_at_utc"] == "2026-05-17T14:00:37.250000+00:00"
     assert summary["metrics"]["development_time_seconds"] == 32.75
     assert summary["metrics"]["development_percent"] == 50.385
+    assert summary["metrics"]["bean_ror_c_per_min"] is None
+    assert summary["metrics"]["env_ror_c_per_min"] is None
+
+
+def test_snapshot_export_uses_configured_ror_parameters(tmp_path: Path) -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    for monotonic_seconds, bean_temp_c, env_temp_c in (
+        (0.0, 150.0, 180.0),
+        (12.0, 160.0, 192.0),
+    ):
+        store.append_telemetry(
+            session,
+            TelemetrySample(
+                recorded_at_utc=clock.utc_now(),
+                monotonic_seconds=monotonic_seconds,
+                bean_temp_c=bean_temp_c,
+                env_temp_c=env_temp_c,
+            ),
+        )
+
+    export = export_roast_snapshot(
+        session,
+        ror_window_seconds=60,
+        ror_min_sample_seconds=20,
+    )
+
+    summary = json.loads(export.summary_path.read_text(encoding="utf-8"))
     assert summary["metrics"]["bean_ror_c_per_min"] is None
     assert summary["metrics"]["env_ror_c_per_min"] is None

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -78,3 +78,5 @@ def test_snapshot_export_preserves_first_crack_detector_metadata(tmp_path: Path)
     assert summary["first_crack_at_utc"] == "2026-05-17T14:00:37.250000+00:00"
     assert summary["metrics"]["development_time_seconds"] == 32.75
     assert summary["metrics"]["development_percent"] == 50.385
+    assert summary["metrics"]["bean_ror_c_per_min"] is None
+    assert summary["metrics"]["env_ror_c_per_min"] is None

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -23,6 +23,7 @@ _T = TypeVar("_T")
 
 _EXPECTED_ROAST_STATE_KEYS = {
     "active",
+    "bean_ror_c_per_min",
     "bean_temp_delta_60s_c",
     "beans_added_at_utc",
     "beans_added_monotonic_seconds",
@@ -39,6 +40,7 @@ _EXPECTED_ROAST_STATE_KEYS = {
     "device_state",
     "elapsed_monotonic_seconds",
     "env_temp_delta_60s_c",
+    "env_ror_c_per_min",
     "events",
     "fan_level_percent",
     "faulted_at_utc",

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,9 +11,11 @@ from coffee_roaster_mcp.session import (
     RoastSessionStore,
     SessionLifecycleError,
     TelemetrySample,
+    compute_bean_ror_c_per_min,
     compute_bean_temp_delta_60s_c,
     compute_development_percent,
     compute_development_time_seconds,
+    compute_env_ror_c_per_min,
     compute_env_temp_delta_60s_c,
     compute_roast_elapsed_seconds,
     compute_roast_metrics,
@@ -944,6 +946,8 @@ def test_compute_roast_metrics_from_event_timestamps() -> None:
     assert metrics.development_percent == 30.0
     assert metrics.bean_temp_delta_60s_c is None
     assert metrics.env_temp_delta_60s_c is None
+    assert metrics.bean_ror_c_per_min is None
+    assert metrics.env_ror_c_per_min is None
 
 
 def test_compute_roast_metrics_returns_none_before_beans_added() -> None:
@@ -961,6 +965,8 @@ def test_compute_roast_metrics_returns_none_before_beans_added() -> None:
     assert metrics.development_percent is None
     assert metrics.bean_temp_delta_60s_c is None
     assert metrics.env_temp_delta_60s_c is None
+    assert metrics.bean_ror_c_per_min is None
+    assert metrics.env_ror_c_per_min is None
 
 
 def test_compute_roast_metrics_uses_clock_for_active_session() -> None:
@@ -986,6 +992,8 @@ def test_compute_roast_metrics_uses_clock_for_active_session() -> None:
     assert metrics.development_percent == 66.667
     assert metrics.bean_temp_delta_60s_c is None
     assert metrics.env_temp_delta_60s_c is None
+    assert metrics.bean_ror_c_per_min is None
+    assert metrics.env_ror_c_per_min is None
 
 
 def test_compute_temperature_deltas_60s_uses_regular_sample_window() -> None:
@@ -1017,6 +1025,8 @@ def test_compute_temperature_deltas_60s_uses_regular_sample_window() -> None:
     assert compute_env_temp_delta_60s_c(session) == 31.5
     assert metrics.bean_temp_delta_60s_c == 21.25
     assert metrics.env_temp_delta_60s_c == 31.5
+    assert metrics.bean_ror_c_per_min == 21.25
+    assert metrics.env_ror_c_per_min == 31.5
 
 
 def test_compute_temperature_deltas_60s_uses_irregular_latest_window() -> None:
@@ -1104,6 +1114,169 @@ def test_compute_temperature_deltas_60s_return_none_for_single_valid_sample() ->
 
     assert compute_bean_temp_delta_60s_c(session) is None
     assert compute_env_temp_delta_60s_c(session) is None
+
+
+def test_compute_temperature_ror_uses_regular_sample_window() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    for monotonic_seconds, bean_temp_c, env_temp_c in (
+        (0.0, 150.0, 180.0),
+        (30.0, 160.0, 195.0),
+        (60.0, 171.25, 211.5),
+    ):
+        store.append_telemetry(
+            session,
+            TelemetrySample(
+                recorded_at_utc=clock.utc_now(),
+                monotonic_seconds=monotonic_seconds,
+                bean_temp_c=bean_temp_c,
+                env_temp_c=env_temp_c,
+            ),
+        )
+
+    metrics = compute_roast_metrics(session, monotonic_now=clock.monotonic_now)
+
+    assert compute_bean_ror_c_per_min(session) == 21.25
+    assert compute_env_ror_c_per_min(session) == 31.5
+    assert metrics.bean_ror_c_per_min == 21.25
+    assert metrics.env_ror_c_per_min == 31.5
+
+
+def test_compute_temperature_ror_uses_irregular_sample_span() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    for monotonic_seconds, bean_temp_c, env_temp_c in (
+        (3.0, 140.0, 180.0),
+        (20.0, 150.0, 190.0),
+        (64.0, 171.0, 218.0),
+        (72.0, 178.0, 226.0),
+    ):
+        store.append_telemetry(
+            session,
+            TelemetrySample(
+                recorded_at_utc=clock.utc_now(),
+                monotonic_seconds=monotonic_seconds,
+                bean_temp_c=bean_temp_c,
+                env_temp_c=env_temp_c,
+            ),
+        )
+
+    assert compute_bean_ror_c_per_min(session) == 32.308
+    assert compute_env_ror_c_per_min(session) == 41.538
+
+
+def test_compute_temperature_ror_skips_missing_sensor_values() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    for monotonic_seconds, bean_temp_c, env_temp_c in (
+        (1.0, 150.0, None),
+        (4.0, None, 200.0),
+        (20.0, 158.0, None),
+        (40.0, None, 215.0),
+    ):
+        store.append_telemetry(
+            session,
+            TelemetrySample(
+                recorded_at_utc=clock.utc_now(),
+                monotonic_seconds=monotonic_seconds,
+                bean_temp_c=bean_temp_c,
+                env_temp_c=env_temp_c,
+            ),
+        )
+
+    assert compute_bean_ror_c_per_min(session) == 25.263
+    assert compute_env_ror_c_per_min(session) == 25.0
+
+
+def test_compute_temperature_ror_returns_none_before_min_sample_span() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    for monotonic_seconds, bean_temp_c, env_temp_c in (
+        (1.0, 150.0, 200.0),
+        (9.0, 158.0, 212.0),
+    ):
+        store.append_telemetry(
+            session,
+            TelemetrySample(
+                recorded_at_utc=clock.utc_now(),
+                monotonic_seconds=monotonic_seconds,
+                bean_temp_c=bean_temp_c,
+                env_temp_c=env_temp_c,
+            ),
+        )
+
+    assert compute_bean_ror_c_per_min(session) is None
+    assert compute_env_ror_c_per_min(session) is None
+
+
+def test_compute_temperature_ror_uses_configurable_window_and_min_span() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    for monotonic_seconds, bean_temp_c, env_temp_c in (
+        (0.0, 100.0, 150.0),
+        (40.0, 130.0, 170.0),
+        (70.0, 145.0, 182.0),
+    ):
+        store.append_telemetry(
+            session,
+            TelemetrySample(
+                recorded_at_utc=clock.utc_now(),
+                monotonic_seconds=monotonic_seconds,
+                bean_temp_c=bean_temp_c,
+                env_temp_c=env_temp_c,
+            ),
+        )
+
+    metrics = compute_roast_metrics(
+        session,
+        monotonic_now=clock.monotonic_now,
+        ror_window_seconds=45,
+        ror_min_sample_seconds=20,
+    )
+
+    assert (
+        compute_bean_ror_c_per_min(
+            session,
+            window_seconds=45,
+            min_sample_seconds=20,
+        )
+        == 30.0
+    )
+    assert (
+        compute_env_ror_c_per_min(
+            session,
+            window_seconds=45,
+            min_sample_seconds=20,
+        )
+        == 24.0
+    )
+    assert metrics.bean_ror_c_per_min == 30.0
+    assert metrics.env_ror_c_per_min == 24.0
 
 
 def test_compute_development_time_seconds_returns_none_before_first_crack() -> None:


### PR DESCRIPTION
## Summary
- Add explicit `compute_bean_ror_c_per_min(...)` and `compute_env_ror_c_per_min(...)` helpers using the E5-S1 rolling telemetry buffer.
- Normalize latest-minus-oldest retained bean/environment temperature slopes to C/min over the latest rolling RoR window, skipping missing values per sensor and returning `None` until the configured minimum sample span is met.
- Wire the new fields through existing `compute_roast_metrics(...)`, `get_roast_state`, and snapshot summary metric surfaces while updating durable state docs for E5-S5 and the next E5-S6 pointer.

## Tests
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`
- `./.venv/bin/coffee-roaster-mcp --help`
- `./.venv/bin/coffee-roaster-mcp --version`

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bean and environment rate-of-rise (RoR) metrics to session state and exported roast summaries; RoR is derived from rolling telemetry with configurable window and minimum sample-span parameters.

* **Documentation**
  * New session summary and updated epic/registry docs marking E5-S5 complete, documenting RoR behavior and the transition to E5-S6.

* **Tests**
  * Added tests for RoR computation, sampling edge cases, and updated snapshot/export expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->