### PR TITLE
E5-S10: Add autonomous telemetry sampler

### DIFF
--- a/docs/session-summaries/2026-05-24-e5-s10-autonomous-telemetry-sampler.md
+++ b/docs/session-summaries/2026-05-24-e5-s10-autonomous-telemetry-sampler.md
@@ -81,6 +81,12 @@ Full validation:
 - `./.venv/bin/coffee-roaster-mcp --help`: passed
 - `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
 
+## Usage Snapshot
+
+Operator-provided cumulative session usage:
+
+- Tokens used so far in this session: `552K`
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E5-S10 should

--- a/docs/session-summaries/2026-05-24-e5-s10-autonomous-telemetry-sampler.md
+++ b/docs/session-summaries/2026-05-24-e5-s10-autonomous-telemetry-sampler.md
@@ -1,0 +1,93 @@
+# E5-S10 Autonomous Telemetry Sampler
+
+This summary captures the E5-S10 implementation, validation state, and restart
+context.
+
+## Scope
+
+Story: `E5-S10` / issue `#127`, add autonomous telemetry sampler.
+
+Branch: `feature/127-autonomous-telemetry-sampler`
+
+The implementation stayed inside the E5-S10 boundary:
+
+- start a session-owned telemetry sampler from `start_roast_session`
+- poll the configured roaster driver at `logging.sample_interval_seconds`
+- keep the default sample interval at 5 seconds
+- append sampled state through the existing `RoastSessionStore` telemetry path
+- keep `get_roast_state` as an opportunistic telemetry refresh path
+- stop sampler workers on owner-session completion/fault and MCP shutdown
+- fail closed with a diagnosable fault event on sampler driver-read failure
+- preserve append-only JSONL runtime logging, CSV export schema, summary schema,
+  one-session store ownership, configured-driver state/control wiring,
+  automatic T0 behavior, session-owned first-crack runtime behavior, mock-safe
+  CI, Hottop validation boundaries, and first-crack artifact/audio boundaries
+
+No model training, ONNX export, Hugging Face sync, real microphone validation,
+live Hottop validation, end-to-end agent roast validation, broad release
+validation, package metadata, PyPI publishing, or MCP Registry work was added.
+
+## Implementation Summary
+
+`src/coffee_roaster_mcp/mcp_server.py` now owns a `_TelemetrySampler` background
+worker in `ServerContext`. `start_roast_session` starts the sampler for the new
+session, and MCP lifespan shutdown stops it before first-crack runtime shutdown.
+Cooling completion and emergency stop also stop the owning sampler explicitly.
+
+The sampler waits one configured interval before its first autonomous read, then
+polls `RoasterDriver.read_state()` on the configured cadence. Successful reads
+append telemetry through `RoastSessionStore.record_active_telemetry_sample(...)`
+and then run the existing automatic T0 and first-crack runtime processing paths
+for the same active session. This keeps runtime mutation behind the existing
+store boundary and avoids making client polling the only way telemetry, derived
+metrics, JSONL logging, automatic T0, or first-crack processing can advance.
+
+`get_roast_state` still performs the existing explicit state read and telemetry
+append, so MCP calls can refresh telemetry opportunistically. Driver read
+failures inside the sampler fail closed through the existing emergency-stop
+safety payload path, record a fault event with the read failure in the reason,
+stop first-crack processing for the session, and let the sampler worker exit.
+
+`tests/test_package.py` now covers:
+
+- no-client-poll append-only telemetry logging through the stdio MCP flow
+- opportunistic telemetry refresh from `get_roast_state`
+- sampler shutdown stopping background reads
+- sampler driver-read failure faulting the active session and exiting
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E5-S10` complete and sets
+  the active story to `E6-S1`.
+- `docs/state/registry.md` says the next story is `E6-S1: add PyPI package
+  metadata`.
+- `docs/state/github-issues.md` adds issue `#127` to the Epic 5 story index.
+
+## Validation
+
+Focused validation:
+
+- `./.venv/bin/python -m pytest tests/test_config.py tests/test_session.py tests/test_package.py`:
+  108 passed
+- `./.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_package.py`:
+  43 passed
+
+Full validation:
+
+- `./.venv/bin/python -m pytest`: 341 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+## Restart Prompt
+
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E5-S10 should
+be checked first. If it has merged, verify issue #127 is closed, check out
+`main`, run `git pull --ff-only origin main`, then begin E6-S1 from updated
+main on the appropriate `feature/49-...` branch after reading the registry,
+active epic, this summary, and GitHub issue #49. Keep E6-S1 scoped to package
+metadata only; do not add PyPI publishing, MCP Registry work, live hardware
+validation, model training/export/sync, real microphone validation, or broad
+release validation unless issue #49 explicitly requires it.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E5-S10`
-- Current target: Add autonomous telemetry sampler
+- Active story: `E6-S1`
+- Current target: Add PyPI package metadata
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -273,16 +273,21 @@ The first implementation milestone is a mock vertical slice that requires no roa
   metadata key-set coverage. Existing metric helpers, append-only JSONL writes,
   CSV/summary values, session/runtime boundaries, and mock-safe behavior remain
   unchanged.
-- `E5-S10` is added before distribution because telemetry capture currently
-  depends on MCP clients calling `get_roast_state`. `start_roast_session` should
-  start a session-owned sampler that polls the configured driver at
-  `logging.sample_interval_seconds`, defaulting to 5 seconds, appends telemetry
-  through the existing `RoastSessionStore` boundary, and lets append-only JSONL
-  logging plus RoR/delta metrics advance even when the agent or MCP client does
-  not poll state reliably. MCP tool calls may still refresh telemetry
-  opportunistically. The sampler must preserve the one-session boundary,
-  configured-driver control wiring, mock-safe CI, fail-closed safety behavior,
-  automatic T0 behavior, and session-owned first-crack runtime behavior.
+- `E5-S10` added the autonomous telemetry sampler before distribution.
+  Starting a roast session now starts a session-owned background sampler that
+  polls the configured driver at `logging.sample_interval_seconds`, defaulting
+  to 5 seconds. Sampled state is appended through the existing
+  `RoastSessionStore.record_active_telemetry_sample(...)` path, so rolling
+  metrics and append-only JSONL telemetry rows advance even when no MCP client
+  polls `get_roast_state`. MCP state reads still refresh telemetry
+  opportunistically. The sampler waits for the configured interval before its
+  first autonomous sample so explicit tool reads remain deterministic, stops
+  when the owning session is no longer active or when the MCP process shuts
+  down, and fails closed with a diagnosable fault event if the configured driver
+  read fails. The implementation preserves the one-session boundary,
+  configured-driver control wiring, mock-safe CI, automatic T0 processing,
+  session-owned first-crack runtime processing, append-only JSONL logging, CSV
+  and summary export schemas, and Hottop/model/audio validation boundaries.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -587,7 +592,7 @@ Goal: compute roast metrics from one session clock and export durable logs.
 - [x] `E5-S9` Add log schema tests.
   - Done when JSONL, CSV, and summary schema completeness is covered by tests.
 
-- [ ] `E5-S10` Add autonomous telemetry sampler.
+- [x] `E5-S10` Add autonomous telemetry sampler.
   - Done when `start_roast_session` starts a session-owned telemetry sampler
     that polls the configured roaster driver at `logging.sample_interval_seconds`
     without requiring `get_roast_state` polling; the default configured interval
@@ -616,6 +621,8 @@ Goal: compute roast metrics from one session clock and export durable logs.
 - Event rows are written immediately, not only on the sampled telemetry loop.
 - Telemetry rows and rolling metrics advance at the configured sampler cadence
   even when an MCP client does not poll `get_roast_state`.
+- Epic 5 is complete through E5-S10. Runtime telemetry now advances both from
+  the autonomous sampler cadence and from opportunistic MCP state reads.
 
 ## Epic 6: Distribution And MCP Registry Publishing
 
@@ -1551,6 +1558,39 @@ After completing a story:
   - Ran `./.venv/bin/python -m pytest tests/test_session.py tests/test_exports.py`:
     81 passed.
   - Ran `./.venv/bin/python -m pytest`: 337 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E5-S10:
+  - Added a session-owned autonomous telemetry sampler to the MCP runtime.
+  - `start_roast_session` starts the sampler for the new session; MCP lifespan
+    shutdown stops it, and cooling completion or emergency stop stop the owning
+    sampler explicitly.
+  - The sampler polls the configured `RoasterDriver.read_state()` boundary at
+    `logging.sample_interval_seconds`, defaulting to 5 seconds, and appends
+    samples through `RoastSessionStore.record_active_telemetry_sample(...)`.
+  - Successful sampler reads also run the existing automatic T0 and
+    session-owned first-crack processing paths so those runtime paths no longer
+    depend only on `get_roast_state` polling.
+  - MCP `get_roast_state` continues to refresh telemetry opportunistically.
+  - Driver read failures fail closed through the existing emergency-stop safety
+    payload path, record a diagnosable fault event, stop first-crack processing,
+    and stop the sampler without issuing unrelated hardware commands.
+  - Added mock-safe MCP/runtime tests for no-client-poll telemetry logging,
+    opportunistic state-read refresh, sampler shutdown, driver-read failure, and
+    background-worker lifecycle behavior.
+  - Kept append-only JSONL runtime logging, the CSV schema, the summary schema,
+    the one-session store boundary, configured-driver control/state wiring,
+    automatic T0 behavior, session-owned first-crack runtime behavior, Hottop
+    validation boundaries, first-crack artifact/audio boundaries, and all
+    E5-S1 through E5-S9 metric/log/export helpers unchanged.
+  - Ran `./.venv/bin/python -m pytest tests/test_config.py tests/test_session.py tests/test_package.py`:
+    108 passed.
+  - Ran `./.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_package.py`:
+    43 passed.
+  - Ran `./.venv/bin/python -m pytest`: 341 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/github-issues.md
+++ b/docs/state/github-issues.md
@@ -82,6 +82,7 @@ Milestone: `v0.1`
 - #46 E5-S7: Export CSV roast log
 - #47 E5-S8: Export summary.json
 - #48 E5-S9: Add log schema tests
+- #127 E5-S10: Add autonomous telemetry sampler
 
 ## Epic 6 Stories
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -241,14 +241,14 @@ coverage, CSV export remains pinned to the E5-S7 field order, and `summary.json`
 now has exact top-level, nested metrics, and first-crack model metadata key-set
 coverage. Epic 5 metric/log/export helper behavior remains unchanged.
 
-E5-S10 is added before distribution to close the autonomous telemetry sampling
-gap. Telemetry capture currently happens when an MCP client calls
-`get_roast_state`; E5-S10 should make `start_roast_session` start a
-session-owned sampler that polls the configured driver at
-`logging.sample_interval_seconds`, defaulting to 5 seconds, appends telemetry
-through the existing `RoastSessionStore` path, and lets append-only JSONL
-telemetry plus RoR/delta metrics advance even without client polling. MCP tool
-calls may still refresh telemetry opportunistically.
+E5-S10 completed the autonomous telemetry sampling gap. Starting a roast
+session now starts a session-owned background sampler that polls the configured
+driver at `logging.sample_interval_seconds`, defaulting to 5 seconds, and
+appends telemetry through the existing `RoastSessionStore` path. Append-only
+JSONL telemetry plus RoR/delta metrics now advance without client polling, while
+MCP tool calls may still refresh telemetry opportunistically. Successful sampler
+reads also run existing automatic T0 and first-crack runtime processing. Driver
+read failures fail closed with a diagnosable fault event and stop the sampler.
 
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
@@ -256,7 +256,7 @@ first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E5-S10: add autonomous telemetry sampler.
+The next story is E6-S1: add PyPI package metadata.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -81,8 +81,12 @@ class _TelemetrySampler:
 
     def start_for_session(self, session_id: str) -> None:
         """Start autonomous sampling for one session id."""
+        thread: Thread | None
         with self._lock:
-            self._stop_locked()
+            thread = self._stop_locked()
+        self._join_thread(thread)
+
+        with self._lock:
             self._stop_event = Event()
             self._active_session_id = session_id
             self._last_error = None
@@ -97,15 +101,19 @@ class _TelemetrySampler:
     def stop_for_session(self, session_id: str, *, reason: str) -> None:
         """Stop sampling if the supplied session currently owns the sampler."""
         _ = reason
+        thread: Thread | None
         with self._lock:
             if self._active_session_id != session_id:
                 return
-            self._stop_locked()
+            thread = self._stop_locked()
+        self._join_thread(thread)
 
     def shutdown(self) -> None:
         """Stop any active sampler worker."""
+        thread: Thread | None
         with self._lock:
-            self._stop_locked()
+            thread = self._stop_locked()
+        self._join_thread(thread)
 
     @property
     def active_session_id(self) -> str | None:
@@ -134,11 +142,15 @@ class _TelemetrySampler:
                         self._active_session_id = None
                 return
 
-    def _stop_locked(self) -> None:
+    def _stop_locked(self) -> Thread | None:
         thread = self._thread
         self._active_session_id = None
         self._thread = None
         self._stop_event.set()
+        return thread
+
+    def _join_thread(self, thread: Thread | None) -> None:
+        """Wait briefly for a sampler worker after releasing the sampler lock."""
         if thread is not None and thread.is_alive():
             thread.join(timeout=max(1.0, self._interval_seconds * 2))
 
@@ -1069,50 +1081,49 @@ def _sample_active_session_telemetry(
 
     try:
         driver_state = server_context.roaster_driver.read_state()
-    except Exception as exc:  # noqa: BLE001 - driver implementations vary.
-        _fault_active_session_after_sampler_read_failure(
+        device_state = _serialize_device_state(driver_state)
+        snapshot = server_context.session_store.record_active_telemetry_sample(
+            session_id=session_id,
+            bean_temp_c=driver_state.bean_temp_c,
+            env_temp_c=driver_state.env_temp_c,
+            heat_level_percent=driver_state.heat_level_percent,
+            fan_level_percent=driver_state.fan_level_percent,
+            cooling_on=driver_state.cooling_on,
+        )
+        if snapshot is None:
+            return False
+
+        auto_t0_recorded = _process_auto_t0_for_active_session(
+            server_context,
+            session_id=session_id,
+            device_state=device_state,
+        )
+        if auto_t0_recorded:
+            server_context.first_crack_runtime.discard_queued_windows_for_session(
+                session_id,
+                reason="Dropped queued pre-T0 detector windows after automatic T0.",
+            )
+        _process_first_crack_runtime_for_active_session(server_context, session_id=session_id)
+    except Exception as exc:  # noqa: BLE001 - background safety path must catch all failures.
+        _fault_active_session_after_sampler_failure(
             server_context,
             session=active_session,
             error=exc,
         )
         return False
 
-    device_state = _serialize_device_state(driver_state)
-    snapshot = server_context.session_store.record_active_telemetry_sample(
-        session_id=session_id,
-        bean_temp_c=driver_state.bean_temp_c,
-        env_temp_c=driver_state.env_temp_c,
-        heat_level_percent=driver_state.heat_level_percent,
-        fan_level_percent=driver_state.fan_level_percent,
-        cooling_on=driver_state.cooling_on,
-    )
-    if snapshot is None:
-        return False
-
-    auto_t0_recorded = _process_auto_t0_for_active_session(
-        server_context,
-        session_id=session_id,
-        device_state=device_state,
-    )
-    if auto_t0_recorded:
-        server_context.first_crack_runtime.discard_queued_windows_for_session(
-            session_id,
-            reason="Dropped queued pre-T0 detector windows after automatic T0.",
-        )
-    _process_first_crack_runtime_for_active_session(server_context, session_id=session_id)
-
     active_session = server_context.session_store.get_active_session()
     return active_session is not None and active_session.id == session_id
 
 
-def _fault_active_session_after_sampler_read_failure(
+def _fault_active_session_after_sampler_failure(
     server_context: ServerContext,
     *,
     session: RoastSession,
     error: BaseException,
 ) -> None:
-    """Fail closed when the autonomous sampler cannot read the configured driver."""
-    reason = f"autonomous telemetry sampler driver read failed: {type(error).__name__}: {error}"
+    """Fail closed when autonomous sampling cannot safely continue."""
+    reason = f"autonomous telemetry sampler failed: {type(error).__name__}: {error}"
     safety_payload = run_driver_emergency_stop(server_context, reason=reason)
     try:
         _, snapshot = server_context.session_store.emergency_stop_snapshot(
@@ -1125,7 +1136,7 @@ def _fault_active_session_after_sampler_read_failure(
         return
     server_context.first_crack_runtime.stop_for_session(
         snapshot.id,
-        reason="autonomous telemetry sampler driver read failure",
+        reason="autonomous telemetry sampler failure",
     )
 
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -8,6 +8,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from threading import Event, RLock, Thread
 from typing import Literal
 
 from mcp.server.fastmcp import Context, FastMCP
@@ -45,6 +46,7 @@ class ServerContext:
         session_store: Authoritative in-process roast session owner.
         roaster_driver: Configured driver boundary.
         first_crack_runtime: Session-owned first-crack detector runtime.
+        telemetry_sampler: Session-owned autonomous telemetry sampler.
         started_at_utc: UTC time when the MCP process initialized.
     """
 
@@ -53,7 +55,92 @@ class ServerContext:
     session_store: RoastSessionStore
     roaster_driver: RoasterDriver
     first_crack_runtime: FirstCrackSessionRuntime
+    telemetry_sampler: _TelemetrySampler
     started_at_utc: datetime
+
+
+TelemetrySampleCallback = Callable[[str], bool]
+
+
+class _TelemetrySampler:
+    """Poll driver telemetry for the currently owning roast session."""
+
+    def __init__(
+        self,
+        *,
+        interval_seconds: float,
+        sample_callback: TelemetrySampleCallback,
+    ) -> None:
+        self._interval_seconds = interval_seconds
+        self._sample_callback = sample_callback
+        self._lock = RLock()
+        self._stop_event = Event()
+        self._thread: Thread | None = None
+        self._active_session_id: str | None = None
+        self._last_error: str | None = None
+
+    def start_for_session(self, session_id: str) -> None:
+        """Start autonomous sampling for one session id."""
+        with self._lock:
+            self._stop_locked()
+            self._stop_event = Event()
+            self._active_session_id = session_id
+            self._last_error = None
+            self._thread = Thread(
+                target=self._run,
+                args=(session_id, self._stop_event),
+                name=f"roast-telemetry-sampler-{session_id}",
+                daemon=True,
+            )
+            self._thread.start()
+
+    def stop_for_session(self, session_id: str, *, reason: str) -> None:
+        """Stop sampling if the supplied session currently owns the sampler."""
+        _ = reason
+        with self._lock:
+            if self._active_session_id != session_id:
+                return
+            self._stop_locked()
+
+    def shutdown(self) -> None:
+        """Stop any active sampler worker."""
+        with self._lock:
+            self._stop_locked()
+
+    @property
+    def active_session_id(self) -> str | None:
+        """Return the session id currently owned by the sampler."""
+        with self._lock:
+            return self._active_session_id
+
+    @property
+    def last_error(self) -> str | None:
+        """Return the latest sampler error, if any."""
+        with self._lock:
+            return self._last_error
+
+    def _run(self, session_id: str, stop_event: Event) -> None:
+        while not stop_event.wait(self._interval_seconds):
+            try:
+                keep_sampling = self._sample_callback(session_id)
+            except Exception as exc:  # noqa: BLE001 - background worker must not escape.
+                with self._lock:
+                    if self._active_session_id == session_id:
+                        self._last_error = f"{type(exc).__name__}: {exc}"
+                keep_sampling = False
+            if not keep_sampling:
+                with self._lock:
+                    if self._active_session_id == session_id:
+                        self._active_session_id = None
+                return
+
+    def _stop_locked(self) -> None:
+        thread = self._thread
+        self._active_session_id = None
+        self._thread = None
+        self._stop_event.set()
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=max(1.0, self._interval_seconds * 2))
 
 
 @dataclass(frozen=True)
@@ -320,7 +407,18 @@ def build_server_context(
         )
     except ValueError as exc:
         raise ConfigError(str(exc)) from exc
-    return ServerContext(
+    server_context: ServerContext | None = None
+
+    def sample_active_session(session_id: str) -> bool:
+        if server_context is None:
+            return False
+        return _sample_active_session_telemetry(server_context, session_id=session_id)
+
+    telemetry_sampler = _TelemetrySampler(
+        interval_seconds=config.logging.sample_interval_seconds,
+        sample_callback=sample_active_session,
+    )
+    server_context = ServerContext(
         config=config,
         transport=transport,
         session_store=RoastSessionStore(
@@ -329,8 +427,10 @@ def build_server_context(
         ),
         roaster_driver=roaster_driver,
         first_crack_runtime=build_first_crack_session_runtime(config),
+        telemetry_sampler=telemetry_sampler,
         started_at_utc=datetime.now(UTC),
     )
+    return server_context
 
 
 def create_mcp_server(
@@ -355,6 +455,7 @@ def create_mcp_server(
         try:
             yield server_context
         finally:
+            server_context.telemetry_sampler.shutdown()
             server_context.first_crack_runtime.shutdown()
 
     mcp = FastMCP(
@@ -439,6 +540,7 @@ def create_mcp_server(
             server_context.session_store.clear_session_start_reservation(reservation)
             raise
         _start_first_crack_runtime(server_context, session=session)
+        server_context.telemetry_sampler.start_for_session(session.id)
         return StartRoastSessionResult(
             session=_serialize_session_state(
                 session,
@@ -564,6 +666,8 @@ def create_mcp_server(
             snapshot.id,
             reason="beans dropped",
         )
+        if not snapshot.active:
+            server_context.telemetry_sampler.stop_for_session(snapshot.id, reason="beans dropped")
         return _serialize_event_result(snapshot=snapshot, event=event)
 
     @mcp.tool()
@@ -585,6 +689,10 @@ def create_mcp_server(
         session = _require_active_session(server_context)
         event, snapshot = _run_reserved_driver_stop_cooling(server_context, session)
         server_context.first_crack_runtime.stop_for_session(
+            snapshot.id,
+            reason="cooling stopped",
+        )
+        server_context.telemetry_sampler.stop_for_session(
             snapshot.id,
             reason="cooling stopped",
         )
@@ -631,6 +739,10 @@ def create_mcp_server(
             allow_stopped_latest=True,
         )
         server_context.first_crack_runtime.stop_for_session(
+            snapshot.id,
+            reason="emergency stop",
+        )
+        server_context.telemetry_sampler.stop_for_session(
             snapshot.id,
             reason="emergency stop",
         )
@@ -943,6 +1055,78 @@ def _record_polling_telemetry_for_active_session(
         cooling_on=driver_state.cooling_on,
     )
     return session if snapshot is None else snapshot
+
+
+def _sample_active_session_telemetry(
+    server_context: ServerContext,
+    *,
+    session_id: str,
+) -> bool:
+    """Append one autonomous telemetry sample for the owning active session."""
+    active_session = server_context.session_store.get_active_session()
+    if active_session is None or active_session.id != session_id:
+        return False
+
+    try:
+        driver_state = server_context.roaster_driver.read_state()
+    except Exception as exc:  # noqa: BLE001 - driver implementations vary.
+        _fault_active_session_after_sampler_read_failure(
+            server_context,
+            session=active_session,
+            error=exc,
+        )
+        return False
+
+    device_state = _serialize_device_state(driver_state)
+    snapshot = server_context.session_store.record_active_telemetry_sample(
+        session_id=session_id,
+        bean_temp_c=driver_state.bean_temp_c,
+        env_temp_c=driver_state.env_temp_c,
+        heat_level_percent=driver_state.heat_level_percent,
+        fan_level_percent=driver_state.fan_level_percent,
+        cooling_on=driver_state.cooling_on,
+    )
+    if snapshot is None:
+        return False
+
+    auto_t0_recorded = _process_auto_t0_for_active_session(
+        server_context,
+        session_id=session_id,
+        device_state=device_state,
+    )
+    if auto_t0_recorded:
+        server_context.first_crack_runtime.discard_queued_windows_for_session(
+            session_id,
+            reason="Dropped queued pre-T0 detector windows after automatic T0.",
+        )
+    _process_first_crack_runtime_for_active_session(server_context, session_id=session_id)
+
+    active_session = server_context.session_store.get_active_session()
+    return active_session is not None and active_session.id == session_id
+
+
+def _fault_active_session_after_sampler_read_failure(
+    server_context: ServerContext,
+    *,
+    session: RoastSession,
+    error: BaseException,
+) -> None:
+    """Fail closed when the autonomous sampler cannot read the configured driver."""
+    reason = f"autonomous telemetry sampler driver read failed: {type(error).__name__}: {error}"
+    safety_payload = run_driver_emergency_stop(server_context, reason=reason)
+    try:
+        _, snapshot = server_context.session_store.emergency_stop_snapshot(
+            session,
+            reason=reason,
+            safety_payload=safety_payload,
+            allow_stopped_latest=True,
+        )
+    except SessionLifecycleError:
+        return
+    server_context.first_crack_runtime.stop_for_session(
+        snapshot.id,
+        reason="autonomous telemetry sampler driver read failure",
+    )
 
 
 def _serialize_session_state(

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -195,14 +195,17 @@ def test_stdio_server_supports_basic_mock_roast_tool_flow(tmp_path: Path) -> Non
 
 
 def test_stdio_server_autonomous_sampler_logs_without_state_polling(tmp_path: Path) -> None:
+    """Verify the stdio sampler writes telemetry without client state polling."""
     asyncio.run(_assert_autonomous_sampler_logs_without_state_polling(tmp_path))
 
 
 def test_stdio_server_state_polling_still_refreshes_telemetry(tmp_path: Path) -> None:
+    """Verify `get_roast_state` remains an opportunistic telemetry refresh path."""
     asyncio.run(_assert_state_polling_still_refreshes_telemetry(tmp_path))
 
 
 def test_telemetry_sampler_shutdown_stops_background_reads(tmp_path: Path) -> None:
+    """Verify sampler shutdown stops a mock-safe background reader."""
     config_path = tmp_path / "coffee-roaster-mcp.yaml"
     config_path.write_text("logging:\n  sample_interval_seconds: 0.01\n", encoding="utf-8")
     server_context = build_server_context(config_path=config_path)
@@ -220,6 +223,7 @@ def test_telemetry_sampler_shutdown_stops_background_reads(tmp_path: Path) -> No
 
 
 def test_telemetry_sampler_driver_read_failure_faults_session(tmp_path: Path) -> None:
+    """Verify sampler driver-read failure faults closed and exits the worker."""
     config_path = tmp_path / "coffee-roaster-mcp.yaml"
     config_path.write_text("logging:\n  sample_interval_seconds: 0.01\n", encoding="utf-8")
     server_context = build_server_context(config_path=config_path)
@@ -233,12 +237,19 @@ def test_telemetry_sampler_driver_read_failure_faults_session(tmp_path: Path) ->
     snapshot = server_context.session_store.get_session_snapshot(session_id=session.id)
     assert snapshot.active is False
     assert snapshot.phase == "fault"
+    assert snapshot.heat_level_percent == 0
+    assert snapshot.fan_level_percent == 100
+    assert snapshot.cooling_on is True
     assert driver.emergency_stop_called is True
     fault_event = snapshot.event_timeline[-1]
     assert fault_event.kind == "fault"
+    assert fault_event.payload["driver_safety_method_called"] is True
+    assert fault_event.payload["heat_level_percent"] == 0
+    assert fault_event.payload["fan_level_percent"] == 100
+    assert fault_event.payload["cooling_on"] is True
     assert (
         fault_event.payload["reason"]
-        == "autonomous telemetry sampler driver read failed: RuntimeError: read offline"
+        == "autonomous telemetry sampler failed: RuntimeError: read offline"
     )
     assert server_context.telemetry_sampler.active_session_id is None
 
@@ -793,11 +804,18 @@ def _telemetry_row_count(path: Path) -> int:
     """Return the number of telemetry rows in an append-only JSONL log."""
     if not path.exists():
         return 0
-    return sum(
-        1
-        for line in path.read_text(encoding="utf-8").splitlines()
-        if json.loads(line)["type"] == "telemetry"
-    )
+    lines = path.read_text(encoding="utf-8").splitlines()
+    telemetry_rows = 0
+    for index, line in enumerate(lines):
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            if index == len(lines) - 1:
+                break
+            raise
+        if row.get("type") == "telemetry":
+            telemetry_rows += 1
+    return telemetry_rows
 
 
 def _wait_for_condition(condition: Callable[[], bool], timeout_seconds: float = 1.0) -> None:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -4,7 +4,8 @@ import asyncio
 import json
 import os
 import sys
-from collections.abc import Awaitable
+import time
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, TypeVar, cast
@@ -16,6 +17,7 @@ from mcp.client.stdio import stdio_client
 from coffee_roaster_mcp import __version__, cli
 from coffee_roaster_mcp.cli import build_parser, main
 from coffee_roaster_mcp.config import ConfigError
+from coffee_roaster_mcp.drivers import EmergencyStopResult, RoasterState
 from coffee_roaster_mcp.mcp_server import build_server_context, run_driver_emergency_stop
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -190,6 +192,55 @@ async def _assert_stdio_server_tools(tmp_path: Path) -> None:
 
 def test_stdio_server_supports_basic_mock_roast_tool_flow(tmp_path: Path) -> None:
     asyncio.run(_assert_basic_mock_roast_flow(tmp_path))
+
+
+def test_stdio_server_autonomous_sampler_logs_without_state_polling(tmp_path: Path) -> None:
+    asyncio.run(_assert_autonomous_sampler_logs_without_state_polling(tmp_path))
+
+
+def test_stdio_server_state_polling_still_refreshes_telemetry(tmp_path: Path) -> None:
+    asyncio.run(_assert_state_polling_still_refreshes_telemetry(tmp_path))
+
+
+def test_telemetry_sampler_shutdown_stops_background_reads(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("logging:\n  sample_interval_seconds: 0.01\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    driver = _CountingDriver()
+    object.__setattr__(server_context, "roaster_driver", driver)
+    session = server_context.session_store.start_session()
+
+    server_context.telemetry_sampler.start_for_session(session.id)
+    _wait_for_condition(lambda: driver.read_count >= 2)
+    server_context.telemetry_sampler.shutdown()
+    reads_after_shutdown = driver.read_count
+    time.sleep(0.05)
+
+    assert driver.read_count == reads_after_shutdown
+
+
+def test_telemetry_sampler_driver_read_failure_faults_session(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("logging:\n  sample_interval_seconds: 0.01\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    driver = _FailingReadDriver()
+    object.__setattr__(server_context, "roaster_driver", driver)
+    session = server_context.session_store.start_session()
+
+    server_context.telemetry_sampler.start_for_session(session.id)
+    _wait_for_condition(lambda: server_context.session_store.get_active_session() is None)
+
+    snapshot = server_context.session_store.get_session_snapshot(session_id=session.id)
+    assert snapshot.active is False
+    assert snapshot.phase == "fault"
+    assert driver.emergency_stop_called is True
+    fault_event = snapshot.event_timeline[-1]
+    assert fault_event.kind == "fault"
+    assert (
+        fault_event.payload["reason"]
+        == "autonomous telemetry sampler driver read failed: RuntimeError: read offline"
+    )
+    assert server_context.telemetry_sampler.active_session_id is None
 
 
 async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
@@ -437,6 +488,73 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         assert old_session_state_after_rollover.structuredContent["active"] is False
 
 
+async def _assert_autonomous_sampler_logs_without_state_polling(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("logging:\n  sample_interval_seconds: 0.01\n", encoding="utf-8")
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "coffee_roaster_mcp.cli", "serve"],
+        env=_build_clean_server_env(),
+        cwd=tmp_path,
+    )
+
+    async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
+        await _call_with_timeout(session.initialize())
+
+        start_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("start_roast_session", {})),
+        )
+        session_id = start_result.structuredContent["session"]["session_id"]
+        log_path = tmp_path / "logs" / "roasts" / session_id / "roast.jsonl"
+        await _wait_for_async_condition(lambda: _telemetry_row_count(log_path) >= 2)
+
+        export_result = cast(
+            Any,
+            await _call_with_timeout(
+                session.call_tool("export_roast_log", {"session_id": session_id})
+            ),
+        )
+        assert export_result.structuredContent["ready"] is True
+        rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+        assert [row["type"] for row in rows[:2]] == ["telemetry", "telemetry"]
+
+
+async def _assert_state_polling_still_refreshes_telemetry(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("logging:\n  sample_interval_seconds: 60\n", encoding="utf-8")
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "coffee_roaster_mcp.cli", "serve"],
+        env=_build_clean_server_env(),
+        cwd=tmp_path,
+    )
+
+    async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
+        await _call_with_timeout(session.initialize())
+
+        start_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("start_roast_session", {})),
+        )
+        session_id = start_result.structuredContent["session"]["session_id"]
+        log_path = tmp_path / "logs" / "roasts" / session_id / "roast.jsonl"
+        assert _telemetry_row_count(log_path) == 0
+
+        state_result = cast(
+            Any,
+            await _call_with_timeout(
+                session.call_tool("get_roast_state", {"session_id": session_id})
+            ),
+        )
+
+        assert state_result.structuredContent["session_id"] == session_id
+        state_log_rows = [
+            json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()
+        ]
+        assert len([row for row in state_log_rows if row["type"] == "telemetry"]) == 1
+
+
 def test_stdio_server_rejects_manual_first_crack_override_when_disabled(tmp_path: Path) -> None:
     asyncio.run(_assert_manual_override_disabled(tmp_path))
 
@@ -604,6 +722,50 @@ class _FailingSafetyDriver:
         raise RuntimeError("driver offline")
 
 
+class _CountingDriver:
+    """Mock-safe driver that counts autonomous state reads."""
+
+    name = "mock"
+
+    def __init__(self) -> None:
+        self.read_count = 0
+        self.emergency_stop_called = False
+
+    def read_state(self) -> RoasterState:
+        """Return incrementing deterministic telemetry."""
+        self.read_count += 1
+        return RoasterState(
+            driver="mock",
+            connected=True,
+            bean_temp_c=150.0 + self.read_count,
+            env_temp_c=200.0 + self.read_count,
+            heat_level_percent=0,
+            fan_level_percent=0,
+            cooling_on=False,
+        )
+
+    def emergency_stop(self, *, reason: str) -> EmergencyStopResult:
+        """Record fail-closed safety invocation."""
+        _ = reason
+        self.emergency_stop_called = True
+        return EmergencyStopResult(
+            driver="mock",
+            safety_method="emergency_stop",
+            heat_level_percent=0,
+            fan_level_percent=100,
+            cooling_on=True,
+        )
+
+
+class _FailingReadDriver(_CountingDriver):
+    """Driver double that fails state reads."""
+
+    def read_state(self) -> RoasterState:
+        """Raise a deterministic read failure."""
+        self.read_count += 1
+        raise RuntimeError("read offline")
+
+
 def _build_clean_server_env(overrides: dict[str, str] | None = None) -> dict[str, str]:
     """Return a minimal subprocess environment for MCP startup tests."""
     pythonpath_parts = [str(REPO_ROOT / "src")]
@@ -625,3 +787,37 @@ def _build_clean_server_env(overrides: dict[str, str] | None = None) -> dict[str
 async def _call_with_timeout(awaitable: Awaitable[_T], timeout_seconds: float = 5.0) -> _T:
     """Fail fast if the MCP smoke test subprocess stops responding."""
     return await asyncio.wait_for(awaitable, timeout=timeout_seconds)
+
+
+def _telemetry_row_count(path: Path) -> int:
+    """Return the number of telemetry rows in an append-only JSONL log."""
+    if not path.exists():
+        return 0
+    return sum(
+        1
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if json.loads(line)["type"] == "telemetry"
+    )
+
+
+def _wait_for_condition(condition: Callable[[], bool], timeout_seconds: float = 1.0) -> None:
+    """Wait for a synchronous test condition to become true."""
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if condition():
+            return
+        time.sleep(0.005)
+    raise AssertionError("Timed out waiting for condition.")
+
+
+async def _wait_for_async_condition(
+    condition: Callable[[], bool],
+    timeout_seconds: float = 2.0,
+) -> None:
+    """Wait for an async test condition to become true."""
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if condition():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("Timed out waiting for condition.")


### PR DESCRIPTION
## Summary
- Add a session-owned autonomous telemetry sampler to the MCP runtime.
- Start the sampler from `start_roast_session`, append samples through the existing `RoastSessionStore` telemetry path, and keep `get_roast_state` as an opportunistic refresh path.
- Fail closed with a diagnosable fault event on sampler driver-read failure and stop sampler workers on session completion/fault or MCP shutdown.
- Update durable state docs and add the E5-S10 session summary.

## Scope Notes
- Preserves append-only JSONL runtime logging, the CSV schema, the summary schema, the one-session `RoastSessionStore` boundary, mock-safe CI, MCP semantics, fail-closed safety behavior, configured-driver control/state wiring, automatic T0 behavior, session-owned first-crack runtime behavior, Hottop validation boundaries, first-crack artifact/audio boundaries, and E5-S1 through E5-S9 metric/log/export helpers.
- Does not add model training, ONNX export, Hugging Face sync, real microphone validation, live Hottop validation, end-to-end agent roast validation, broad release validation, package metadata, PyPI publishing, or MCP Registry work.

## Tests
- `./.venv/bin/python -m pytest tests/test_config.py tests/test_session.py tests/test_package.py`
- `./.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_package.py`
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`
- `./.venv/bin/coffee-roaster-mcp --help`
- `./.venv/bin/coffee-roaster-mcp --version`

Closes #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added autonomous background telemetry sampling that records roaster data at configurable intervals and drives existing runtime processing (T0 / first-crack) for active sessions.
  * Implemented fail-closed safety handling for driver read failures: records diagnosable fault events, triggers a safety shutdown, and halts related processing.

* **Documentation**
  * Marked E5-S10 complete, added session summary and expanded validation/usage notes; set E6-S1 as next story.

* **Tests**
  * Expanded tests for sampling behavior, polling integration, shutdown, and driver-failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->