### PR TITLE
E5-S6: Write append-only JSONL roast log

### DIFF
--- a/docs/session-summaries/2026-05-23-e5-s6-append-only-jsonl-log.md
+++ b/docs/session-summaries/2026-05-23-e5-s6-append-only-jsonl-log.md
@@ -1,0 +1,73 @@
+# E5-S6 Append-Only JSONL Roast Log
+
+This summary captures the E5-S6 implementation, validation state, and restart
+context.
+
+## Scope
+
+Story: `E5-S6` / issue `#45`, write append-only JSONL roast log.
+
+Branch: `feature/45-write-append-only-jsonl-roast-log`
+
+The implementation stayed inside the E5-S6 boundary:
+
+- write JSONL event rows immediately when new authoritative timeline events are
+  recorded
+- write JSONL telemetry rows from the existing E5-S1 polling sample path at the
+  configured sample interval, defaulting to 1 Hz
+- preserve the E5-S1 rolling telemetry buffer for derived metrics
+- preserve E5-S2 elapsed, E5-S3 development metric, E5-S4 delta, and E5-S5 RoR
+  helpers
+- preserve the one-session `RoastSessionStore` mutation boundary and mock-safe
+  MCP path
+- keep snapshot CSV and `summary.json` behavior available without overwriting
+  an existing append-only `roast.jsonl`
+
+No final CSV schema work, final `summary.json` schema work, model training, ONNX
+export, Hugging Face sync, real microphone validation, live Hottop validation,
+end-to-end agent roast validation, or broad release validation was added.
+
+## Implementation Summary
+
+`RoastSessionStore` now owns append-only JSONL writes at the same mutation
+points that already own session state:
+
+- `record_event(...)` appends event rows for new timeline events.
+- automatic first-crack detection appends the confirmed first-crack row.
+- emergency fault recording appends the fault row.
+- telemetry recording appends telemetry rows only when the configured interval
+  has elapsed since the last written telemetry row for that session.
+
+The MCP server passes `logging.sample_interval_seconds` into the session store,
+so the default remains 1 Hz while config can tune the interval.
+
+`export_roast_snapshot(...)` still writes `roast.csv` and `summary.json`, but it
+does not overwrite an existing append-only runtime `roast.jsonl`. If a legacy
+snapshot has no runtime JSONL file yet, export can still create the current
+event-only JSONL fallback.
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E5-S6` complete.
+- `docs/state/registry.md` says the next story is `E5-S7: export CSV roast log`.
+
+## Validation
+
+Local validation:
+
+- `./.venv/bin/python -m pytest`: 321 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+## Restart Prompt
+
+Resume in `/Users/sertanyamaner/git/coffee-roaster-mcp`. PR for E5-S6 should be
+checked first. If it has merged, verify issue #45 is closed, check out `main`,
+run `git pull --ff-only origin main`, then begin E5-S7 from updated main on the
+appropriate `feature/46-...` branch after reading the registry, active epic,
+this summary, and the GitHub issue for E5-S7. Keep E5-S7 scoped to CSV roast log
+export unless its issue explicitly requires more, and preserve the append-only
+JSONL runtime writer plus existing metrics/session/runtime boundaries.

--- a/docs/session-summaries/2026-05-23-e5-s6-append-only-jsonl-log.md
+++ b/docs/session-summaries/2026-05-23-e5-s6-append-only-jsonl-log.md
@@ -55,7 +55,7 @@ Durable state updates:
 
 Local validation:
 
-- `./.venv/bin/python -m pytest`: 321 passed
+- `./.venv/bin/python -m pytest`: 325 passed
 - `./.venv/bin/python -m ruff check .`: passed
 - `./.venv/bin/python -m ruff format --check .`: passed
 - `./.venv/bin/python -m pyright`: 0 errors
@@ -64,8 +64,8 @@ Local validation:
 
 ## Restart Prompt
 
-Resume in `/Users/sertanyamaner/git/coffee-roaster-mcp`. PR for E5-S6 should be
-checked first. If it has merged, verify issue #45 is closed, check out `main`,
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E5-S6 should
+be checked first. If it has merged, verify issue #45 is closed, check out `main`,
 run `git pull --ff-only origin main`, then begin E5-S7 from updated main on the
 appropriate `feature/46-...` branch after reading the registry, active epic,
 this summary, and the GitHub issue for E5-S7. Keep E5-S7 scoped to CSV roast log

--- a/docs/session-summaries/2026-05-23-e5-s6-append-only-jsonl-log.md
+++ b/docs/session-summaries/2026-05-23-e5-s6-append-only-jsonl-log.md
@@ -44,7 +44,8 @@ so the default remains 1 Hz while config can tune the interval.
 `export_roast_snapshot(...)` still writes `roast.csv` and `summary.json`, but it
 does not overwrite an existing append-only runtime `roast.jsonl`. If a legacy
 snapshot has no runtime JSONL file yet, export can still create the current
-event-only JSONL fallback.
+event-only JSONL fallback. Export now fails closed if `roast.jsonl` exists as a
+directory or other non-file path instead of reporting a ready export.
 
 Durable state updates:
 
@@ -55,7 +56,7 @@ Durable state updates:
 
 Local validation:
 
-- `./.venv/bin/python -m pytest`: 325 passed
+- `./.venv/bin/python -m pytest`: 327 passed
 - `./.venv/bin/python -m ruff check .`: passed
 - `./.venv/bin/python -m ruff format --check .`: passed
 - `./.venv/bin/python -m pyright`: 0 errors
@@ -129,11 +130,44 @@ Review quality comparison:
   covered the same root issue as two of the Codex findings.
 - The overlap was useful: both reviewers independently flagged JSONL durability
   atomicity, which was the highest-risk issue in the story.
-- CodeRabbit's follow-up after `4bdf412` reported only one low-value nitpick:
-  the `_telemetry_log_row_if_due(...)` docstring still says "configured 1 Hz"
-  even though the interval is configurable. This is documentation polish, not a
-  behavior blocker, and all review threads from the first pass are marked
-  resolved.
+
+Codex review `4351526483` added three actionable edge-case findings after
+`4bdf412`:
+
+- `export_roast_snapshot(...)` treated an existing `roast.jsonl` directory as a
+  valid append-only log path and could still return `ready=True`.
+- Reserved driver drop completion applied driver control state before recording
+  `beans_dropped`, so a failed JSONL event append could leave control state
+  updated without the matching event and phase transition.
+- Reserved driver start-cooling completion had the same rollback gap for
+  `cooling_started`.
+
+The follow-up fix addressed those findings:
+
+- Existing non-file `roast.jsonl` paths now raise `ValueError` during export.
+- Reserved driver drop completion restores the previous heat, fan, and cooling
+  fields if event logging fails before completion.
+- Reserved driver start-cooling completion restores the previous heat, fan, and
+  cooling fields if event logging fails before completion.
+- Regression tests cover the non-file export path plus control rollback for
+  failed drop and cooling-start event appends.
+
+CodeRabbit's follow-up after `4bdf412` reported only one low-value nitpick: the
+`_telemetry_log_row_if_due(...)` docstring still said "configured 1 Hz" even
+though the interval is configurable. The follow-up fix also changed that wording
+to "configured logging interval."
+
+Updated review quality comparison:
+
+- Codex stayed strongest on state/log atomicity and fail-closed behavior. Its
+  second pass found two hardware-control consistency gaps that were adjacent to
+  the first-pass reservation cleanup finding.
+- CodeRabbit stayed strongest on documentation, handoff, and consistency drift.
+  Its only second-pass note was documentation polish after the functional review
+  fixes were in place.
+- The combined review coverage was useful: Codex drove the risk-bearing runtime
+  fixes, while CodeRabbit improved durable handoff quality and caught stale
+  wording around configurable behavior.
 
 ## Restart Prompt
 

--- a/docs/session-summaries/2026-05-23-e5-s6-append-only-jsonl-log.md
+++ b/docs/session-summaries/2026-05-23-e5-s6-append-only-jsonl-log.md
@@ -62,6 +62,79 @@ Local validation:
 - `./.venv/bin/coffee-roaster-mcp --help`: passed
 - `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
 
+GitHub validation after commit `4bdf412`:
+
+- `Build Package`: passed
+- `Checks`: passed
+- `CodeRabbit`: passed with review skipped on the latest check run
+- PR #123 remained open, mergeable, and based on `main`
+
+## Usage Snapshot
+
+Operator-provided context snapshot after PR #123 review and fix turn:
+
+- Context window: `31% left (182K used / 258K)`
+- 5h limit: `92% left`, resets `02:17 on 24 May`
+- Weekly limit: `98% left`, resets `21:17 on 30 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `04:41 on 24 May`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `23:41 on 30 May`
+- Warning: `limits may be stale - run /status again shortly`
+
+## Review Comparison
+
+PR #123 review state was checked after the initial E5-S6 implementation commit
+`f9946ca` and after the review-fix commit `4bdf412`.
+
+Codex review on `f9946ca` reported four actionable findings:
+
+- Event log writes happened after in-memory event/phase mutation, so an I/O
+  error could commit session state while losing the JSONL row.
+- Telemetry writes happened after appending to the rolling telemetry buffer, so
+  a failed JSONL append could advance metrics state without durable log state.
+- Invalid `logging.sample_interval_seconds` could surface as raw `ValueError`
+  from `RoastSessionStore` construction instead of the config layer's
+  `ConfigError`.
+- Reserved driver drop/cooling paths could leave a pending command reservation
+  if a JSONL event append failed while completing the reservation.
+
+CodeRabbit's first pass on `f9946ca` overlapped with Codex on the core atomicity
+problem and added two separate review findings:
+
+- The restart prompt used the machine-specific path
+  `/Users/sertanyamaner/git/coffee-roaster-mcp`; this was made portable as
+  "the local clone of `syamaner/coffee-roaster-mcp`".
+- `_copy_session_for_read(...)` did not preserve
+  `last_logged_telemetry_monotonic_seconds`, so snapshots lost the new telemetry
+  log cursor.
+
+The accepted fix in `4bdf412` addressed the shared and unique findings:
+
+- Event rows are staged and appended to JSONL before timeline and phase mutation.
+- Telemetry rows are staged and appended before the telemetry buffer and cursor
+  advance.
+- Reserved driver event completions now clear pending reservations in `finally`
+  blocks.
+- `logging.sample_interval_seconds` now uses positive-float config validation.
+- Read snapshots copy `last_logged_telemetry_monotonic_seconds`.
+- Regression tests cover failed event writes, failed telemetry writes, reserved
+  drop cleanup, cursor copying, and positive sample interval validation.
+
+Review quality comparison:
+
+- Codex was sharper on operational failure modes. It split the logging issue
+  into event atomicity, telemetry atomicity, config error normalization, and
+  reservation cleanup, which mapped directly to risk-bearing tests.
+- CodeRabbit was broader on handoff and consistency. It caught the portable
+  restart prompt and snapshot cursor omission, and its grouped atomicity comment
+  covered the same root issue as two of the Codex findings.
+- The overlap was useful: both reviewers independently flagged JSONL durability
+  atomicity, which was the highest-risk issue in the story.
+- CodeRabbit's follow-up after `4bdf412` reported only one low-value nitpick:
+  the `_telemetry_log_row_if_due(...)` docstring still says "configured 1 Hz"
+  even though the interval is configurable. This is documentation polish, not a
+  behavior blocker, and all review threads from the first pass are marked
+  resolved.
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E5-S6 should

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -1438,7 +1438,7 @@ After completing a story:
     training/export/sync, real microphone validation, live Hottop validation,
     end-to-end agent roast validation, and broad release validation out of
     scope.
-  - Ran `./.venv/bin/python -m pytest`: 321 passed.
+  - Ran `./.venv/bin/python -m pytest`: 325 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E5-S6`
-- Current target: Write append-only JSONL roast log
+- Active story: `E5-S7`
+- Current target: Export CSV roast log
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -243,6 +243,14 @@ The first implementation milestone is a mock vertical slice that requires no roa
   defaulting to 10 seconds. Existing `get_roast_state` and snapshot summary
   metric surfaces use these helpers through `compute_roast_metrics(...)`.
   Append-only telemetry writers and final log schemas remain later Epic 5 work.
+- `E5-S6` writes append-only runtime JSONL logs from the authoritative
+  `RoastSessionStore`. Event rows are appended to `roast.jsonl` immediately
+  when new timeline events are recorded, and telemetry rows are appended from
+  the existing E5-S1 polling path at the configured
+  `logging.sample_interval_seconds`, defaulting to 1 Hz. Snapshot export keeps
+  writing CSV and `summary.json` from the current session but no longer
+  overwrites an existing append-only JSONL log. Final CSV and summary schemas
+  remain later Epic 5 work.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -535,7 +543,7 @@ Goal: compute roast metrics from one session clock and export durable logs.
 - [x] `E5-S5` Compute bean/env RoR.
   - Done when RoR is normalized to C/min and returns null before 10 seconds of samples.
 
-- [ ] `E5-S6` Write append-only JSONL roast log.
+- [x] `E5-S6` Write append-only JSONL roast log.
   - Done when telemetry rows are written at 1 Hz and event rows are written immediately.
 
 - [ ] `E5-S7` Export CSV roast log.
@@ -1411,6 +1419,26 @@ After completing a story:
     validation, end-to-end agent roast validation, and broad release validation
     out of scope.
   - Ran `./.venv/bin/python -m pytest`: 318 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E5-S6:
+  - Added append-only `roast.jsonl` runtime writes behind the authoritative
+    `RoastSessionStore` mutation boundary.
+  - Event rows are written immediately when new session timeline events are
+    recorded, including automatic first-crack and emergency fault paths.
+  - Telemetry rows are written from the existing E5-S1 polling sample path at
+    `logging.sample_interval_seconds`, defaulting to 1 Hz, while still
+    preserving the rolling telemetry buffer for derived metrics.
+  - Snapshot export still writes CSV and `summary.json`, but does not overwrite
+    an existing append-only JSONL runtime log.
+  - Kept final CSV schema work, final summary schema work, model
+    training/export/sync, real microphone validation, live Hottop validation,
+    end-to-end agent roast validation, and broad release validation out of
+    scope.
+  - Ran `./.venv/bin/python -m pytest`: 321 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -210,13 +210,23 @@ helpers through `compute_roast_metrics(...)`. Append-only telemetry writers,
 final JSONL/CSV/summary schemas, and broad release validation remain later Epic
 5/E7 work.
 
+E5-S6 added the append-only runtime JSONL roast log. `RoastSessionStore` now
+writes event rows to each session's `roast.jsonl` immediately when new
+authoritative timeline events are recorded, and writes telemetry rows from the
+existing E5-S1 driver polling path no more often than
+`logging.sample_interval_seconds`, defaulting to 1 Hz. The existing rolling
+telemetry buffer, metric helpers, one-session store boundary, mock-safe MCP
+flow, and final CSV/summary schema boundaries remain unchanged. Snapshot export
+continues to write CSV and `summary.json`, but no longer overwrites an existing
+append-only `roast.jsonl` file.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E5-S6: write append-only JSONL roast log.
+The next story is E5-S7: export CSV roast log.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/config.py
+++ b/src/coffee_roaster_mcp/config.py
@@ -245,7 +245,7 @@ def _audio_from_mapping(raw: Mapping[str, Any]) -> AudioConfig:
 def _logging_from_mapping(raw: Mapping[str, Any]) -> LoggingConfig:
     return LoggingConfig(
         log_dir=_path(raw, "log_dir", Path("./logs"), label="logging.log_dir"),
-        sample_interval_seconds=_float(
+        sample_interval_seconds=_positive_float(
             raw,
             "sample_interval_seconds",
             1.0,

--- a/src/coffee_roaster_mcp/exports.py
+++ b/src/coffee_roaster_mcp/exports.py
@@ -67,7 +67,8 @@ def export_roast_snapshot(
     summary_path = log_dir / "summary.json"
 
     log_dir.mkdir(parents=True, exist_ok=True)
-    _write_event_jsonl(jsonl_path, session=session)
+    if not jsonl_path.exists():
+        _write_event_jsonl(jsonl_path, session=session)
     _write_event_csv(csv_path, session=session)
     _write_summary_json(
         summary_path,
@@ -84,8 +85,8 @@ def export_roast_snapshot(
         summary_path=summary_path,
         ready=True,
         note=(
-            "Snapshot export written from the current in-process session. "
-            "Append-only telemetry writers and final log schemas land in Epic 5."
+            "Snapshot CSV and summary export written from the current "
+            "in-process session. JSONL is append-only during the roast."
         ),
     )
 

--- a/src/coffee_roaster_mcp/exports.py
+++ b/src/coffee_roaster_mcp/exports.py
@@ -56,7 +56,8 @@ def export_roast_snapshot(
         Export file paths and readiness metadata.
 
     Raises:
-        ValueError: If the session has no log writer target.
+        ValueError: If the session has no log writer target or the JSONL path
+            is not a regular file.
     """
     if session.log_writer is None:
         raise ValueError("Session log target is unavailable.")
@@ -67,6 +68,8 @@ def export_roast_snapshot(
     summary_path = log_dir / "summary.json"
 
     log_dir.mkdir(parents=True, exist_ok=True)
+    if jsonl_path.exists() and not jsonl_path.is_file():
+        raise ValueError(f"JSONL export path exists but is not a file: {jsonl_path}")
     if not jsonl_path.exists():
         _write_event_jsonl(jsonl_path, session=session)
     _write_event_csv(csv_path, session=session)

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -323,7 +323,10 @@ def build_server_context(
     return ServerContext(
         config=config,
         transport=transport,
-        session_store=RoastSessionStore(default_log_dir=config.logging.log_dir / "roasts"),
+        session_store=RoastSessionStore(
+            default_log_dir=config.logging.log_dir / "roasts",
+            telemetry_log_interval_seconds=config.logging.sample_interval_seconds,
+        ),
         roaster_driver=roaster_driver,
         first_crack_runtime=build_first_crack_session_runtime(config),
         started_at_utc=datetime.now(UTC),

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -107,12 +107,18 @@ def _append_telemetry_with_limit(
         and sample.monotonic_seconds < session.telemetry_buffer[-1].monotonic_seconds
     ):
         raise SessionLifecycleError("Telemetry samples must be appended in timestamp order.")
-    session.telemetry_buffer.append(sample)
-    _append_telemetry_log_row_if_due(
+
+    telemetry_row = _telemetry_log_row_if_due(
         session,
         sample,
         log_interval_seconds=log_interval_seconds,
     )
+    if telemetry_row is not None:
+        _append_jsonl_log_row(session, telemetry_row)
+
+    session.telemetry_buffer.append(sample)
+    if telemetry_row is not None:
+        session.last_logged_telemetry_monotonic_seconds = sample.monotonic_seconds
     while len(session.telemetry_buffer) > max_samples:
         session.telemetry_buffer.popleft()
 
@@ -143,31 +149,27 @@ def _append_event_log_row(session: RoastSession, event: RoastEvent) -> None:
     )
 
 
-def _append_telemetry_log_row_if_due(
+def _telemetry_log_row_if_due(
     session: RoastSession,
     sample: TelemetrySample,
     *,
     log_interval_seconds: float,
-) -> None:
-    """Append one telemetry log row when the configured 1 Hz interval is due."""
+) -> Mapping[str, object] | None:
+    """Return one telemetry log row when the configured 1 Hz interval is due."""
     last_logged = session.last_logged_telemetry_monotonic_seconds
     if last_logged is not None and sample.monotonic_seconds - last_logged < log_interval_seconds:
-        return
-    _append_jsonl_log_row(
-        session,
-        {
-            "session_id": session.id,
-            "type": "telemetry",
-            "recorded_at_utc": sample.recorded_at_utc.isoformat(),
-            "monotonic_seconds": sample.monotonic_seconds,
-            "bean_temp_c": sample.bean_temp_c,
-            "env_temp_c": sample.env_temp_c,
-            "heat_level_percent": sample.heat_level_percent,
-            "fan_level_percent": sample.fan_level_percent,
-            "cooling_on": sample.cooling_on,
-        },
-    )
-    session.last_logged_telemetry_monotonic_seconds = sample.monotonic_seconds
+        return None
+    return {
+        "session_id": session.id,
+        "type": "telemetry",
+        "recorded_at_utc": sample.recorded_at_utc.isoformat(),
+        "monotonic_seconds": sample.monotonic_seconds,
+        "bean_temp_c": sample.bean_temp_c,
+        "env_temp_c": sample.env_temp_c,
+        "heat_level_percent": sample.heat_level_percent,
+        "fan_level_percent": sample.fan_level_percent,
+        "cooling_on": sample.cooling_on,
+    }
 
 
 @dataclass(frozen=True)
@@ -1160,10 +1162,12 @@ class RoastSessionStore:
                 fan_level_percent=fan_level_percent,
                 cooling_on=cooling_on,
             )
-            event = self.record_event(session, "beans_dropped")
-            if cooling_on:
-                self.record_event(session, "cooling_started")
-            self._clear_driver_command_reservation_locked(session, reservation)
+            try:
+                event = self.record_event(session, "beans_dropped")
+                if cooling_on:
+                    self.record_event(session, "cooling_started")
+            finally:
+                self._clear_driver_command_reservation_locked(session, reservation)
             return event, _copy_session_for_read(session)
 
     def complete_reserved_driver_start_cooling_snapshot(
@@ -1184,8 +1188,10 @@ class RoastSessionStore:
                 fan_level_percent=fan_level_percent,
                 cooling_on=cooling_on,
             )
-            event = self.record_event(session, "cooling_started")
-            self._clear_driver_command_reservation_locked(session, reservation)
+            try:
+                event = self.record_event(session, "cooling_started")
+            finally:
+                self._clear_driver_command_reservation_locked(session, reservation)
             return event, _copy_session_for_read(session)
 
     def complete_reserved_driver_stop_cooling_snapshot(
@@ -1212,16 +1218,18 @@ class RoastSessionStore:
                 fan_level_percent,
                 label="fan_level_percent",
             )
-            event = self.record_event(session, "cooling_stopped")
-            session.heat_level_percent = validated_heat
-            session.fan_level_percent = validated_fan
-            session.cooling_on = False
-            session.stop(
-                utc_now=self._utc_now,
-                monotonic_now=self._monotonic_now,
-                phase="complete",
-            )
-            self._clear_driver_command_reservation_locked(session, reservation)
+            try:
+                event = self.record_event(session, "cooling_stopped")
+                session.heat_level_percent = validated_heat
+                session.fan_level_percent = validated_fan
+                session.cooling_on = False
+                session.stop(
+                    utc_now=self._utc_now,
+                    monotonic_now=self._monotonic_now,
+                    phase="complete",
+                )
+            finally:
+                self._clear_driver_command_reservation_locked(session, reservation)
             return event, _copy_session_for_read(session)
 
     def clear_driver_command_reservation(
@@ -1317,9 +1325,9 @@ class RoastSessionStore:
                 monotonic_seconds=monotonic_seconds,
                 payload={} if payload is None else dict(payload),
             )
+            _append_event_log_row(session, event)
             session.event_timeline.append(event)
             _apply_event_timestamp(session, event)
-            _append_event_log_row(session, event)
             return event
 
     def record_event_snapshot(
@@ -1448,9 +1456,9 @@ class RoastSessionStore:
                 monotonic_seconds=detected_elapsed_seconds,
                 payload={} if payload is None else dict(payload),
             )
+            _append_event_log_row(session, event)
             session.event_timeline.append(event)
             _apply_event_timestamp(session, event)
-            _append_event_log_row(session, event)
             return event, _copy_session_for_read(session)
 
     def emergency_stop(
@@ -1679,9 +1687,9 @@ class RoastSessionStore:
             monotonic_seconds=session.elapsed_monotonic_seconds(self._monotonic_now),
             payload=dict(payload),
         )
+        _append_event_log_row(session, event)
         session.event_timeline.append(event)
         _apply_event_timestamp(session, event)
-        _append_event_log_row(session, event)
         return event
 
 
@@ -1895,6 +1903,7 @@ def _copy_session_for_read(session: RoastSession) -> RoastSession:
         event_timeline=deepcopy(session.event_timeline),
         telemetry_buffer=deque(session.telemetry_buffer),
         log_writer=session.log_writer,
+        last_logged_telemetry_monotonic_seconds=(session.last_logged_telemetry_monotonic_seconds),
         stopped_at_utc=session.stopped_at_utc,
         monotonic_stop=session.monotonic_stop,
         pending_driver_command_token=session.pending_driver_command_token,

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 from collections import deque
 from collections.abc import Callable, Mapping
@@ -96,6 +97,7 @@ def _append_telemetry_with_limit(
     sample: TelemetrySample,
     *,
     max_samples: int,
+    log_interval_seconds: float,
 ) -> None:
     """Append telemetry to one session with an explicit retention limit."""
     if max_samples < 0:
@@ -106,8 +108,66 @@ def _append_telemetry_with_limit(
     ):
         raise SessionLifecycleError("Telemetry samples must be appended in timestamp order.")
     session.telemetry_buffer.append(sample)
+    _append_telemetry_log_row_if_due(
+        session,
+        sample,
+        log_interval_seconds=log_interval_seconds,
+    )
     while len(session.telemetry_buffer) > max_samples:
         session.telemetry_buffer.popleft()
+
+
+def _append_jsonl_log_row(session: RoastSession, row: Mapping[str, object]) -> None:
+    """Append one JSON row to the session's durable roast log."""
+    if session.log_writer is None:
+        return
+    path = session.log_writer.log_dir / "roast.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as output:
+        output.write(json.dumps(row, sort_keys=True))
+        output.write("\n")
+
+
+def _append_event_log_row(session: RoastSession, event: RoastEvent) -> None:
+    """Append one event row to the session's durable roast log."""
+    _append_jsonl_log_row(
+        session,
+        {
+            "session_id": session.id,
+            "type": "event",
+            "kind": event.kind,
+            "recorded_at_utc": event.recorded_at_utc.isoformat(),
+            "monotonic_seconds": event.monotonic_seconds,
+            "payload": dict(event.payload),
+        },
+    )
+
+
+def _append_telemetry_log_row_if_due(
+    session: RoastSession,
+    sample: TelemetrySample,
+    *,
+    log_interval_seconds: float,
+) -> None:
+    """Append one telemetry log row when the configured 1 Hz interval is due."""
+    last_logged = session.last_logged_telemetry_monotonic_seconds
+    if last_logged is not None and sample.monotonic_seconds - last_logged < log_interval_seconds:
+        return
+    _append_jsonl_log_row(
+        session,
+        {
+            "session_id": session.id,
+            "type": "telemetry",
+            "recorded_at_utc": sample.recorded_at_utc.isoformat(),
+            "monotonic_seconds": sample.monotonic_seconds,
+            "bean_temp_c": sample.bean_temp_c,
+            "env_temp_c": sample.env_temp_c,
+            "heat_level_percent": sample.heat_level_percent,
+            "fan_level_percent": sample.fan_level_percent,
+            "cooling_on": sample.cooling_on,
+        },
+    )
+    session.last_logged_telemetry_monotonic_seconds = sample.monotonic_seconds
 
 
 @dataclass(frozen=True)
@@ -266,6 +326,8 @@ class RoastSession:
         event_timeline: Shared ordered event timeline for future runtime stories.
         telemetry_buffer: Rolling telemetry sample buffer.
         log_writer: Append-only log writer reference when available.
+        last_logged_telemetry_monotonic_seconds: Latest telemetry timestamp
+            written to the append-only JSONL log.
         stopped_at_utc: Wall-clock UTC stop time once the session is stopped.
         monotonic_stop: Monotonic clock value captured when the session stops.
     """
@@ -295,6 +357,7 @@ class RoastSession:
     event_timeline: list[RoastEvent] = field(default_factory=_event_timeline_default)
     telemetry_buffer: deque[TelemetrySample] = field(default_factory=_telemetry_buffer_default)
     log_writer: LogWriterReference | None = None
+    last_logged_telemetry_monotonic_seconds: float | None = None
     stopped_at_utc: datetime | None = None
     monotonic_stop: float | None = None
     pending_driver_command_token: str | None = None
@@ -670,6 +733,7 @@ class RoastSessionStore:
         monotonic_now: Callable[[], float] | None = None,
         session_id_factory: Callable[[], str] | None = None,
         default_log_dir: Path = Path("./logs/roasts"),
+        telemetry_log_interval_seconds: float = 1.0,
     ) -> None:
         """Initialize the single-session store.
 
@@ -680,6 +744,8 @@ class RoastSessionStore:
             monotonic_now: Optional monotonic clock supplier.
             session_id_factory: Optional session id supplier.
             default_log_dir: Base directory for future log writer references.
+            telemetry_log_interval_seconds: Minimum seconds between telemetry
+                rows in the append-only JSONL log.
         """
         import time
 
@@ -687,8 +753,11 @@ class RoastSessionStore:
             raise ValueError("telemetry_buffer_limit must be >= 0.")
         if session_history_limit < 1:
             raise ValueError("session_history_limit must be >= 1.")
+        if not math.isfinite(telemetry_log_interval_seconds) or telemetry_log_interval_seconds <= 0:
+            raise ValueError("telemetry_log_interval_seconds must be greater than 0.")
 
         self._telemetry_buffer_limit = telemetry_buffer_limit
+        self._telemetry_log_interval_seconds = telemetry_log_interval_seconds
         self._session_history_limit = session_history_limit
         self._utc_now = utc_now or (lambda: datetime.now(UTC))
         self._monotonic_now = monotonic_now or time.monotonic
@@ -792,6 +861,7 @@ class RoastSessionStore:
                 session,
                 sample,
                 max_samples=self._telemetry_buffer_limit,
+                log_interval_seconds=self._telemetry_log_interval_seconds,
             )
 
     def record_telemetry_sample(
@@ -835,6 +905,7 @@ class RoastSessionStore:
                 session,
                 sample,
                 max_samples=self._telemetry_buffer_limit,
+                log_interval_seconds=self._telemetry_log_interval_seconds,
             )
             return _copy_session_for_read(session)
 
@@ -882,6 +953,7 @@ class RoastSessionStore:
                 self._latest_session,
                 sample,
                 max_samples=self._telemetry_buffer_limit,
+                log_interval_seconds=self._telemetry_log_interval_seconds,
             )
             return _copy_session_for_read(self._latest_session)
 
@@ -1247,6 +1319,7 @@ class RoastSessionStore:
             )
             session.event_timeline.append(event)
             _apply_event_timestamp(session, event)
+            _append_event_log_row(session, event)
             return event
 
     def record_event_snapshot(
@@ -1377,6 +1450,7 @@ class RoastSessionStore:
             )
             session.event_timeline.append(event)
             _apply_event_timestamp(session, event)
+            _append_event_log_row(session, event)
             return event, _copy_session_for_read(session)
 
     def emergency_stop(
@@ -1607,6 +1681,7 @@ class RoastSessionStore:
         )
         session.event_timeline.append(event)
         _apply_event_timestamp(session, event)
+        _append_event_log_row(session, event)
         return event
 
 

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -155,7 +155,7 @@ def _telemetry_log_row_if_due(
     *,
     log_interval_seconds: float,
 ) -> Mapping[str, object] | None:
-    """Return one telemetry log row when the configured 1 Hz interval is due."""
+    """Return one telemetry log row when the configured logging interval is due."""
     last_logged = session.last_logged_telemetry_monotonic_seconds
     if last_logged is not None and sample.monotonic_seconds - last_logged < log_interval_seconds:
         return None
@@ -1156,6 +1156,11 @@ class RoastSessionStore:
         """
         with self._lock:
             self._assert_driver_command_reservation(session, reservation)
+            previous_control_state = (
+                session.heat_level_percent,
+                session.fan_level_percent,
+                session.cooling_on,
+            )
             self.apply_driver_control_state(
                 session,
                 heat_level_percent=heat_level_percent,
@@ -1166,6 +1171,13 @@ class RoastSessionStore:
                 event = self.record_event(session, "beans_dropped")
                 if cooling_on:
                     self.record_event(session, "cooling_started")
+            except Exception:
+                (
+                    session.heat_level_percent,
+                    session.fan_level_percent,
+                    session.cooling_on,
+                ) = previous_control_state
+                raise
             finally:
                 self._clear_driver_command_reservation_locked(session, reservation)
             return event, _copy_session_for_read(session)
@@ -1182,6 +1194,11 @@ class RoastSessionStore:
         """Complete a reserved cooling-start command and record the event."""
         with self._lock:
             self._assert_driver_command_reservation(session, reservation)
+            previous_control_state = (
+                session.heat_level_percent,
+                session.fan_level_percent,
+                session.cooling_on,
+            )
             self.apply_driver_control_state(
                 session,
                 heat_level_percent=heat_level_percent,
@@ -1190,6 +1207,13 @@ class RoastSessionStore:
             )
             try:
                 event = self.record_event(session, "cooling_started")
+            except Exception:
+                (
+                    session.heat_level_percent,
+                    session.fan_level_percent,
+                    session.cooling_on,
+                ) = previous_control_state
+                raise
             finally:
                 self._clear_driver_command_reservation_locked(session, reservation)
             return event, _copy_session_for_read(session)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -101,6 +101,20 @@ session:
     assert config.session.ror_min_sample_seconds == 12
 
 
+def test_logging_sample_interval_must_be_positive(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        """
+logging:
+  sample_interval_seconds: 0
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigError, match="logging.sample_interval_seconds"):
+        load_config(config_path, environ={})
+
+
 def test_environment_overrides_file_config(tmp_path: Path) -> None:
     config_path = tmp_path / "coffee-roaster-mcp.yaml"
     config_path.write_text(

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -7,6 +7,8 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 from coffee_roaster_mcp.exports import export_roast_snapshot
 from coffee_roaster_mcp.session import EventPayloadValue, RoastSessionStore, TelemetrySample
 
@@ -113,3 +115,21 @@ def test_snapshot_export_uses_configured_ror_parameters(tmp_path: Path) -> None:
     summary = json.loads(export.summary_path.read_text(encoding="utf-8"))
     assert summary["metrics"]["bean_ror_c_per_min"] is None
     assert summary["metrics"]["env_ror_c_per_min"] is None
+
+
+def test_snapshot_export_rejects_existing_jsonl_directory(tmp_path: Path) -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    assert session.log_writer is not None
+    jsonl_path = session.log_writer.log_dir / "roast.jsonl"
+    jsonl_path.unlink()
+    jsonl_path.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="JSONL export path exists but is not a file"):
+        export_roast_snapshot(session)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -77,7 +77,8 @@ def test_in_process_mcp_tools_cover_mock_roast_and_export(tmp_path: Path) -> Non
     assert Path(export.csv_path).exists()
     assert Path(export.summary_path).exists()
 
-    events = [json.loads(line) for line in Path(export.jsonl_path).read_text().splitlines()]
+    rows = [json.loads(line) for line in Path(export.jsonl_path).read_text().splitlines()]
+    events = [row for row in rows if row["type"] == "event"]
     assert [event["kind"] for event in events] == [
         "beans_added",
         "first_crack_detected",

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -366,9 +366,10 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         assert export_jsonl_path.exists()
         assert export_csv_path.exists()
         assert export_summary_path.exists()
-        exported_events = [
+        exported_rows = [
             json.loads(line) for line in export_jsonl_path.read_text(encoding="utf-8").splitlines()
         ]
+        exported_events = [row for row in exported_rows if row["type"] == "event"]
         assert [event["kind"] for event in exported_events] == [
             "beans_added",
             "first_crack_detected",

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -333,6 +333,12 @@ def test_reserved_driver_drop_log_failure_clears_reservation(
     )
     session = store.start_session()
     store.record_event(session, "beans_added")
+    store.apply_driver_control_state(
+        session,
+        heat_level_percent=35,
+        fan_level_percent=25,
+        cooling_on=False,
+    )
     drop_reservation = store.reserve_driver_drop(session)
     assert drop_reservation.reservation is not None
 
@@ -355,6 +361,59 @@ def test_reserved_driver_drop_log_failure_clears_reservation(
 
     assert session.pending_driver_command_token is None
     assert session.pending_driver_command_kind is None
+    assert session.heat_level_percent == 35
+    assert session.fan_level_percent == 25
+    assert session.cooling_on is False
+    assert session.beans_dropped_at_utc is None
+    assert session.phase == "roasting"
+
+
+def test_reserved_driver_start_cooling_log_failure_rolls_back_controls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    store.record_event(session, "beans_dropped")
+    store.apply_driver_control_state(
+        session,
+        heat_level_percent=30,
+        fan_level_percent=40,
+        cooling_on=False,
+    )
+    cooling_reservation = store.reserve_driver_start_cooling(session)
+    assert cooling_reservation.reservation is not None
+
+    def fail_event_log_write(
+        _session: session_module.RoastSession,
+        _event: session_module.RoastEvent,
+    ) -> None:
+        raise OSError("log unavailable")
+
+    monkeypatch.setattr(session_module, "_append_event_log_row", fail_event_log_write)
+
+    with pytest.raises(OSError, match="log unavailable"):
+        store.complete_reserved_driver_start_cooling_snapshot(
+            session,
+            reservation=cooling_reservation.reservation,
+            heat_level_percent=0,
+            fan_level_percent=100,
+            cooling_on=True,
+        )
+
+    assert session.pending_driver_command_token is None
+    assert session.pending_driver_command_kind is None
+    assert session.heat_level_percent == 30
+    assert session.fan_level_percent == 40
+    assert session.cooling_on is False
+    assert session.cooling_started_at_utc is None
+    assert session.phase == "dropped"
 
 
 def test_record_active_telemetry_sample_returns_none_when_session_is_stale() -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
@@ -182,6 +183,90 @@ def test_record_telemetry_sample_uses_session_clock_and_snapshot_retains_buffer(
     assert samples[0].fan_level_percent == 35
     assert samples[0].cooling_on is False
     assert list(store.get_session_snapshot().telemetry_buffer) == samples
+
+
+def test_append_only_jsonl_log_writes_events_immediately_and_telemetry_at_1hz(
+    tmp_path: Path,
+) -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+        session_id_factory=lambda: "session-001",
+        telemetry_log_interval_seconds=1.0,
+    )
+    session = store.start_session()
+
+    clock.monotonic_value = 100.0
+    store.record_telemetry_sample(
+        session,
+        bean_temp_c=151.25,
+        env_temp_c=204.5,
+        heat_level_percent=55,
+        fan_level_percent=35,
+        cooling_on=False,
+    )
+    clock.monotonic_value = 100.5
+    store.record_telemetry_sample(
+        session,
+        bean_temp_c=151.5,
+        env_temp_c=205.0,
+        heat_level_percent=55,
+        fan_level_percent=35,
+        cooling_on=False,
+    )
+    clock.monotonic_value = 100.7
+    event = store.record_event(session, "beans_added")
+    clock.monotonic_value = 101.2
+    store.record_telemetry_sample(
+        session,
+        bean_temp_c=152.0,
+        env_temp_c=206.0,
+        heat_level_percent=60,
+        fan_level_percent=40,
+        cooling_on=False,
+    )
+
+    log_path = tmp_path / "roasts" / "session-001" / "roast.jsonl"
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+    assert [row["type"] for row in rows] == ["telemetry", "event", "telemetry"]
+    assert rows[0]["session_id"] == "session-001"
+    assert rows[0]["bean_temp_c"] == 151.25
+    assert rows[0]["monotonic_seconds"] == 0.0
+    assert rows[1]["kind"] == "beans_added"
+    assert rows[1]["recorded_at_utc"] == event.recorded_at_utc.isoformat()
+    assert round(rows[1]["monotonic_seconds"], 3) == 0.7
+    assert rows[2]["bean_temp_c"] == 152.0
+    assert rows[2]["env_temp_c"] == 206.0
+    assert rows[2]["heat_level_percent"] == 60
+    assert rows[2]["fan_level_percent"] == 40
+
+
+def test_append_only_jsonl_log_includes_automatic_first_crack_events(tmp_path: Path) -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+        session_id_factory=lambda: "session-001",
+    )
+    session = store.start_session()
+
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 110.0
+    store.record_first_crack_detection_snapshot(
+        session,
+        detected_at_monotonic_seconds=109.25,
+        payload={"source": "first_crack_detector"},
+    )
+
+    log_path = tmp_path / "roasts" / "session-001" / "roast.jsonl"
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+    assert [row["kind"] for row in rows] == ["beans_added", "first_crack_detected"]
+    assert rows[1]["payload"] == {"source": "first_crack_detector"}
+    assert rows[1]["monotonic_seconds"] == 9.25
 
 
 def test_record_active_telemetry_sample_returns_none_when_session_is_stale() -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -7,6 +7,7 @@ from typing import cast
 
 import pytest
 
+import coffee_roaster_mcp.session as session_module
 from coffee_roaster_mcp.session import (
     RoastEventKind,
     RoastSessionStore,
@@ -241,6 +242,9 @@ def test_append_only_jsonl_log_writes_events_immediately_and_telemetry_at_1hz(
     assert rows[2]["env_temp_c"] == 206.0
     assert rows[2]["heat_level_percent"] == 60
     assert rows[2]["fan_level_percent"] == 40
+    latest_logged = store.get_session_snapshot().last_logged_telemetry_monotonic_seconds
+    assert latest_logged is not None
+    assert round(latest_logged, 3) == 1.2
 
 
 def test_append_only_jsonl_log_includes_automatic_first_crack_events(tmp_path: Path) -> None:
@@ -267,6 +271,90 @@ def test_append_only_jsonl_log_includes_automatic_first_crack_events(tmp_path: P
     assert [row["kind"] for row in rows] == ["beans_added", "first_crack_detected"]
     assert rows[1]["payload"] == {"source": "first_crack_detector"}
     assert rows[1]["monotonic_seconds"] == 9.25
+
+
+def test_event_log_write_failure_does_not_commit_event(tmp_path: Path) -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+        session_id_factory=lambda: "session-001",
+    )
+    session = store.start_session()
+    blocked_log_dir = tmp_path / "roasts" / "session-001"
+    blocked_log_dir.parent.mkdir(parents=True)
+    blocked_log_dir.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(OSError):
+        store.record_event(session, "beans_added")
+
+    assert session.event_timeline == []
+    assert session.phase == "pre_roast"
+    assert session.beans_added_at_utc is None
+
+
+def test_telemetry_log_write_failure_does_not_advance_buffer(tmp_path: Path) -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+        session_id_factory=lambda: "session-001",
+    )
+    session = store.start_session()
+    blocked_log_dir = tmp_path / "roasts" / "session-001"
+    blocked_log_dir.parent.mkdir(parents=True)
+    blocked_log_dir.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(OSError):
+        store.record_telemetry_sample(
+            session,
+            bean_temp_c=151.25,
+            env_temp_c=204.5,
+            heat_level_percent=55,
+            fan_level_percent=35,
+            cooling_on=False,
+        )
+
+    assert list(session.telemetry_buffer) == []
+    assert session.last_logged_telemetry_monotonic_seconds is None
+
+
+def test_reserved_driver_drop_log_failure_clears_reservation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    drop_reservation = store.reserve_driver_drop(session)
+    assert drop_reservation.reservation is not None
+
+    def fail_event_log_write(
+        _session: session_module.RoastSession,
+        _event: session_module.RoastEvent,
+    ) -> None:
+        raise OSError("log unavailable")
+
+    monkeypatch.setattr(session_module, "_append_event_log_row", fail_event_log_write)
+
+    with pytest.raises(OSError, match="log unavailable"):
+        store.complete_reserved_driver_drop_snapshot(
+            session,
+            reservation=drop_reservation.reservation,
+            heat_level_percent=0,
+            fan_level_percent=100,
+            cooling_on=True,
+        )
+
+    assert session.pending_driver_command_token is None
+    assert session.pending_driver_command_kind is None
 
 
 def test_record_active_telemetry_sample_returns_none_when_session_is_stale() -> None:


### PR DESCRIPTION
## Summary
- Add append-only runtime `roast.jsonl` writes behind the authoritative `RoastSessionStore` mutation boundary.
- Write event rows immediately when new timeline events are recorded, including automatic first-crack and emergency fault paths.
- Write telemetry rows from the existing E5-S1 polling path at `logging.sample_interval_seconds`, defaulting to 1 Hz, while preserving the rolling telemetry buffer and derived metric helpers.
- Keep snapshot CSV and `summary.json` export behavior, but avoid overwriting an existing append-only JSONL runtime log.
- Update durable state docs and add the E5-S6 session summary with the next E5-S7 pointer.

## Tests
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`
- `./.venv/bin/coffee-roaster-mcp --help`
- `./.venv/bin/coffee-roaster-mcp --version`

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Durable append-only JSONL logging for roast events and telemetry (telemetry sampled at a configurable interval, default 1 Hz)
  * Snapshot export becomes idempotent: preserves existing JSONL logs and fails if the JSONL path exists but is not a file

* **Documentation**
  * New and updated docs describing append-only logging, export behavior, validation checklist, and milestone status

* **Tests**
  * New and updated tests validating JSONL logging behavior, export edge cases, and positive sampling-interval validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->