### PR TITLE
E5-S7: Export CSV roast log

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,11 +378,14 @@ the active in-process session.
 
 Current export files:
 
-- `roast.jsonl` with the current event timeline snapshot
-- `roast.csv` with the current event timeline snapshot
+- `roast.jsonl` with append-only event and sampled telemetry rows during the
+  roast
+- `roast.csv` with telemetry and event rows using the planned CSV columns for
+  timestamps, elapsed seconds, phase, temperatures, controls, event flags,
+  development percent, RoR/delta metrics, and first-crack model metadata
 - `summary.json` with current session-level metadata and timestamp-derived
   metrics
 - output under `logs/roasts/{session_id}/`
 
-Append-only telemetry logging, rolling RoR metrics, development percentage
-hardening, and final log schemas land in Epic 5.
+Final `summary.json` schema work and broad release validation land in later
+stories.

--- a/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
+++ b/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
@@ -122,6 +122,43 @@ Validation after second review fixes:
 - `./.venv/bin/coffee-roaster-mcp --help`: passed
 - `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
 
+## Code Review Analysis
+
+PR #124 benefited from overlapping CodeRabbit and Codex review coverage. Both
+reviewers focused on the same highest-risk part of the story: whether exported
+CSV rows preserve a defensible point-in-time timeline when session events and
+telemetry samples share monotonic timestamps.
+
+CodeRabbit provided the broadest structured review surface. Its walkthrough
+identified the intended CSV export shape, related prior metric stories, and the
+out-of-scope boundaries. Its actionable comments were strongest where a direct
+local patch was obvious: flip same-time row ordering, derive cooling transition
+state from events, exclude same-timestamp telemetry from event rows, and add a
+`cooling_stopped` regression test. It also surfaced the docstring coverage
+warning, which was useful for keeping the touched test surface within project
+quality expectations.
+
+Codex review was more behavior-oriented. It independently flagged that same-time
+ordering was not just a presentation issue: telemetry rows, event rows, event
+flags, first-crack metadata, and metric snapshots could all disagree if the
+exporter mixed inclusive `<=` views with event-before-telemetry ordering. The
+Codex comments pushed the implementation from a row-ordering fix toward a
+consistent point-in-time model: scoped same-time events for each event row,
+configured RoR parameters for CSV metrics, strict-before telemetry lookup for
+event rows, and strict-before telemetry in event metric snapshots.
+
+The review overlap was useful rather than redundant. CodeRabbit usually
+provided concrete edit targets and regression-test prompts, while Codex exposed
+the broader invariant that each CSV row must describe only the state visible at
+that row in exported order. The combined result was stronger than either review
+alone: event rows now avoid later same-time events and later same-time telemetry,
+telemetry rows still include same-time event state only after the event row is
+emitted, metric configuration stays aligned with `summary.json`, and cooling
+transition rows are covered by explicit regression tests.
+
+All CodeRabbit and Codex actionable review threads are resolved as of commit
+`351ba85`.
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E5-S7 should

--- a/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
+++ b/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
@@ -64,6 +64,16 @@ Full validation:
 - `./.venv/bin/coffee-roaster-mcp --help`: passed
 - `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
 
+## Usage Snapshot
+
+Operator-provided context snapshot after PR #124 creation:
+
+- Context window: `56% left (121K used / 258K)`
+- 5h limit: `90% left`, resets `02:17`
+- Weekly limit: `98% left`, resets `21:17 on 30 May`
+- GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `05:16`
+- GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `00:16 on 31 May`
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E5-S7 should

--- a/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
+++ b/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
@@ -74,6 +74,10 @@ Operator-provided context snapshot after PR #124 creation:
 - GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `05:16`
 - GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `00:16 on 31 May`
 
+Operator-provided cumulative session usage after the third review-fix round:
+
+- Tokens used so far in this session: `656K`
+
 ## Review Fixes
 
 PR #124 review feedback from CodeRabbit and Codex was checked with

--- a/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
+++ b/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
@@ -156,8 +156,30 @@ telemetry rows still include same-time event state only after the event row is
 emitted, metric configuration stays aligned with `summary.json`, and cooling
 transition rows are covered by explicit regression tests.
 
-All CodeRabbit and Codex actionable review threads are resolved as of commit
-`351ba85`.
+The first two CodeRabbit and Codex actionable review rounds were resolved as of
+commit `351ba85`.
+
+Third review-fix round:
+
+- driver-completed drop, cooling-start, and cooling-stop events now carry the
+  driver-returned heat, fan, and cooling state in their event payloads, allowing
+  CSV and JSONL exports to preserve post-transition control state without
+  guessing from stale telemetry
+- CSV telemetry metric snapshots now include only samples visible up to the
+  current telemetry row when multiple samples share the same monotonic timestamp
+- regression coverage now verifies driver transition payload state on
+  `beans_dropped` / `cooling_started` rows and same-time telemetry metric
+  isolation
+
+Validation after third review fixes:
+
+- `./.venv/bin/python -m pytest tests/test_exports.py`: 9 passed
+- `./.venv/bin/python -m pytest`: 333 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
 
 ## Restart Prompt
 

--- a/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
+++ b/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
@@ -185,6 +185,25 @@ Validation after third review fixes:
 - `./.venv/bin/coffee-roaster-mcp --help`: passed
 - `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
 
+Fourth review-fix round:
+
+- completing a reserved driver `start_cooling` command now fails closed when
+  the driver still reports `cooling_on=False`, preventing a contradictory
+  `cooling_started` event payload and preserving session phase/control state
+- regression coverage verifies the failed driver result clears the pending
+  reservation, does not record `cooling_started`, and leaves the session in the
+  dropped phase
+
+Validation after fourth review fixes:
+
+- `./.venv/bin/python -m pytest tests/test_session.py::test_reserved_driver_start_cooling_rejects_inactive_driver_result tests/test_exports.py`: 10 passed
+- `./.venv/bin/python -m pytest`: 334 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E5-S7 should

--- a/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
+++ b/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
@@ -1,0 +1,76 @@
+# E5-S7 CSV Roast Log Export
+
+This summary captures the E5-S7 implementation, validation state, and restart
+context.
+
+## Scope
+
+Story: `E5-S7` / issue `#46`, export CSV roast log.
+
+Branch: `feature/46-export-csv-roast-log`
+
+The implementation stayed inside the E5-S7 boundary:
+
+- update snapshot `roast.csv` export to include all plan-required CSV columns
+- write retained telemetry samples and recorded session events in monotonic
+  order
+- infer phase, event flags, elapsed roast seconds, development percent,
+  60-second temperature deltas, RoR metrics, and first-crack model metadata for
+  CSV rows
+- preserve append-only runtime `roast.jsonl` writes from `RoastSessionStore`
+- preserve existing `summary.json`, metric helper, session lifecycle, MCP, and
+  configured-driver behavior
+
+No final `summary.json` schema work, model training, ONNX export, Hugging Face
+sync, real microphone validation, live Hottop validation, end-to-end agent roast
+validation, or broad release validation was added.
+
+## Implementation Summary
+
+`export_roast_snapshot(...)` still writes `roast.csv` as a snapshot export, but
+the CSV schema now matches the required columns in the v0.1 plan:
+
+- timestamp, elapsed seconds, inferred phase, temperatures, heat/fan controls,
+  cooling state, event marker, and event flags
+- development percent, bean/environment RoR, and bean/environment 60-second
+  deltas computed from the retained telemetry available at each row
+- first-crack model repository, revision, and precision from the authoritative
+  first-crack event payload once first crack has been recorded
+
+The exporter builds rows from the existing in-memory session snapshot. It does
+not change the append-only JSONL runtime writer, the one-session
+`RoastSessionStore` mutation boundary, or the configured MCP control/runtime
+behavior.
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E5-S7` complete and sets
+  the active story to `E5-S8`.
+- `docs/state/registry.md` says the next story is `E5-S8: export summary.json`.
+- `README.md` describes the current JSONL/CSV/summary export behavior.
+
+## Validation
+
+Focused validation:
+
+- `./.venv/bin/python -m pytest tests/test_exports.py`: 4 passed
+
+Full validation:
+
+- `./.venv/bin/python -m pytest`: 328 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+## Restart Prompt
+
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E5-S7 should
+be checked first. If it has merged, verify issue #46 is closed, check out
+`main`, run `git pull --ff-only origin main`, then begin E5-S8 from updated main
+on the appropriate `feature/47-...` branch after reading the registry, active
+epic, this summary, and the GitHub issue for E5-S8. Keep E5-S8 scoped to
+`summary.json` export unless its issue explicitly requires more, and preserve
+the append-only JSONL runtime writer, CSV schema, and existing
+metrics/session/runtime boundaries.

--- a/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
+++ b/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
@@ -74,6 +74,34 @@ Operator-provided context snapshot after PR #124 creation:
 - GPT-5.3-Codex-Spark 5h limit: `100% left`, resets `05:16`
 - GPT-5.3-Codex-Spark weekly limit: `100% left`, resets `00:16 on 31 May`
 
+## Review Fixes
+
+PR #124 review feedback from CodeRabbit and Codex was checked with
+thread-aware GitHub review state. The actionable comments were addressed in the
+CSV exporter:
+
+- same-timestamp rows now emit event rows before telemetry rows so telemetry
+  does not show post-event state before the event row
+- CSV per-row metric calculations now use the same configured RoR window and
+  minimum sample span as `summary.json`
+- event rows now derive state only through the current event, preventing later
+  same-time events from leaking into earlier event rows
+- event transition rows now prefer authoritative post-event control/cooling
+  state where applicable, including `beans_dropped` heat off and cooling
+  transition states
+- private CSV helper docstrings were added for the CodeRabbit docstring
+  coverage warning
+
+Validation after review fixes:
+
+- `./.venv/bin/python -m pytest tests/test_exports.py`: 7 passed
+- `./.venv/bin/python -m pytest`: 331 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E5-S7 should

--- a/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
+++ b/docs/session-summaries/2026-05-24-e5-s7-csv-roast-log-export.md
@@ -102,6 +102,26 @@ Validation after review fixes:
 - `./.venv/bin/coffee-roaster-mcp --help`: passed
 - `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
 
+Second review-fix round:
+
+- event rows now exclude same-timestamp telemetry from direct sample lookup and
+  per-row metric snapshots, so event rows do not include values from later CSV
+  telemetry rows
+- cooling transition tests now cover `cooling_stopped` against stale prior
+  `cooling_on=True` telemetry
+- touched export tests now include docstrings for the CodeRabbit docstring
+  coverage warning
+
+Validation after second review fixes:
+
+- `./.venv/bin/python -m pytest tests/test_exports.py`: 7 passed
+- `./.venv/bin/python -m pytest`: 331 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E5-S7 should

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E5-S7`
-- Current target: Export CSV roast log
+- Active story: `E5-S8`
+- Current target: Export `summary.json`
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -251,6 +251,14 @@ The first implementation milestone is a mock vertical slice that requires no roa
   writing CSV and `summary.json` from the current session but no longer
   overwrites an existing append-only JSONL log. Final CSV and summary schemas
   remain later Epic 5 work.
+- `E5-S7` adds the planned CSV roast log export schema to snapshot
+  `export_roast_log` output. `roast.csv` now includes telemetry and event rows
+  with the required plan columns for timestamps, elapsed seconds, inferred
+  phase, temperatures, controls, cooling state, event markers, event flags,
+  development percent, RoR/delta metrics, and first-crack model metadata.
+  Append-only JSONL runtime logging, existing metric helpers, the one-session
+  store boundary, mock-safe MCP behavior, and `summary.json` behavior remain
+  unchanged. Final `summary.json` schema work remains later Epic 5 work.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -546,7 +554,7 @@ Goal: compute roast metrics from one session clock and export durable logs.
 - [x] `E5-S6` Write append-only JSONL roast log.
   - Done when telemetry rows are written at 1 Hz and event rows are written immediately.
 
-- [ ] `E5-S7` Export CSV roast log.
+- [x] `E5-S7` Export CSV roast log.
   - Done when CSV includes all required columns from the plan.
 
 - [ ] `E5-S8` Export `summary.json`.
@@ -1439,6 +1447,27 @@ After completing a story:
     end-to-end agent roast validation, and broad release validation out of
     scope.
   - Ran `./.venv/bin/python -m pytest`: 325 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E5-S7:
+  - Added the plan-required CSV roast log columns to snapshot `roast.csv`
+    export: timestamp, elapsed seconds, phase, temperatures, controls, cooling
+    state, event marker, event flags, development percent, RoR/delta metrics,
+    and first-crack model metadata.
+  - CSV export now writes both retained telemetry samples and session timeline
+    events in monotonic order, inferring phase and event flags at each row while
+    preserving the existing append-only JSONL runtime writer and `summary.json`
+    behavior.
+  - Added CSV schema tests for telemetry and event rows plus first-crack model
+    metadata fields.
+  - Kept final `summary.json` schema work, model training/export/sync, real
+    microphone validation, live Hottop validation, end-to-end agent roast
+    validation, and broad release validation out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_exports.py`: 4 passed.
+  - Ran `./.venv/bin/python -m pytest`: 328 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -216,9 +216,17 @@ authoritative timeline events are recorded, and writes telemetry rows from the
 existing E5-S1 driver polling path no more often than
 `logging.sample_interval_seconds`, defaulting to 1 Hz. The existing rolling
 telemetry buffer, metric helpers, one-session store boundary, mock-safe MCP
-flow, and final CSV/summary schema boundaries remain unchanged. Snapshot export
+flow, and final CSV/summary schema boundaries remained unchanged. Snapshot export
 continues to write CSV and `summary.json`, but no longer overwrites an existing
 append-only `roast.jsonl` file.
+
+E5-S7 added the planned CSV roast log export schema to snapshot
+`export_roast_log` output. `roast.csv` now includes telemetry and event rows
+using the plan-required columns for timestamps, elapsed seconds, inferred phase,
+temperatures, controls, cooling state, event markers, event flags, development
+percent, RoR/delta metrics, and first-crack model metadata. Append-only JSONL
+runtime logging, the one-session `RoastSessionStore` mutation boundary, existing
+metric helpers, and `summary.json` behavior remain unchanged.
 
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
@@ -226,7 +234,7 @@ first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E5-S7: export CSV roast log.
+The next story is E5-S8: export `summary.json`.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/exports.py
+++ b/src/coffee_roaster_mcp/exports.py
@@ -103,7 +103,12 @@ def export_roast_snapshot(
         raise ValueError(f"JSONL export path exists but is not a file: {jsonl_path}")
     if not jsonl_path.exists():
         _write_event_jsonl(jsonl_path, session=session)
-    _write_event_csv(csv_path, session=session)
+    _write_event_csv(
+        csv_path,
+        session=session,
+        ror_window_seconds=ror_window_seconds,
+        ror_min_sample_seconds=ror_min_sample_seconds,
+    )
     _write_summary_json(
         summary_path,
         session=session,
@@ -133,12 +138,22 @@ def _write_event_jsonl(path: Path, *, session: RoastSession) -> None:
             output.write("\n")
 
 
-def _write_event_csv(path: Path, *, session: RoastSession) -> None:
+def _write_event_csv(
+    path: Path,
+    *,
+    session: RoastSession,
+    ror_window_seconds: float,
+    ror_min_sample_seconds: float,
+) -> None:
     """Write CSV rows with the planned roast log schema."""
     with path.open("w", encoding="utf-8", newline="") as output:
         writer = csv.DictWriter(output, fieldnames=_CSV_FIELDNAMES)
         writer.writeheader()
-        for row in _csv_rows(session):
+        for row in _csv_rows(
+            session,
+            ror_window_seconds=ror_window_seconds,
+            ror_min_sample_seconds=ror_min_sample_seconds,
+        ):
             writer.writerow(row)
 
 
@@ -196,54 +211,82 @@ def _event_row(*, session: RoastSession, event: RoastEvent) -> dict[str, Any]:
     }
 
 
-def _csv_rows(session: RoastSession) -> list[dict[str, object]]:
+def _csv_rows(
+    session: RoastSession,
+    *,
+    ror_window_seconds: float,
+    ror_min_sample_seconds: float,
+) -> list[dict[str, object]]:
+    """Return chronologically ordered CSV rows for telemetry samples and events."""
     rows: list[dict[str, object]] = []
     sorted_events = sorted(session.event_timeline, key=_event_sort_key)
     telemetry_by_monotonic = list(session.telemetry_buffer)
     combined: list[tuple[float, int, RoastEvent | TelemetrySample]] = [
-        (sample.monotonic_seconds, 0, sample) for sample in telemetry_by_monotonic
+        (event.monotonic_seconds, 0, event) for event in sorted_events
     ]
-    combined.extend((event.monotonic_seconds, 1, event) for event in sorted_events)
+    combined.extend((sample.monotonic_seconds, 1, sample) for sample in telemetry_by_monotonic)
     last_sample: TelemetrySample | None = None
     for _, _, item in sorted(combined, key=lambda row: (row[0], row[1])):
         if isinstance(item, TelemetrySample):
             last_sample = item
-            rows.append(_csv_telemetry_row(session, item))
+            rows.append(
+                _csv_telemetry_row(
+                    session,
+                    item,
+                    ror_window_seconds=ror_window_seconds,
+                    ror_min_sample_seconds=ror_min_sample_seconds,
+                )
+            )
             continue
         event_sample = _latest_sample_at_or_before(
             session.telemetry_buffer,
             monotonic_seconds=item.monotonic_seconds,
         )
-        rows.append(_csv_event_row(session, item, telemetry=event_sample or last_sample))
+        rows.append(
+            _csv_event_row(
+                session,
+                item,
+                telemetry=event_sample or last_sample,
+                ror_window_seconds=ror_window_seconds,
+                ror_min_sample_seconds=ror_min_sample_seconds,
+            )
+        )
     return rows
 
 
-def _csv_telemetry_row(session: RoastSession, sample: TelemetrySample) -> dict[str, object]:
+def _csv_telemetry_row(
+    session: RoastSession,
+    sample: TelemetrySample,
+    *,
+    ror_window_seconds: float,
+    ror_min_sample_seconds: float,
+) -> dict[str, object]:
+    """Return one CSV row for a retained telemetry sample."""
+    scoped_events = _events_visible_at(session, monotonic_seconds=sample.monotonic_seconds)
     metrics = compute_roast_metrics(
-        _session_view_at(session, monotonic_seconds=sample.monotonic_seconds),
+        _session_view_at(
+            session,
+            monotonic_seconds=sample.monotonic_seconds,
+            visible_events=scoped_events,
+        ),
         monotonic_now=lambda: session.monotonic_start + sample.monotonic_seconds,
+        ror_window_seconds=ror_window_seconds,
+        ror_min_sample_seconds=ror_min_sample_seconds,
     )
-    fc_payload = _first_crack_payload_at(
-        session,
-        monotonic_seconds=sample.monotonic_seconds,
-    )
+    fc_payload = _first_crack_payload_from(scoped_events)
     return {
         "timestamp_utc": sample.recorded_at_utc.isoformat(),
-        "elapsed_seconds": _roast_elapsed_at(session, sample.monotonic_seconds),
-        "phase": _phase_at(session, sample.monotonic_seconds),
+        "elapsed_seconds": _roast_elapsed_at(scoped_events, sample.monotonic_seconds),
+        "phase": _phase_from(scoped_events),
         "bean_temp_c": sample.bean_temp_c,
         "env_temp_c": sample.env_temp_c,
         "heat_level_percent": sample.heat_level_percent,
         "fan_level_percent": sample.fan_level_percent,
         "cooling_on": sample.cooling_on,
         "event": None,
-        "beans_added": _event_seen_at(session, "beans_added", sample.monotonic_seconds),
-        "first_crack_detected": _event_seen_at(
-            session,
-            "first_crack_detected",
-            sample.monotonic_seconds,
-        ),
-        "beans_dropped": _event_seen_at(session, "beans_dropped", sample.monotonic_seconds),
+        "beans_added": _event_seen_in(scoped_events, "beans_added"),
+        "first_crack_detected": _event_seen_in(scoped_events, "first_crack_detected"),
+        "beans_dropped": _event_seen_in(scoped_events, "beans_dropped"),
         "development_time_percent": metrics.development_percent,
         "bean_ror_c_per_min": metrics.bean_ror_c_per_min,
         "env_ror_c_per_min": metrics.env_ror_c_per_min,
@@ -260,19 +303,30 @@ def _csv_event_row(
     event: RoastEvent,
     *,
     telemetry: TelemetrySample | None,
+    ror_window_seconds: float,
+    ror_min_sample_seconds: float,
 ) -> dict[str, object]:
-    metrics = compute_roast_metrics(
-        _session_view_at(session, monotonic_seconds=event.monotonic_seconds),
-        monotonic_now=lambda: session.monotonic_start + event.monotonic_seconds,
-    )
-    fc_payload = _first_crack_payload_at(
+    """Return one CSV row for a recorded session event."""
+    scoped_events = _events_visible_at(
         session,
         monotonic_seconds=event.monotonic_seconds,
+        current_event=event,
     )
+    metrics = compute_roast_metrics(
+        _session_view_at(
+            session,
+            monotonic_seconds=event.monotonic_seconds,
+            visible_events=scoped_events,
+        ),
+        monotonic_now=lambda: session.monotonic_start + event.monotonic_seconds,
+        ror_window_seconds=ror_window_seconds,
+        ror_min_sample_seconds=ror_min_sample_seconds,
+    )
+    fc_payload = _first_crack_payload_from(scoped_events)
     return {
         "timestamp_utc": event.recorded_at_utc.isoformat(),
-        "elapsed_seconds": _roast_elapsed_at(session, event.monotonic_seconds),
-        "phase": _phase_at(session, event.monotonic_seconds),
+        "elapsed_seconds": _roast_elapsed_at(scoped_events, event.monotonic_seconds),
+        "phase": _phase_from(scoped_events),
         "bean_temp_c": None if telemetry is None else telemetry.bean_temp_c,
         "env_temp_c": None if telemetry is None else telemetry.env_temp_c,
         "heat_level_percent": _event_control_value(
@@ -287,13 +341,9 @@ def _csv_event_row(
         ),
         "cooling_on": _event_cooling_value(event, telemetry=telemetry),
         "event": event.kind,
-        "beans_added": _event_seen_at(session, "beans_added", event.monotonic_seconds),
-        "first_crack_detected": _event_seen_at(
-            session,
-            "first_crack_detected",
-            event.monotonic_seconds,
-        ),
-        "beans_dropped": _event_seen_at(session, "beans_dropped", event.monotonic_seconds),
+        "beans_added": _event_seen_in(scoped_events, "beans_added"),
+        "first_crack_detected": _event_seen_in(scoped_events, "first_crack_detected"),
+        "beans_dropped": _event_seen_in(scoped_events, "beans_dropped"),
         "development_time_percent": metrics.development_percent,
         "bean_ror_c_per_min": metrics.bean_ror_c_per_min,
         "env_ror_c_per_min": metrics.env_ror_c_per_min,
@@ -305,17 +355,18 @@ def _csv_event_row(
     }
 
 
-def _session_view_at(session: RoastSession, *, monotonic_seconds: float) -> RoastSession:
-    events = [
-        event
-        for event in sorted(session.event_timeline, key=_event_sort_key)
-        if event.monotonic_seconds <= monotonic_seconds
-    ]
+def _session_view_at(
+    session: RoastSession,
+    *,
+    monotonic_seconds: float,
+    visible_events: list[RoastEvent],
+) -> RoastSession:
+    """Return a point-in-time session view for metric computation."""
     view = RoastSession(
         id=session.id,
         created_at_utc=session.created_at_utc,
         monotonic_start=session.monotonic_start,
-        event_timeline=list(events),
+        event_timeline=list(visible_events),
         telemetry_buffer=deque(
             sample
             for sample in session.telemetry_buffer
@@ -325,13 +376,14 @@ def _session_view_at(session: RoastSession, *, monotonic_seconds: float) -> Roas
         stopped_at_utc=session.created_at_utc,
         monotonic_stop=session.monotonic_start + monotonic_seconds,
     )
-    for event in events:
+    for event in visible_events:
         _apply_view_event(view, event)
-    view.phase = _phase_at(session, monotonic_seconds)
+    view.phase = _phase_from(visible_events)
     return view
 
 
 def _apply_view_event(session: RoastSession, event: RoastEvent) -> None:
+    """Apply one visible event's timestamp fields to a point-in-time view."""
     if event.kind == "beans_added":
         session.beans_added_at_utc = event.recorded_at_utc
         session.beans_added_monotonic_seconds = event.monotonic_seconds
@@ -352,11 +404,10 @@ def _apply_view_event(session: RoastSession, event: RoastEvent) -> None:
         session.faulted_monotonic_seconds = event.monotonic_seconds
 
 
-def _phase_at(session: RoastSession, monotonic_seconds: float) -> RoastPhase:
+def _phase_from(events: list[RoastEvent]) -> RoastPhase:
+    """Return the lifecycle phase implied by visible events."""
     phase: RoastPhase = "pre_roast"
-    for event in sorted(session.event_timeline, key=_event_sort_key):
-        if event.monotonic_seconds > monotonic_seconds:
-            break
+    for event in events:
         if event.kind == "beans_added":
             phase = "roasting"
         elif event.kind == "first_crack_detected":
@@ -372,38 +423,59 @@ def _phase_at(session: RoastSession, monotonic_seconds: float) -> RoastPhase:
     return phase
 
 
-def _roast_elapsed_at(session: RoastSession, monotonic_seconds: float) -> float | None:
-    if session.beans_added_monotonic_seconds is None:
+def _roast_elapsed_at(events: list[RoastEvent], monotonic_seconds: float) -> float | None:
+    """Return roast elapsed seconds at one row timestamp."""
+    beans_added_seconds = _event_monotonic_seconds(events, "beans_added")
+    if beans_added_seconds is None:
         return None
-    if monotonic_seconds < session.beans_added_monotonic_seconds:
+    if monotonic_seconds < beans_added_seconds:
         return None
     end_seconds = monotonic_seconds
-    if (
-        session.beans_dropped_monotonic_seconds is not None
-        and monotonic_seconds >= session.beans_dropped_monotonic_seconds
-    ):
-        end_seconds = session.beans_dropped_monotonic_seconds
-    return round(max(0.0, end_seconds - session.beans_added_monotonic_seconds), 3)
+    beans_dropped_seconds = _event_monotonic_seconds(events, "beans_dropped")
+    if beans_dropped_seconds is not None and monotonic_seconds >= beans_dropped_seconds:
+        end_seconds = beans_dropped_seconds
+    return round(max(0.0, end_seconds - beans_added_seconds), 3)
 
 
-def _event_seen_at(session: RoastSession, kind: str, monotonic_seconds: float) -> bool:
-    return any(
-        event.kind == kind and event.monotonic_seconds <= monotonic_seconds
-        for event in session.event_timeline
-    )
+def _event_seen_in(events: list[RoastEvent], kind: str) -> bool:
+    """Return whether one event kind is visible for the current row."""
+    return any(event.kind == kind for event in events)
 
 
-def _first_crack_payload_at(
-    session: RoastSession,
-    *,
-    monotonic_seconds: float,
-) -> dict[str, EventPayloadValue]:
-    for event in sorted(session.event_timeline, key=_event_sort_key):
-        if event.monotonic_seconds > monotonic_seconds:
-            break
+def _first_crack_payload_from(events: list[RoastEvent]) -> dict[str, EventPayloadValue]:
+    """Return first-crack metadata visible for the current row."""
+    for event in events:
         if event.kind == "first_crack_detected":
             return dict(event.payload)
     return {}
+
+
+def _events_visible_at(
+    session: RoastSession,
+    *,
+    monotonic_seconds: float,
+    current_event: RoastEvent | None = None,
+) -> list[RoastEvent]:
+    """Return events visible at one row without leaking later same-time events."""
+    visible_events: list[RoastEvent] = []
+    for event in sorted(session.event_timeline, key=_event_sort_key):
+        if event.monotonic_seconds > monotonic_seconds:
+            break
+        if event.monotonic_seconds == monotonic_seconds and current_event is not None:
+            visible_events.append(event)
+            if event is current_event:
+                break
+            continue
+        visible_events.append(event)
+    return visible_events
+
+
+def _event_monotonic_seconds(events: list[RoastEvent], kind: str) -> float | None:
+    """Return the first visible monotonic timestamp for an event kind."""
+    for event in events:
+        if event.kind == kind:
+            return event.monotonic_seconds
+    return None
 
 
 def _latest_sample_at_or_before(
@@ -411,6 +483,7 @@ def _latest_sample_at_or_before(
     *,
     monotonic_seconds: float,
 ) -> TelemetrySample | None:
+    """Return the latest telemetry sample at or before one timestamp."""
     latest: TelemetrySample | None = None
     for sample in samples:
         if sample.monotonic_seconds > monotonic_seconds:
@@ -425,11 +498,14 @@ def _event_control_value(
     telemetry: TelemetrySample | None,
     key: str,
 ) -> int | None:
+    """Return an event row control value with transition-aware overrides."""
     value = event.payload.get(key)
     if isinstance(value, bool):
         return None
     if isinstance(value, int):
         return value
+    if event.kind == "beans_dropped" and key == "heat_level_percent":
+        return 0
     if telemetry is None:
         return None
     if key == "heat_level_percent":
@@ -438,17 +514,24 @@ def _event_control_value(
 
 
 def _event_cooling_value(event: RoastEvent, *, telemetry: TelemetrySample | None) -> bool | None:
+    """Return an event row cooling state with transition-aware overrides."""
     value = event.payload.get("cooling_on")
     if isinstance(value, bool):
         return value
+    if event.kind == "cooling_started":
+        return True
+    if event.kind == "cooling_stopped":
+        return False
     return None if telemetry is None else telemetry.cooling_on
 
 
 def _event_sort_key(event: RoastEvent) -> tuple[float, int]:
+    """Return deterministic event ordering key for CSV export."""
     return (event.monotonic_seconds, _event_order(event.kind))
 
 
 def _event_order(kind: str) -> int:
+    """Return lifecycle ordering for same-timestamp event rows."""
     order_by_kind = {
         "beans_added": 0,
         "first_crack_detected": 1,

--- a/src/coffee_roaster_mcp/exports.py
+++ b/src/coffee_roaster_mcp/exports.py
@@ -4,12 +4,43 @@ from __future__ import annotations
 
 import csv
 import json
+from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from coffee_roaster_mcp.session import RoastEvent, RoastSession, compute_roast_metrics
+from coffee_roaster_mcp.session import (
+    EventPayloadValue,
+    RoastEvent,
+    RoastPhase,
+    RoastSession,
+    TelemetrySample,
+    compute_roast_metrics,
+)
+
+_CSV_FIELDNAMES: tuple[str, ...] = (
+    "timestamp_utc",
+    "elapsed_seconds",
+    "phase",
+    "bean_temp_c",
+    "env_temp_c",
+    "heat_level_percent",
+    "fan_level_percent",
+    "cooling_on",
+    "event",
+    "beans_added",
+    "first_crack_detected",
+    "beans_dropped",
+    "development_time_percent",
+    "bean_ror_c_per_min",
+    "env_ror_c_per_min",
+    "bean_delta_60s_c",
+    "env_delta_60s_c",
+    "fc_model_repo",
+    "fc_model_revision",
+    "fc_model_precision",
+)
 
 
 @dataclass(frozen=True)
@@ -103,29 +134,12 @@ def _write_event_jsonl(path: Path, *, session: RoastSession) -> None:
 
 
 def _write_event_csv(path: Path, *, session: RoastSession) -> None:
-    """Write one CSV row per recorded event."""
+    """Write CSV rows with the planned roast log schema."""
     with path.open("w", encoding="utf-8", newline="") as output:
-        writer = csv.DictWriter(
-            output,
-            fieldnames=[
-                "session_id",
-                "kind",
-                "recorded_at_utc",
-                "monotonic_seconds",
-                "payload_json",
-            ],
-        )
+        writer = csv.DictWriter(output, fieldnames=_CSV_FIELDNAMES)
         writer.writeheader()
-        for event in session.event_timeline:
-            writer.writerow(
-                {
-                    "session_id": session.id,
-                    "kind": event.kind,
-                    "recorded_at_utc": event.recorded_at_utc.isoformat(),
-                    "monotonic_seconds": event.monotonic_seconds,
-                    "payload_json": json.dumps(event.payload, sort_keys=True),
-                }
-            )
+        for row in _csv_rows(session):
+            writer.writerow(row)
 
 
 def _write_summary_json(
@@ -180,6 +194,270 @@ def _event_row(*, session: RoastSession, event: RoastEvent) -> dict[str, Any]:
         "monotonic_seconds": event.monotonic_seconds,
         "payload": dict(event.payload),
     }
+
+
+def _csv_rows(session: RoastSession) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    sorted_events = sorted(session.event_timeline, key=_event_sort_key)
+    telemetry_by_monotonic = list(session.telemetry_buffer)
+    combined: list[tuple[float, int, RoastEvent | TelemetrySample]] = [
+        (sample.monotonic_seconds, 0, sample) for sample in telemetry_by_monotonic
+    ]
+    combined.extend((event.monotonic_seconds, 1, event) for event in sorted_events)
+    last_sample: TelemetrySample | None = None
+    for _, _, item in sorted(combined, key=lambda row: (row[0], row[1])):
+        if isinstance(item, TelemetrySample):
+            last_sample = item
+            rows.append(_csv_telemetry_row(session, item))
+            continue
+        event_sample = _latest_sample_at_or_before(
+            session.telemetry_buffer,
+            monotonic_seconds=item.monotonic_seconds,
+        )
+        rows.append(_csv_event_row(session, item, telemetry=event_sample or last_sample))
+    return rows
+
+
+def _csv_telemetry_row(session: RoastSession, sample: TelemetrySample) -> dict[str, object]:
+    metrics = compute_roast_metrics(
+        _session_view_at(session, monotonic_seconds=sample.monotonic_seconds),
+        monotonic_now=lambda: session.monotonic_start + sample.monotonic_seconds,
+    )
+    fc_payload = _first_crack_payload_at(
+        session,
+        monotonic_seconds=sample.monotonic_seconds,
+    )
+    return {
+        "timestamp_utc": sample.recorded_at_utc.isoformat(),
+        "elapsed_seconds": _roast_elapsed_at(session, sample.monotonic_seconds),
+        "phase": _phase_at(session, sample.monotonic_seconds),
+        "bean_temp_c": sample.bean_temp_c,
+        "env_temp_c": sample.env_temp_c,
+        "heat_level_percent": sample.heat_level_percent,
+        "fan_level_percent": sample.fan_level_percent,
+        "cooling_on": sample.cooling_on,
+        "event": None,
+        "beans_added": _event_seen_at(session, "beans_added", sample.monotonic_seconds),
+        "first_crack_detected": _event_seen_at(
+            session,
+            "first_crack_detected",
+            sample.monotonic_seconds,
+        ),
+        "beans_dropped": _event_seen_at(session, "beans_dropped", sample.monotonic_seconds),
+        "development_time_percent": metrics.development_percent,
+        "bean_ror_c_per_min": metrics.bean_ror_c_per_min,
+        "env_ror_c_per_min": metrics.env_ror_c_per_min,
+        "bean_delta_60s_c": metrics.bean_temp_delta_60s_c,
+        "env_delta_60s_c": metrics.env_temp_delta_60s_c,
+        "fc_model_repo": fc_payload.get("repo_id"),
+        "fc_model_revision": fc_payload.get("revision"),
+        "fc_model_precision": fc_payload.get("precision"),
+    }
+
+
+def _csv_event_row(
+    session: RoastSession,
+    event: RoastEvent,
+    *,
+    telemetry: TelemetrySample | None,
+) -> dict[str, object]:
+    metrics = compute_roast_metrics(
+        _session_view_at(session, monotonic_seconds=event.monotonic_seconds),
+        monotonic_now=lambda: session.monotonic_start + event.monotonic_seconds,
+    )
+    fc_payload = _first_crack_payload_at(
+        session,
+        monotonic_seconds=event.monotonic_seconds,
+    )
+    return {
+        "timestamp_utc": event.recorded_at_utc.isoformat(),
+        "elapsed_seconds": _roast_elapsed_at(session, event.monotonic_seconds),
+        "phase": _phase_at(session, event.monotonic_seconds),
+        "bean_temp_c": None if telemetry is None else telemetry.bean_temp_c,
+        "env_temp_c": None if telemetry is None else telemetry.env_temp_c,
+        "heat_level_percent": _event_control_value(
+            event,
+            telemetry=telemetry,
+            key="heat_level_percent",
+        ),
+        "fan_level_percent": _event_control_value(
+            event,
+            telemetry=telemetry,
+            key="fan_level_percent",
+        ),
+        "cooling_on": _event_cooling_value(event, telemetry=telemetry),
+        "event": event.kind,
+        "beans_added": _event_seen_at(session, "beans_added", event.monotonic_seconds),
+        "first_crack_detected": _event_seen_at(
+            session,
+            "first_crack_detected",
+            event.monotonic_seconds,
+        ),
+        "beans_dropped": _event_seen_at(session, "beans_dropped", event.monotonic_seconds),
+        "development_time_percent": metrics.development_percent,
+        "bean_ror_c_per_min": metrics.bean_ror_c_per_min,
+        "env_ror_c_per_min": metrics.env_ror_c_per_min,
+        "bean_delta_60s_c": metrics.bean_temp_delta_60s_c,
+        "env_delta_60s_c": metrics.env_temp_delta_60s_c,
+        "fc_model_repo": fc_payload.get("repo_id"),
+        "fc_model_revision": fc_payload.get("revision"),
+        "fc_model_precision": fc_payload.get("precision"),
+    }
+
+
+def _session_view_at(session: RoastSession, *, monotonic_seconds: float) -> RoastSession:
+    events = [
+        event
+        for event in sorted(session.event_timeline, key=_event_sort_key)
+        if event.monotonic_seconds <= monotonic_seconds
+    ]
+    view = RoastSession(
+        id=session.id,
+        created_at_utc=session.created_at_utc,
+        monotonic_start=session.monotonic_start,
+        event_timeline=list(events),
+        telemetry_buffer=deque(
+            sample
+            for sample in session.telemetry_buffer
+            if sample.monotonic_seconds <= monotonic_seconds
+        ),
+        log_writer=session.log_writer,
+        stopped_at_utc=session.created_at_utc,
+        monotonic_stop=session.monotonic_start + monotonic_seconds,
+    )
+    for event in events:
+        _apply_view_event(view, event)
+    view.phase = _phase_at(session, monotonic_seconds)
+    return view
+
+
+def _apply_view_event(session: RoastSession, event: RoastEvent) -> None:
+    if event.kind == "beans_added":
+        session.beans_added_at_utc = event.recorded_at_utc
+        session.beans_added_monotonic_seconds = event.monotonic_seconds
+    elif event.kind == "first_crack_detected":
+        session.first_crack_at_utc = event.recorded_at_utc
+        session.first_crack_monotonic_seconds = event.monotonic_seconds
+    elif event.kind == "beans_dropped":
+        session.beans_dropped_at_utc = event.recorded_at_utc
+        session.beans_dropped_monotonic_seconds = event.monotonic_seconds
+    elif event.kind == "cooling_started":
+        session.cooling_started_at_utc = event.recorded_at_utc
+        session.cooling_started_monotonic_seconds = event.monotonic_seconds
+    elif event.kind == "cooling_stopped":
+        session.cooling_stopped_at_utc = event.recorded_at_utc
+        session.cooling_stopped_monotonic_seconds = event.monotonic_seconds
+    elif event.kind == "fault":
+        session.faulted_at_utc = event.recorded_at_utc
+        session.faulted_monotonic_seconds = event.monotonic_seconds
+
+
+def _phase_at(session: RoastSession, monotonic_seconds: float) -> RoastPhase:
+    phase: RoastPhase = "pre_roast"
+    for event in sorted(session.event_timeline, key=_event_sort_key):
+        if event.monotonic_seconds > monotonic_seconds:
+            break
+        if event.kind == "beans_added":
+            phase = "roasting"
+        elif event.kind == "first_crack_detected":
+            phase = "development"
+        elif event.kind == "beans_dropped":
+            phase = "dropped"
+        elif event.kind == "cooling_started":
+            phase = "cooling"
+        elif event.kind == "cooling_stopped":
+            phase = "complete"
+        elif event.kind == "fault":
+            phase = "fault"
+    return phase
+
+
+def _roast_elapsed_at(session: RoastSession, monotonic_seconds: float) -> float | None:
+    if session.beans_added_monotonic_seconds is None:
+        return None
+    if monotonic_seconds < session.beans_added_monotonic_seconds:
+        return None
+    end_seconds = monotonic_seconds
+    if (
+        session.beans_dropped_monotonic_seconds is not None
+        and monotonic_seconds >= session.beans_dropped_monotonic_seconds
+    ):
+        end_seconds = session.beans_dropped_monotonic_seconds
+    return round(max(0.0, end_seconds - session.beans_added_monotonic_seconds), 3)
+
+
+def _event_seen_at(session: RoastSession, kind: str, monotonic_seconds: float) -> bool:
+    return any(
+        event.kind == kind and event.monotonic_seconds <= monotonic_seconds
+        for event in session.event_timeline
+    )
+
+
+def _first_crack_payload_at(
+    session: RoastSession,
+    *,
+    monotonic_seconds: float,
+) -> dict[str, EventPayloadValue]:
+    for event in sorted(session.event_timeline, key=_event_sort_key):
+        if event.monotonic_seconds > monotonic_seconds:
+            break
+        if event.kind == "first_crack_detected":
+            return dict(event.payload)
+    return {}
+
+
+def _latest_sample_at_or_before(
+    samples: deque[TelemetrySample],
+    *,
+    monotonic_seconds: float,
+) -> TelemetrySample | None:
+    latest: TelemetrySample | None = None
+    for sample in samples:
+        if sample.monotonic_seconds > monotonic_seconds:
+            break
+        latest = sample
+    return latest
+
+
+def _event_control_value(
+    event: RoastEvent,
+    *,
+    telemetry: TelemetrySample | None,
+    key: str,
+) -> int | None:
+    value = event.payload.get(key)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if telemetry is None:
+        return None
+    if key == "heat_level_percent":
+        return telemetry.heat_level_percent
+    return telemetry.fan_level_percent
+
+
+def _event_cooling_value(event: RoastEvent, *, telemetry: TelemetrySample | None) -> bool | None:
+    value = event.payload.get("cooling_on")
+    if isinstance(value, bool):
+        return value
+    return None if telemetry is None else telemetry.cooling_on
+
+
+def _event_sort_key(event: RoastEvent) -> tuple[float, int]:
+    return (event.monotonic_seconds, _event_order(event.kind))
+
+
+def _event_order(kind: str) -> int:
+    order_by_kind = {
+        "beans_added": 0,
+        "first_crack_detected": 1,
+        "beans_dropped": 2,
+        "cooling_started": 3,
+        "cooling_stopped": 4,
+        "fault": 5,
+    }
+    return order_by_kind.get(kind, 99)
 
 
 def _iso_or_none(value: datetime | None) -> str | None:

--- a/src/coffee_roaster_mcp/exports.py
+++ b/src/coffee_roaster_mcp/exports.py
@@ -268,6 +268,7 @@ def _csv_telemetry_row(
             session,
             monotonic_seconds=sample.monotonic_seconds,
             visible_events=scoped_events,
+            current_sample=sample,
         ),
         monotonic_now=lambda: session.monotonic_start + sample.monotonic_seconds,
         ror_window_seconds=ror_window_seconds,
@@ -362,6 +363,7 @@ def _session_view_at(
     monotonic_seconds: float,
     visible_events: list[RoastEvent],
     include_same_time_telemetry: bool = True,
+    current_sample: TelemetrySample | None = None,
 ) -> RoastSession:
     """Return a point-in-time session view for metric computation."""
     view = RoastSession(
@@ -369,11 +371,11 @@ def _session_view_at(
         created_at_utc=session.created_at_utc,
         monotonic_start=session.monotonic_start,
         event_timeline=list(visible_events),
-        telemetry_buffer=deque(
-            sample
-            for sample in session.telemetry_buffer
-            if sample.monotonic_seconds < monotonic_seconds
-            or (include_same_time_telemetry and sample.monotonic_seconds == monotonic_seconds)
+        telemetry_buffer=_telemetry_visible_at(
+            session.telemetry_buffer,
+            monotonic_seconds=monotonic_seconds,
+            include_same_time=include_same_time_telemetry,
+            current_sample=current_sample,
         ),
         log_writer=session.log_writer,
         stopped_at_utc=session.created_at_utc,
@@ -383,6 +385,27 @@ def _session_view_at(
         _apply_view_event(view, event)
     view.phase = _phase_from(visible_events)
     return view
+
+
+def _telemetry_visible_at(
+    samples: deque[TelemetrySample],
+    *,
+    monotonic_seconds: float,
+    include_same_time: bool,
+    current_sample: TelemetrySample | None,
+) -> deque[TelemetrySample]:
+    """Return telemetry samples visible to one point-in-time row."""
+    visible: deque[TelemetrySample] = deque()
+    for sample in samples:
+        if sample.monotonic_seconds < monotonic_seconds:
+            visible.append(sample)
+            continue
+        if sample.monotonic_seconds > monotonic_seconds or not include_same_time:
+            break
+        visible.append(sample)
+        if current_sample is not None and sample is current_sample:
+            break
+    return visible
 
 
 def _apply_view_event(session: RoastSession, event: RoastEvent) -> None:

--- a/src/coffee_roaster_mcp/exports.py
+++ b/src/coffee_roaster_mcp/exports.py
@@ -238,7 +238,7 @@ def _csv_rows(
                 )
             )
             continue
-        event_sample = _latest_sample_at_or_before(
+        event_sample = _latest_sample_before(
             session.telemetry_buffer,
             monotonic_seconds=item.monotonic_seconds,
         )
@@ -317,6 +317,7 @@ def _csv_event_row(
             session,
             monotonic_seconds=event.monotonic_seconds,
             visible_events=scoped_events,
+            include_same_time_telemetry=False,
         ),
         monotonic_now=lambda: session.monotonic_start + event.monotonic_seconds,
         ror_window_seconds=ror_window_seconds,
@@ -360,6 +361,7 @@ def _session_view_at(
     *,
     monotonic_seconds: float,
     visible_events: list[RoastEvent],
+    include_same_time_telemetry: bool = True,
 ) -> RoastSession:
     """Return a point-in-time session view for metric computation."""
     view = RoastSession(
@@ -370,7 +372,8 @@ def _session_view_at(
         telemetry_buffer=deque(
             sample
             for sample in session.telemetry_buffer
-            if sample.monotonic_seconds <= monotonic_seconds
+            if sample.monotonic_seconds < monotonic_seconds
+            or (include_same_time_telemetry and sample.monotonic_seconds == monotonic_seconds)
         ),
         log_writer=session.log_writer,
         stopped_at_utc=session.created_at_utc,
@@ -478,15 +481,15 @@ def _event_monotonic_seconds(events: list[RoastEvent], kind: str) -> float | Non
     return None
 
 
-def _latest_sample_at_or_before(
+def _latest_sample_before(
     samples: deque[TelemetrySample],
     *,
     monotonic_seconds: float,
 ) -> TelemetrySample | None:
-    """Return the latest telemetry sample at or before one timestamp."""
+    """Return the latest telemetry sample strictly before one timestamp."""
     latest: TelemetrySample | None = None
     for sample in samples:
-        if sample.monotonic_seconds > monotonic_seconds:
+        if sample.monotonic_seconds >= monotonic_seconds:
             break
         latest = sample
     return latest

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -1199,6 +1199,11 @@ class RoastSessionStore:
         """Complete a reserved cooling-start command and record the event."""
         with self._lock:
             self._assert_driver_command_reservation(session, reservation)
+            if not cooling_on:
+                self._clear_driver_command_reservation_locked(session, reservation)
+                raise SessionLifecycleError(
+                    "Driver still reports cooling inactive after start_cooling."
+                )
             previous_control_state = (
                 session.heat_level_percent,
                 session.fan_level_percent,

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -1167,10 +1167,15 @@ class RoastSessionStore:
                 fan_level_percent=fan_level_percent,
                 cooling_on=cooling_on,
             )
+            event_payload: dict[str, EventPayloadValue] = {
+                "heat_level_percent": heat_level_percent,
+                "fan_level_percent": fan_level_percent,
+                "cooling_on": cooling_on,
+            }
             try:
-                event = self.record_event(session, "beans_dropped")
+                event = self.record_event(session, "beans_dropped", payload=event_payload)
                 if cooling_on:
-                    self.record_event(session, "cooling_started")
+                    self.record_event(session, "cooling_started", payload=event_payload)
             except Exception:
                 (
                     session.heat_level_percent,
@@ -1206,7 +1211,15 @@ class RoastSessionStore:
                 cooling_on=cooling_on,
             )
             try:
-                event = self.record_event(session, "cooling_started")
+                event = self.record_event(
+                    session,
+                    "cooling_started",
+                    payload={
+                        "heat_level_percent": heat_level_percent,
+                        "fan_level_percent": fan_level_percent,
+                        "cooling_on": cooling_on,
+                    },
+                )
             except Exception:
                 (
                     session.heat_level_percent,
@@ -1243,7 +1256,15 @@ class RoastSessionStore:
                 label="fan_level_percent",
             )
             try:
-                event = self.record_event(session, "cooling_stopped")
+                event = self.record_event(
+                    session,
+                    "cooling_stopped",
+                    payload={
+                        "heat_level_percent": validated_heat,
+                        "fan_level_percent": validated_fan,
+                        "cooling_on": False,
+                    },
+                )
                 session.heat_level_percent = validated_heat
                 session.fan_level_percent = validated_fan
                 session.cooling_on = False

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -385,6 +385,96 @@ def test_snapshot_export_csv_event_rows_use_transition_control_state(
     assert cooling_stopped_row["cooling_on"] == "False"
 
 
+def test_snapshot_export_csv_uses_driver_transition_payload_state(
+    tmp_path: Path,
+) -> None:
+    """Use driver-returned transition payload state for drop and cooling rows."""
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    store.append_telemetry(
+        session,
+        TelemetrySample(
+            recorded_at_utc=datetime(2026, 5, 17, 14, 1, 0, tzinfo=UTC),
+            monotonic_seconds=60.0,
+            bean_temp_c=170.0,
+            env_temp_c=204.0,
+            heat_level_percent=45,
+            fan_level_percent=40,
+            cooling_on=False,
+        ),
+    )
+    clock.monotonic_value = 180.0
+    drop_reservation = store.reserve_driver_drop(session)
+    assert drop_reservation.reservation is not None
+    store.complete_reserved_driver_drop_snapshot(
+        session,
+        reservation=drop_reservation.reservation,
+        heat_level_percent=0,
+        fan_level_percent=100,
+        cooling_on=True,
+    )
+
+    export = export_roast_snapshot(session)
+
+    with export.csv_path.open(encoding="utf-8", newline="") as csv_file:
+        rows = list(csv.DictReader(csv_file))
+    drop_row = next(row for row in rows if row["event"] == "beans_dropped")
+    cooling_row = next(row for row in rows if row["event"] == "cooling_started")
+    assert drop_row["heat_level_percent"] == "0"
+    assert drop_row["fan_level_percent"] == "100"
+    assert drop_row["cooling_on"] == "True"
+    assert cooling_row["heat_level_percent"] == "0"
+    assert cooling_row["fan_level_percent"] == "100"
+    assert cooling_row["cooling_on"] == "True"
+
+
+def test_snapshot_export_csv_telemetry_metrics_do_not_use_later_same_time_samples(
+    tmp_path: Path,
+) -> None:
+    """Compute telemetry row metrics only from samples visible up to that row."""
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    for bean_temp_c, env_temp_c, monotonic_seconds in (
+        (150.0, 180.0, 0.0),
+        (160.0, 192.0, 60.0),
+        (190.0, 228.0, 60.0),
+    ):
+        store.append_telemetry(
+            session,
+            TelemetrySample(
+                recorded_at_utc=datetime(2026, 5, 17, 14, 1, tzinfo=UTC),
+                monotonic_seconds=monotonic_seconds,
+                bean_temp_c=bean_temp_c,
+                env_temp_c=env_temp_c,
+            ),
+        )
+
+    export = export_roast_snapshot(session)
+
+    with export.csv_path.open(encoding="utf-8", newline="") as csv_file:
+        rows = list(csv.DictReader(csv_file))
+    first_same_time_row = rows[1]
+    second_same_time_row = rows[2]
+    assert first_same_time_row["bean_temp_c"] == "160.0"
+    assert first_same_time_row["bean_delta_60s_c"] == "10.0"
+    assert first_same_time_row["bean_ror_c_per_min"] == "10.0"
+    assert second_same_time_row["bean_temp_c"] == "190.0"
+    assert second_same_time_row["bean_delta_60s_c"] == "40.0"
+    assert second_same_time_row["bean_ror_c_per_min"] == "40.0"
+
+
 def test_snapshot_export_rejects_existing_jsonl_directory(tmp_path: Path) -> None:
     """Reject non-file JSONL export paths instead of reporting readiness."""
     clock = ClockHarness()

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -53,6 +53,7 @@ class ClockHarness:
 
 
 def test_snapshot_export_preserves_first_crack_detector_metadata(tmp_path: Path) -> None:
+    """Export first-crack detector metadata in JSONL, CSV, and summary files."""
     clock = ClockHarness()
     store = RoastSessionStore(
         utc_now=clock.utc_now,
@@ -114,6 +115,7 @@ def test_snapshot_export_preserves_first_crack_detector_metadata(tmp_path: Path)
 
 
 def test_snapshot_export_uses_configured_ror_parameters(tmp_path: Path) -> None:
+    """Apply configured RoR parameters consistently to summary and CSV rows."""
     clock = ClockHarness()
     store = RoastSessionStore(
         utc_now=clock.utc_now,
@@ -153,6 +155,7 @@ def test_snapshot_export_uses_configured_ror_parameters(tmp_path: Path) -> None:
 def test_snapshot_export_csv_includes_plan_columns_for_telemetry_and_events(
     tmp_path: Path,
 ) -> None:
+    """Export telemetry and event rows with the planned CSV schema."""
     clock = ClockHarness()
     store = RoastSessionStore(
         utc_now=clock.utc_now,
@@ -253,6 +256,7 @@ def test_snapshot_export_csv_includes_plan_columns_for_telemetry_and_events(
 def test_snapshot_export_csv_orders_same_time_events_before_telemetry(
     tmp_path: Path,
 ) -> None:
+    """Emit same-time event rows before telemetry without future sample data."""
     clock = ClockHarness()
     store = RoastSessionStore(
         utc_now=clock.utc_now,
@@ -281,12 +285,18 @@ def test_snapshot_export_csv_orders_same_time_events_before_telemetry(
         rows = list(csv.DictReader(csv_file))
     assert [row["event"] for row in rows] == ["beans_added", ""]
     assert rows[0]["phase"] == "roasting"
+    assert rows[0]["bean_temp_c"] == ""
+    assert rows[0]["heat_level_percent"] == ""
+    assert rows[0]["bean_delta_60s_c"] == ""
     assert rows[1]["phase"] == "roasting"
+    assert rows[1]["bean_temp_c"] == "150.0"
+    assert rows[1]["heat_level_percent"] == "50"
 
 
 def test_snapshot_export_csv_keeps_same_time_event_rows_chronological(
     tmp_path: Path,
 ) -> None:
+    """Keep same-time event rows scoped to their own lifecycle order."""
     clock = ClockHarness()
     store = RoastSessionStore(
         utc_now=clock.utc_now,
@@ -322,6 +332,7 @@ def test_snapshot_export_csv_keeps_same_time_event_rows_chronological(
 def test_snapshot_export_csv_event_rows_use_transition_control_state(
     tmp_path: Path,
 ) -> None:
+    """Use event transition state instead of stale telemetry on event rows."""
     clock = ClockHarness()
     store = RoastSessionStore(
         utc_now=clock.utc_now,
@@ -346,6 +357,20 @@ def test_snapshot_export_csv_event_rows_use_transition_control_state(
     clock.monotonic_value = 180.0
     store.record_event(session, "beans_dropped")
     store.record_event(session, "cooling_started")
+    store.append_telemetry(
+        session,
+        TelemetrySample(
+            recorded_at_utc=datetime(2026, 5, 17, 14, 1, 5, tzinfo=UTC),
+            monotonic_seconds=82.0,
+            bean_temp_c=168.0,
+            env_temp_c=200.0,
+            heat_level_percent=0,
+            fan_level_percent=40,
+            cooling_on=True,
+        ),
+    )
+    clock.monotonic_value = 185.0
+    store.record_event(session, "cooling_stopped")
 
     export = export_roast_snapshot(session)
 
@@ -353,12 +378,15 @@ def test_snapshot_export_csv_event_rows_use_transition_control_state(
         rows = list(csv.DictReader(csv_file))
     drop_row = next(row for row in rows if row["event"] == "beans_dropped")
     cooling_row = next(row for row in rows if row["event"] == "cooling_started")
+    cooling_stopped_row = next(row for row in rows if row["event"] == "cooling_stopped")
     assert drop_row["heat_level_percent"] == "0"
     assert drop_row["cooling_on"] == "False"
     assert cooling_row["cooling_on"] == "True"
+    assert cooling_stopped_row["cooling_on"] == "False"
 
 
 def test_snapshot_export_rejects_existing_jsonl_directory(tmp_path: Path) -> None:
+    """Reject non-file JSONL export paths instead of reporting readiness."""
     clock = ClockHarness()
     store = RoastSessionStore(
         utc_now=clock.utc_now,

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -12,6 +12,29 @@ import pytest
 from coffee_roaster_mcp.exports import export_roast_snapshot
 from coffee_roaster_mcp.session import EventPayloadValue, RoastSessionStore, TelemetrySample
 
+EXPECTED_CSV_FIELDNAMES = [
+    "timestamp_utc",
+    "elapsed_seconds",
+    "phase",
+    "bean_temp_c",
+    "env_temp_c",
+    "heat_level_percent",
+    "fan_level_percent",
+    "cooling_on",
+    "event",
+    "beans_added",
+    "first_crack_detected",
+    "beans_dropped",
+    "development_time_percent",
+    "bean_ror_c_per_min",
+    "env_ror_c_per_min",
+    "bean_delta_60s_c",
+    "env_delta_60s_c",
+    "fc_model_repo",
+    "fc_model_revision",
+    "fc_model_precision",
+]
+
 
 class ClockHarness:
     """Deterministic clock supplier for export tests."""
@@ -70,11 +93,17 @@ def test_snapshot_export_preserves_first_crack_detector_metadata(tmp_path: Path)
     assert first_crack_jsonl["payload"] == metadata
 
     with export.csv_path.open(encoding="utf-8", newline="") as csv_file:
-        csv_rows = list(csv.DictReader(csv_file))
-    first_crack_csv_payload = json.loads(csv_rows[1]["payload_json"])
-    assert csv_rows[1]["kind"] == "first_crack_detected"
-    assert float(csv_rows[1]["monotonic_seconds"]) == 37.25
-    assert first_crack_csv_payload == metadata
+        reader = csv.DictReader(csv_file)
+        csv_rows = list(reader)
+    assert reader.fieldnames == EXPECTED_CSV_FIELDNAMES
+    first_crack_csv_row = csv_rows[1]
+    assert first_crack_csv_row["event"] == "first_crack_detected"
+    assert first_crack_csv_row["elapsed_seconds"] == "32.25"
+    assert first_crack_csv_row["phase"] == "development"
+    assert first_crack_csv_row["first_crack_detected"] == "True"
+    assert first_crack_csv_row["fc_model_repo"] == "syamaner/coffee-first-crack-detection"
+    assert first_crack_csv_row["fc_model_revision"] == "v0.1.0"
+    assert first_crack_csv_row["fc_model_precision"] == "int8"
 
     summary = json.loads(export.summary_path.read_text(encoding="utf-8"))
     assert summary["first_crack_at_utc"] == "2026-05-17T14:00:37.250000+00:00"
@@ -115,6 +144,106 @@ def test_snapshot_export_uses_configured_ror_parameters(tmp_path: Path) -> None:
     summary = json.loads(export.summary_path.read_text(encoding="utf-8"))
     assert summary["metrics"]["bean_ror_c_per_min"] is None
     assert summary["metrics"]["env_ror_c_per_min"] is None
+
+
+def test_snapshot_export_csv_includes_plan_columns_for_telemetry_and_events(
+    tmp_path: Path,
+) -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+
+    store.append_telemetry(
+        session,
+        TelemetrySample(
+            recorded_at_utc=datetime(2026, 5, 17, 14, 0, 1, tzinfo=UTC),
+            monotonic_seconds=1.0,
+            bean_temp_c=150.0,
+            env_temp_c=180.0,
+            heat_level_percent=50,
+            fan_level_percent=20,
+            cooling_on=False,
+        ),
+    )
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    store.append_telemetry(
+        session,
+        TelemetrySample(
+            recorded_at_utc=datetime(2026, 5, 17, 14, 0, 15, tzinfo=UTC),
+            monotonic_seconds=15.0,
+            bean_temp_c=160.0,
+            env_temp_c=192.0,
+            heat_level_percent=60,
+            fan_level_percent=25,
+            cooling_on=False,
+        ),
+    )
+    metadata: dict[str, EventPayloadValue] = {
+        "repo_id": "syamaner/coffee-first-crack-detection",
+        "revision": "v0.1.0",
+        "precision": "int8",
+    }
+    clock.monotonic_value = 135.0
+    store.record_event(session, "first_crack_detected", payload=metadata)
+    store.append_telemetry(
+        session,
+        TelemetrySample(
+            recorded_at_utc=datetime(2026, 5, 17, 14, 1, 15, tzinfo=UTC),
+            monotonic_seconds=75.0,
+            bean_temp_c=170.0,
+            env_temp_c=204.0,
+            heat_level_percent=45,
+            fan_level_percent=40,
+            cooling_on=False,
+        ),
+    )
+    clock.monotonic_value = 180.0
+    store.record_event(session, "beans_dropped")
+
+    export = export_roast_snapshot(session)
+
+    with export.csv_path.open(encoding="utf-8", newline="") as csv_file:
+        reader = csv.DictReader(csv_file)
+        rows = list(reader)
+    assert reader.fieldnames == EXPECTED_CSV_FIELDNAMES
+    assert [row["event"] for row in rows] == [
+        "",
+        "beans_added",
+        "",
+        "first_crack_detected",
+        "",
+        "beans_dropped",
+    ]
+    first_telemetry = rows[0]
+    assert first_telemetry["phase"] == "pre_roast"
+    assert first_telemetry["elapsed_seconds"] == ""
+    assert first_telemetry["bean_temp_c"] == "150.0"
+    assert first_telemetry["event"] == ""
+
+    post_fc_telemetry = rows[4]
+    assert post_fc_telemetry["phase"] == "development"
+    assert post_fc_telemetry["elapsed_seconds"] == "70.0"
+    assert post_fc_telemetry["beans_added"] == "True"
+    assert post_fc_telemetry["first_crack_detected"] == "True"
+    assert post_fc_telemetry["beans_dropped"] == "False"
+    assert post_fc_telemetry["development_time_percent"] == "57.143"
+    assert post_fc_telemetry["bean_ror_c_per_min"] == "10.0"
+    assert post_fc_telemetry["env_ror_c_per_min"] == "12.0"
+    assert post_fc_telemetry["bean_delta_60s_c"] == "10.0"
+    assert post_fc_telemetry["env_delta_60s_c"] == "12.0"
+    assert post_fc_telemetry["fc_model_repo"] == "syamaner/coffee-first-crack-detection"
+    assert post_fc_telemetry["fc_model_revision"] == "v0.1.0"
+    assert post_fc_telemetry["fc_model_precision"] == "int8"
+
+    drop_event = rows[5]
+    assert drop_event["phase"] == "dropped"
+    assert drop_event["elapsed_seconds"] == "75.0"
+    assert drop_event["beans_dropped"] == "True"
 
 
 def test_snapshot_export_rejects_existing_jsonl_directory(tmp_path: Path) -> None:

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -144,6 +144,10 @@ def test_snapshot_export_uses_configured_ror_parameters(tmp_path: Path) -> None:
     summary = json.loads(export.summary_path.read_text(encoding="utf-8"))
     assert summary["metrics"]["bean_ror_c_per_min"] is None
     assert summary["metrics"]["env_ror_c_per_min"] is None
+    with export.csv_path.open(encoding="utf-8", newline="") as csv_file:
+        csv_rows = list(csv.DictReader(csv_file))
+    assert csv_rows[-1]["bean_ror_c_per_min"] == ""
+    assert csv_rows[-1]["env_ror_c_per_min"] == ""
 
 
 def test_snapshot_export_csv_includes_plan_columns_for_telemetry_and_events(
@@ -244,6 +248,114 @@ def test_snapshot_export_csv_includes_plan_columns_for_telemetry_and_events(
     assert drop_event["phase"] == "dropped"
     assert drop_event["elapsed_seconds"] == "75.0"
     assert drop_event["beans_dropped"] == "True"
+
+
+def test_snapshot_export_csv_orders_same_time_events_before_telemetry(
+    tmp_path: Path,
+) -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    store.append_telemetry(
+        session,
+        TelemetrySample(
+            recorded_at_utc=datetime(2026, 5, 17, 14, 0, 5, tzinfo=UTC),
+            monotonic_seconds=5.0,
+            bean_temp_c=150.0,
+            env_temp_c=180.0,
+            heat_level_percent=50,
+            fan_level_percent=20,
+            cooling_on=False,
+        ),
+    )
+
+    export = export_roast_snapshot(session)
+
+    with export.csv_path.open(encoding="utf-8", newline="") as csv_file:
+        rows = list(csv.DictReader(csv_file))
+    assert [row["event"] for row in rows] == ["beans_added", ""]
+    assert rows[0]["phase"] == "roasting"
+    assert rows[1]["phase"] == "roasting"
+
+
+def test_snapshot_export_csv_keeps_same_time_event_rows_chronological(
+    tmp_path: Path,
+) -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    store.record_event(
+        session,
+        "first_crack_detected",
+        payload={
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "revision": "v0.1.0",
+            "precision": "int8",
+        },
+    )
+
+    export = export_roast_snapshot(session)
+
+    with export.csv_path.open(encoding="utf-8", newline="") as csv_file:
+        rows = list(csv.DictReader(csv_file))
+    assert [row["event"] for row in rows] == ["beans_added", "first_crack_detected"]
+    assert rows[0]["phase"] == "roasting"
+    assert rows[0]["first_crack_detected"] == "False"
+    assert rows[0]["fc_model_repo"] == ""
+    assert rows[1]["phase"] == "development"
+    assert rows[1]["first_crack_detected"] == "True"
+    assert rows[1]["fc_model_repo"] == "syamaner/coffee-first-crack-detection"
+
+
+def test_snapshot_export_csv_event_rows_use_transition_control_state(
+    tmp_path: Path,
+) -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    store.append_telemetry(
+        session,
+        TelemetrySample(
+            recorded_at_utc=datetime(2026, 5, 17, 14, 1, 0, tzinfo=UTC),
+            monotonic_seconds=60.0,
+            bean_temp_c=170.0,
+            env_temp_c=204.0,
+            heat_level_percent=45,
+            fan_level_percent=40,
+            cooling_on=False,
+        ),
+    )
+    clock.monotonic_value = 180.0
+    store.record_event(session, "beans_dropped")
+    store.record_event(session, "cooling_started")
+
+    export = export_roast_snapshot(session)
+
+    with export.csv_path.open(encoding="utf-8", newline="") as csv_file:
+        rows = list(csv.DictReader(csv_file))
+    drop_row = next(row for row in rows if row["event"] == "beans_dropped")
+    cooling_row = next(row for row in rows if row["event"] == "cooling_started")
+    assert drop_row["heat_level_percent"] == "0"
+    assert drop_row["cooling_on"] == "False"
+    assert cooling_row["cooling_on"] == "True"
 
 
 def test_snapshot_export_rejects_existing_jsonl_directory(tmp_path: Path) -> None:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -343,7 +343,11 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
             "cooling_started",
             "cooling_stopped",
         ]
-        assert state_content["events"][2]["payload"] == {}
+        assert state_content["events"][2]["payload"] == {
+            "cooling_on": True,
+            "fan_level_percent": 100,
+            "heat_level_percent": 0,
+        }
 
         export_result = cast(
             Any,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -416,6 +416,43 @@ def test_reserved_driver_start_cooling_log_failure_rolls_back_controls(
     assert session.phase == "dropped"
 
 
+def test_reserved_driver_start_cooling_rejects_inactive_driver_result() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    store.record_event(session, "beans_dropped")
+    store.apply_driver_control_state(
+        session,
+        heat_level_percent=30,
+        fan_level_percent=40,
+        cooling_on=False,
+    )
+    cooling_reservation = store.reserve_driver_start_cooling(session)
+    assert cooling_reservation.reservation is not None
+
+    with pytest.raises(SessionLifecycleError, match="cooling inactive after start_cooling"):
+        store.complete_reserved_driver_start_cooling_snapshot(
+            session,
+            reservation=cooling_reservation.reservation,
+            heat_level_percent=0,
+            fan_level_percent=100,
+            cooling_on=False,
+        )
+
+    assert session.pending_driver_command_token is None
+    assert session.pending_driver_command_kind is None
+    assert session.heat_level_percent == 30
+    assert session.fan_level_percent == 40
+    assert session.cooling_on is False
+    assert session.cooling_started_at_utc is None
+    assert session.event_timeline[-1].kind == "beans_dropped"
+    assert session.phase == "dropped"
+
+
 def test_record_active_telemetry_sample_returns_none_when_session_is_stale() -> None:
     clock = ClockHarness()
     issued_ids = iter(["session-001", "session-002"])


### PR DESCRIPTION
## Summary
- Replace the snapshot `roast.csv` event-only output with the plan-required CSV roast log schema.
- Write retained telemetry samples and session events in monotonic order, with inferred phase, elapsed roast seconds, event flags, development percent, RoR/delta metrics, and first-crack model metadata.
- Update README and durable state/session docs for E5-S7 and the E5-S8 next-story pointer.

## Scope Notes
- Preserves append-only runtime `roast.jsonl` writes from `RoastSessionStore`.
- Preserves the one-session store boundary, mock-safe MCP behavior, existing metric helpers, configured-driver behavior, and current `summary.json` output.
- Does not add final `summary.json` schema work, model training/export/sync, real microphone validation, live Hottop validation, end-to-end agent roast validation, or broad release validation.

## Tests
- `./.venv/bin/python -m pytest tests/test_exports.py`
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`
- `./.venv/bin/coffee-roaster-mcp --help`
- `./.venv/bin/coffee-roaster-mcp --version`

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic CSV roast export emitting a single, chronologically ordered timeline of telemetry and event rows with computed metrics, inferred phase, development %, and first-crack metadata.
  * Event records now include control-state details (heat/fan/cooling) for transition rows.

* **Documentation**
  * Updated README and docs describing CSV/JSON snapshot formats, planned summary.json follow-up, and validation notes.

* **Tests**
  * Added/expanded tests covering CSV schema, same-time ordering, per-row metrics, control-state transitions, and smoke test payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->