### PR TITLE
E5-S8: Export summary.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,9 +383,9 @@ Current export files:
 - `roast.csv` with telemetry and event rows using the planned CSV columns for
   timestamps, elapsed seconds, phase, temperatures, controls, event flags,
   development percent, RoR/delta metrics, and first-crack model metadata
-- `summary.json` with current session-level metadata and timestamp-derived
-  metrics
+- `summary.json` with session timestamps, total roast seconds, development
+  metrics, roaster driver, and first-crack model metadata
 - output under `logs/roasts/{session_id}/`
 
-Final `summary.json` schema work and broad release validation land in later
-stories.
+Final cross-format log schema completeness tests and broad release validation
+land in later stories.

--- a/docs/session-summaries/2026-05-24-e5-s8-summary-json-export.md
+++ b/docs/session-summaries/2026-05-24-e5-s8-summary-json-export.md
@@ -1,0 +1,78 @@
+# E5-S8 Summary JSON Export
+
+This summary captures the E5-S8 implementation, validation state, and restart
+context.
+
+## Scope
+
+Story: `E5-S8` / issue `#47`, export `summary.json`.
+
+Branch: `feature/47-export-summary-json`
+
+The implementation stayed inside the E5-S8 boundary:
+
+- add the plan-required session-level `summary.json` fields
+- include lifecycle timestamps, total roast seconds, development metrics,
+  configured roaster driver, and first-crack model metadata
+- keep the existing summary fields and metric helper values for compatibility
+- preserve append-only runtime `roast.jsonl` writes from `RoastSessionStore`
+- preserve the E5-S7 CSV schema, one-session store boundary, MCP behavior, and
+  configured-driver runtime behavior
+
+No model training, ONNX export, Hugging Face sync, real microphone validation,
+live Hottop validation, end-to-end agent roast validation, or broad release
+validation was added.
+
+## Implementation Summary
+
+`export_roast_snapshot(...)` now accepts the configured `roaster_driver`, and
+the MCP `export_roast_log` tool passes `config.roaster.driver` into the snapshot
+export path. Direct export calls continue to default to the mock driver, matching
+the repo's default runtime path.
+
+`summary.json` now includes:
+
+- `started_at_utc`, lifecycle timestamp fields, and existing session state
+- `total_roast_seconds`
+- `development_time_seconds`
+- `development_time_percent`
+- `roaster_driver`
+- `first_crack_model` with `repo_id`, `revision`, and `precision`
+
+First-crack model metadata comes from the authoritative
+`first_crack_detected` event payload. The existing nested `metrics` block is
+preserved and now also carries `development_time_percent` as an alias for the
+existing `development_percent` value.
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E5-S8` complete and sets
+  the active story to `E5-S9`.
+- `docs/state/registry.md` says the next story is `E5-S9: add log schema tests`.
+- `README.md` describes the current JSONL, CSV, and summary export behavior.
+
+## Validation
+
+Focused validation:
+
+- `./.venv/bin/python -m pytest tests/test_exports.py`: 10 passed
+
+Full validation:
+
+- `./.venv/bin/python -m pytest`: 335 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+## Restart Prompt
+
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E5-S8 should
+be checked first. If it has merged, verify issue #47 is closed, check out
+`main`, run `git pull --ff-only origin main`, then begin E5-S9 from updated main
+on the appropriate `feature/48-...` branch after reading the registry, active
+epic, this summary, and the GitHub issue for E5-S9. Keep E5-S9 scoped to log
+schema tests unless its issue explicitly requires more, and preserve the
+append-only JSONL runtime writer, CSV schema, summary schema, and existing
+metrics/session/runtime boundaries.

--- a/docs/session-summaries/2026-05-24-e5-s8-summary-json-export.md
+++ b/docs/session-summaries/2026-05-24-e5-s8-summary-json-export.md
@@ -66,6 +66,12 @@ Full validation:
 - `./.venv/bin/coffee-roaster-mcp --help`: passed
 - `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
 
+## Usage Snapshot
+
+Operator-provided cumulative session usage after PR #125 creation:
+
+- Tokens used so far in this session: `116K`
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E5-S8 should

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E5-S8`
-- Current target: Export `summary.json`
+- Active story: `E5-S9`
+- Current target: Add log schema tests
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -259,6 +259,13 @@ The first implementation milestone is a mock vertical slice that requires no roa
   Append-only JSONL runtime logging, existing metric helpers, the one-session
   store boundary, mock-safe MCP behavior, and `summary.json` behavior remain
   unchanged. Final `summary.json` schema work remains later Epic 5 work.
+- `E5-S8` adds the planned `summary.json` session-level schema. Snapshot
+  summary export now includes session timestamps, total roast seconds,
+  development seconds and percent, the configured roaster driver, and
+  first-crack model metadata from the authoritative first-crack event payload.
+  Existing summary fields and metric helper values are preserved, and the
+  append-only JSONL runtime writer, CSV schema, one-session store boundary, and
+  mock-safe MCP behavior remain unchanged.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -557,7 +564,7 @@ Goal: compute roast metrics from one session clock and export durable logs.
 - [x] `E5-S7` Export CSV roast log.
   - Done when CSV includes all required columns from the plan.
 
-- [ ] `E5-S8` Export `summary.json`.
+- [x] `E5-S8` Export `summary.json`.
   - Done when summary includes session timestamps, total roast seconds, development metrics, roaster driver, and first-crack model metadata.
 
 - [ ] `E5-S9` Add log schema tests.
@@ -1468,6 +1475,24 @@ After completing a story:
     validation, and broad release validation out of scope.
   - Ran `./.venv/bin/python -m pytest tests/test_exports.py`: 4 passed.
   - Ran `./.venv/bin/python -m pytest`: 328 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E5-S8:
+  - Added the planned `summary.json` session-level schema fields to snapshot
+    export: `started_at_utc`, lifecycle timestamps, `total_roast_seconds`,
+    development seconds/percent, `roaster_driver`, and `first_crack_model`.
+  - Passed the configured roaster driver from the MCP `export_roast_log` path
+    into summary export while preserving the existing direct-export mock
+    default.
+  - Kept append-only JSONL runtime logging, the E5-S7 CSV schema, one-session
+    store ownership, existing metric helpers, mock-safe CI behavior, first-crack
+    artifact/audio boundaries, Hottop validation boundary, and release
+    validation scope unchanged.
+  - Ran `./.venv/bin/python -m pytest tests/test_exports.py`: 10 passed.
+  - Ran `./.venv/bin/python -m pytest`: 335 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -228,13 +228,20 @@ percent, RoR/delta metrics, and first-crack model metadata. Append-only JSONL
 runtime logging, the one-session `RoastSessionStore` mutation boundary, existing
 metric helpers, and `summary.json` behavior remain unchanged.
 
+E5-S8 added the planned `summary.json` session-level schema. Snapshot summary
+export now includes session timestamps, total roast seconds, development
+seconds/percent, the configured roaster driver, and first-crack model metadata
+from the authoritative first-crack event payload while preserving append-only
+JSONL runtime logging, the CSV schema, the one-session store boundary, and
+existing metric helpers.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E5-S8: export `summary.json`.
+The next story is E5-S9: add log schema tests.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/exports.py
+++ b/src/coffee_roaster_mcp/exports.py
@@ -69,6 +69,7 @@ class RoastLogExport:
 def export_roast_snapshot(
     session: RoastSession,
     *,
+    roaster_driver: str = "mock",
     ror_window_seconds: float = 60.0,
     ror_min_sample_seconds: float = 10.0,
 ) -> RoastLogExport:
@@ -80,6 +81,7 @@ def export_roast_snapshot(
 
     Args:
         session: Copied session snapshot to export.
+        roaster_driver: Configured roaster driver used for the session.
         ror_window_seconds: Rolling telemetry window for RoR calculations.
         ror_min_sample_seconds: Minimum valid sensor sample span required for RoR.
 
@@ -112,6 +114,7 @@ def export_roast_snapshot(
     _write_summary_json(
         summary_path,
         session=session,
+        roaster_driver=roaster_driver,
         ror_window_seconds=ror_window_seconds,
         ror_min_sample_seconds=ror_min_sample_seconds,
     )
@@ -161,19 +164,22 @@ def _write_summary_json(
     path: Path,
     *,
     session: RoastSession,
+    roaster_driver: str,
     ror_window_seconds: float = 60.0,
     ror_min_sample_seconds: float = 10.0,
 ) -> None:
-    """Write a compact summary for the exported session snapshot."""
+    """Write a session-level summary with the planned summary schema fields."""
     metrics = compute_roast_metrics(
         session,
         ror_window_seconds=ror_window_seconds,
         ror_min_sample_seconds=ror_min_sample_seconds,
     )
+    first_crack_model = _summary_first_crack_model(session)
     payload: dict[str, Any] = {
         "session_id": session.id,
         "active": session.active,
         "phase": session.phase,
+        "started_at_utc": session.created_at_utc.isoformat(),
         "created_at_utc": session.created_at_utc.isoformat(),
         "stopped_at_utc": _iso_or_none(session.stopped_at_utc),
         "beans_added_at_utc": _iso_or_none(session.beans_added_at_utc),
@@ -186,10 +192,16 @@ def _write_summary_json(
         "fan_level_percent": session.fan_level_percent,
         "cooling_on": session.cooling_on,
         "event_count": len(session.event_timeline),
+        "total_roast_seconds": metrics.roast_elapsed_seconds,
+        "development_time_seconds": metrics.development_time_seconds,
+        "development_time_percent": metrics.development_percent,
+        "roaster_driver": roaster_driver,
+        "first_crack_model": first_crack_model,
         "metrics": {
             "roast_elapsed_seconds": metrics.roast_elapsed_seconds,
             "development_time_seconds": metrics.development_time_seconds,
             "development_percent": metrics.development_percent,
+            "development_time_percent": metrics.development_percent,
             "bean_temp_delta_60s_c": metrics.bean_temp_delta_60s_c,
             "env_temp_delta_60s_c": metrics.env_temp_delta_60s_c,
             "bean_ror_c_per_min": metrics.bean_ror_c_per_min,
@@ -209,6 +221,21 @@ def _event_row(*, session: RoastSession, event: RoastEvent) -> dict[str, Any]:
         "monotonic_seconds": event.monotonic_seconds,
         "payload": dict(event.payload),
     }
+
+
+def _summary_first_crack_model(session: RoastSession) -> dict[str, str | None]:
+    """Return first-crack model metadata for summary export."""
+    payload = _first_crack_payload_from(session.event_timeline)
+    return {
+        "repo_id": _string_payload_value(payload.get("repo_id")),
+        "revision": _string_payload_value(payload.get("revision")),
+        "precision": _string_payload_value(payload.get("precision")),
+    }
+
+
+def _string_payload_value(value: EventPayloadValue | None) -> str | None:
+    """Return a payload value only when it is string metadata."""
+    return value if isinstance(value, str) else None
 
 
 def _csv_rows(

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -600,6 +600,7 @@ def create_mcp_server(
         session = _resolve_session(server_context, session_id=session_id)
         export = export_roast_snapshot(
             session,
+            roaster_driver=server_context.config.roaster.driver,
             ror_window_seconds=server_context.config.session.ror_window_seconds,
             ror_min_sample_seconds=server_context.config.session.ror_min_sample_seconds,
         )

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -107,11 +107,74 @@ def test_snapshot_export_preserves_first_crack_detector_metadata(tmp_path: Path)
     assert first_crack_csv_row["fc_model_precision"] == "int8"
 
     summary = json.loads(export.summary_path.read_text(encoding="utf-8"))
+    assert summary["started_at_utc"] == "2026-05-17T14:00:00+00:00"
     assert summary["first_crack_at_utc"] == "2026-05-17T14:00:37.250000+00:00"
+    assert summary["total_roast_seconds"] == 65.0
+    assert summary["development_time_seconds"] == 32.75
+    assert summary["development_time_percent"] == 50.385
+    assert summary["roaster_driver"] == "mock"
+    assert summary["first_crack_model"] == {
+        "repo_id": "syamaner/coffee-first-crack-detection",
+        "revision": "v0.1.0",
+        "precision": "int8",
+    }
     assert summary["metrics"]["development_time_seconds"] == 32.75
     assert summary["metrics"]["development_percent"] == 50.385
+    assert summary["metrics"]["development_time_percent"] == 50.385
     assert summary["metrics"]["bean_ror_c_per_min"] is None
     assert summary["metrics"]["env_ror_c_per_min"] is None
+
+
+def test_snapshot_export_summary_includes_plan_required_schema(
+    tmp_path: Path,
+) -> None:
+    """Export summary.json with session timing, driver, and model fields."""
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    clock.utc_value = datetime(2026, 5, 17, 14, 0, 10, tzinfo=UTC)
+    clock.monotonic_value = 110.0
+    store.record_event(session, "beans_added")
+    clock.utc_value = datetime(2026, 5, 17, 14, 1, tzinfo=UTC)
+    clock.monotonic_value = 160.0
+    store.record_event(
+        session,
+        "first_crack_detected",
+        payload={
+            "repo_id": "syamaner/coffee-first-crack-detection",
+            "revision": "release-2026-05",
+            "precision": "fp32",
+            "confidence": 0.91,
+        },
+    )
+    clock.utc_value = datetime(2026, 5, 17, 14, 1, 30, tzinfo=UTC)
+    clock.monotonic_value = 190.0
+    store.record_event(session, "beans_dropped")
+
+    export = export_roast_snapshot(
+        session,
+        roaster_driver="hottop_kn8828b_2k_plus",
+    )
+
+    summary = json.loads(export.summary_path.read_text(encoding="utf-8"))
+    assert summary["session_id"] == session.id
+    assert summary["started_at_utc"] == "2026-05-17T14:00:00+00:00"
+    assert summary["beans_added_at_utc"] == "2026-05-17T14:00:10+00:00"
+    assert summary["first_crack_at_utc"] == "2026-05-17T14:01:00+00:00"
+    assert summary["beans_dropped_at_utc"] == "2026-05-17T14:01:30+00:00"
+    assert summary["total_roast_seconds"] == 80.0
+    assert summary["development_time_seconds"] == 30.0
+    assert summary["development_time_percent"] == 37.5
+    assert summary["roaster_driver"] == "hottop_kn8828b_2k_plus"
+    assert summary["first_crack_model"] == {
+        "repo_id": "syamaner/coffee-first-crack-detection",
+        "revision": "release-2026-05",
+        "precision": "fp32",
+    }
 
 
 def test_snapshot_export_uses_configured_ror_parameters(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add the planned `summary.json` session-level schema fields for lifecycle timestamps, total roast seconds, development metrics, configured roaster driver, and first-crack model metadata.
- Pass the configured roaster driver from the MCP `export_roast_log` path into snapshot export while keeping direct export calls mock-safe by default.
- Update README and durable state/session docs for E5-S8 and the E5-S9 next-story pointer.

## Scope Notes
- Preserves append-only runtime `roast.jsonl` writes from `RoastSessionStore`.
- Preserves the E5-S7 CSV schema, one-session store boundary, existing metric helpers, mock-safe MCP behavior, configured-driver runtime behavior, first-crack artifact/audio boundaries, and Hottop validation boundary.
- Does not add model training/export/sync, real microphone validation, live Hottop validation, end-to-end agent roast validation, broad release validation, or E5-S9 cross-format schema coverage.

## Tests
- `./.venv/bin/python -m pytest tests/test_exports.py`
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`
- `./.venv/bin/coffee-roaster-mcp --help`
- `./.venv/bin/coffee-roaster-mcp --version`

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced session summary export: includes session timestamps (started_at_utc), total roast seconds, development time seconds/percent, configured roaster driver, and first-crack model metadata.

* **Documentation**
  * Updated planning, registry, and session-summary docs to reflect the new summary schema and roadmap progress.

* **Tests**
  * Added/expanded tests to validate the new summary schema and included fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->