### PR TITLE
E6-S2: Add README MCP verification string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RoastPilot
 
+<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->
+
 RoastPilot is a spec-driven MCP server for autonomous coffee roasting.
 
 The package name is `coffee-roaster-mcp`. PyPI publishing is planned for the v0.1 release; this repository currently contains the local package scaffold and project plan.

--- a/docs/session-summaries/2026-05-24-e6-s2-readme-mcp-verification-string.md
+++ b/docs/session-summaries/2026-05-24-e6-s2-readme-mcp-verification-string.md
@@ -55,6 +55,12 @@ Full validation:
 - `./.venv/bin/coffee-roaster-mcp --help`: passed
 - `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
 
+## Usage Snapshot
+
+Operator-provided cumulative session usage:
+
+- Tokens used so far in this session: `120K used`
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E6-S2 should

--- a/docs/session-summaries/2026-05-24-e6-s2-readme-mcp-verification-string.md
+++ b/docs/session-summaries/2026-05-24-e6-s2-readme-mcp-verification-string.md
@@ -1,0 +1,65 @@
+# E6-S2 README MCP Verification String
+
+This summary captures the E6-S2 implementation, validation state, and restart
+context.
+
+## Scope
+
+Story: `E6-S2` / issue `#50`, add README MCP verification string.
+
+Branch: `feature/50-readme-mcp-verification-string`
+
+The implementation stayed inside the E6-S2 boundary:
+
+- add `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->` to `README.md`
+- add a focused README verification string check
+- preserve the existing package metadata, runtime behavior, registry metadata
+  boundary, and release workflow boundary
+
+No `server.json`, PyPI publishing, MCP Registry publishing, release workflow,
+live hardware validation, model training/export/sync, real microphone
+validation, or broad release validation was added.
+
+## Implementation Summary
+
+`README.md` now includes the hidden MCP Registry verification comment directly
+under the `RoastPilot` heading:
+
+```html
+<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->
+```
+
+`tests/test_readme.py` reads the repository README and asserts that the exact
+verification string appears once.
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E6-S2` complete and sets
+  the active story to `E6-S3`.
+- `docs/state/registry.md` says the next story is `E6-S3: add server.json`.
+
+## Validation
+
+Focused validation:
+
+- `./.venv/bin/python -m pytest tests/test_readme.py`: 1 passed
+- `./.venv/bin/python -m ruff check README.md tests/test_readme.py`: passed
+- `./.venv/bin/python -m ruff format --check tests/test_readme.py`: passed
+
+Full validation:
+
+- `./.venv/bin/python -m pytest`: 344 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+## Restart Prompt
+
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E6-S2 should
+be checked first. If it has merged, verify issue #50 is closed, check out
+`main`, run `git pull --ff-only origin main`, then begin E6-S3 from updated
+main on the appropriate `feature/51-...` branch after reading the registry,
+active epic, this summary, and GitHub issue #51. Keep E6-S3 scoped to
+`server.json` unless issue #51 explicitly expands the work.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E6-S2`
-- Current target: Add README MCP verification string
+- Active story: `E6-S3`
+- Current target: Add `server.json`
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -296,6 +296,13 @@ The first implementation milestone is a mock vertical slice that requires no roa
   the human-facing title in the package summary. The distribution includes a
   `py.typed` marker, and tests inspect installed package metadata plus the
   console script entry point.
+- `E6-S2` adds the MCP Registry README verification string only. The README now
+  includes `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`, and a
+  focused README test pins that the verification string appears exactly once.
+  This story does not add `server.json`, PyPI publishing, MCP Registry
+  publishing, release workflow behavior, live hardware validation, model
+  training/export/sync, real microphone validation, or broad release
+  validation.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -641,7 +648,7 @@ Goal: make RoastPilot installable and discoverable through PyPI and the MCP Regi
 - [x] `E6-S1` Add PyPI package metadata.
   - Done when package metadata is complete for `coffee-roaster-mcp`.
 
-- [ ] `E6-S2` Add README MCP verification string.
+- [x] `E6-S2` Add README MCP verification string.
   - Done when README includes `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`.
 
 - [ ] `E6-S3` Add `server.json`.
@@ -1622,6 +1629,25 @@ After completing a story:
   - Inspected built wheel metadata and confirmed package name, `RoastPilot`
     summary, Python requirement, project URLs, and classifiers.
   - Ran `./.venv/bin/python -m pytest`: 343 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E6-S2:
+  - Added the exact MCP Registry README verification string:
+    `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`.
+  - Added focused README coverage proving the verification string appears
+    exactly once.
+  - Kept `server.json`, PyPI publishing, MCP Registry publishing, release
+    workflow behavior, live hardware validation, model training/export/sync,
+    real microphone validation, and broad release validation out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_readme.py`: 1 passed.
+  - Ran `./.venv/bin/python -m ruff check README.md tests/test_readme.py`:
+    passed.
+  - Ran `./.venv/bin/python -m ruff format --check tests/test_readme.py`:
+    passed.
+  - Ran `./.venv/bin/python -m pytest`: 344 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -259,13 +259,20 @@ title in the package summary. The distribution includes a `py.typed` marker,
 and package metadata tests inspect the installed distribution metadata plus the
 console script entry point.
 
+E6-S2 added the exact MCP Registry README verification string
+`<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->` and focused README
+coverage that verifies the string appears once. `server.json`, PyPI publishing,
+MCP Registry publishing, release workflow behavior, live hardware validation,
+model training/export/sync, real microphone validation, and broad release
+validation remain out of scope for E6-S2.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E6-S2: add README MCP verification string.
+The next story is E6-S3: add `server.json`.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,13 @@
+"""README coverage for public MCP Registry verification metadata."""
+
+from pathlib import Path
+
+
+def test_readme_includes_mcp_verification_string() -> None:
+    """Check the README includes the MCP Registry package-name proof."""
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    verification_string = "<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->"
+
+    readme_text = readme.read_text(encoding="utf-8")
+
+    assert readme_text.count(verification_string) == 1


### PR DESCRIPTION
## Summary
- Add the MCP Registry README verification string for `io.github.syamaner/coffee-roaster-mcp`
- Add focused README coverage that asserts the verification string appears exactly once
- Update durable state docs and add the E6-S2 session summary

## Validation
- `./.venv/bin/python -m pytest tests/test_readme.py` - 1 passed
- `./.venv/bin/python -m ruff check README.md tests/test_readme.py` - passed
- `./.venv/bin/python -m ruff format --check tests/test_readme.py` - passed
- `./.venv/bin/python -m pytest` - 344 passed
- `./.venv/bin/python -m ruff check .` - passed
- `./.venv/bin/python -m ruff format --check .` - passed
- `./.venv/bin/python -m pyright` - 0 errors
- `./.venv/bin/coffee-roaster-mcp --help` - passed
- `./.venv/bin/coffee-roaster-mcp --version` - `coffee-roaster-mcp 0.1.0`

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README includes an MCP Registry verification metadata comment; project docs updated with a session summary, epic state changes (E6‑S2 completed, next E6‑S3) and recorded validation steps/state transitions.
* **Tests**
  * Added an automated test that asserts the verification string appears exactly once in the README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->