### PR TITLE
E6-S3: Add server.json

### DIFF
--- a/docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md
+++ b/docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md
@@ -215,6 +215,15 @@ Example `summary.json`:
 
 - Source repo target: `github.com/syamaner/coffee-roaster-mcp`.
 - Publish package to PyPI as `coffee-roaster-mcp`.
+- Before live publishing, confirm the release owner has a PyPI account, PyPI
+  2FA and recovery codes are configured, and the `coffee-roaster-mcp` project
+  name is owned or reserved.
+- Prefer PyPI Trusted Publishing from GitHub Actions for release uploads.
+  Document the exact GitHub repository, workflow filename, release environment,
+  and tag-triggered job configured in PyPI. Use API tokens only as a documented
+  fallback with explicit GitHub secret names and rotation notes.
+- If TestPyPI rehearsal is included, confirm the release owner also has a
+  TestPyPI account and matching Trusted Publishing or token fallback setup.
 - Add console entrypoint `coffee-roaster-mcp`.
 - Add root `server.json` for MCP Registry.
 - Register as `io.github.syamaner/coffee-roaster-mcp`.
@@ -374,6 +383,16 @@ Do not rely on code review to validate coffee roasting safety, Hottop hardware b
 - Confirm package builds cleanly.
 - Confirm `server.json.version` matches package version.
 - Confirm README contains MCP verification string.
+- Confirm release owner can access PyPI and, if used, TestPyPI.
+- Confirm PyPI account has 2FA and recovery codes configured.
+- Confirm `coffee-roaster-mcp` project ownership or reservation on PyPI.
+- Confirm PyPI Trusted Publishing is configured for the GitHub repository,
+  release workflow filename, release environment, and tag-triggered publishing
+  job.
+- If Trusted Publishing is not usable, confirm token fallback secret names,
+  least-privilege scope, and rotation notes.
+- Confirm GitHub release environment approvals and protected-tag rules before
+  live publish.
 - Pin HF model revision before release.
 - Publish package to TestPyPI if desired.
 - Install package from TestPyPI and run mock smoke test.
@@ -486,7 +505,10 @@ Stories:
 - Add PyPI metadata.
 - Add README verification string.
 - Add `server.json`.
-- Add release workflow.
+- Add release workflow, including PyPI/TestPyPI account prerequisites, PyPI
+  Trusted Publishing setup, fallback-token documentation, protected release
+  environment rules, dry-run validation, PyPI publish, and registry metadata
+  publish after PyPI succeeds.
 - Add MCP Registry publishing verification spike.
 - Document install and hardware setup.
 

--- a/docs/session-summaries/2026-05-24-e6-s3-server-json.md
+++ b/docs/session-summaries/2026-05-24-e6-s3-server-json.md
@@ -1,0 +1,74 @@
+# E6-S3 Server JSON
+
+This summary captures the E6-S3 implementation, validation state, and restart
+context.
+
+## Scope
+
+Story: `E6-S3` / issue `#51`, add `server.json`.
+
+Branch: `feature/51-add-server-json`
+
+The implementation stayed inside the E6-S3 boundary:
+
+- add root `server.json`
+- declare MCP Registry name `io.github.syamaner/coffee-roaster-mcp`
+- declare title `RoastPilot`
+- declare PyPI package `coffee-roaster-mcp`
+- declare stdio transport
+- add a focused schema validation check
+
+No version alignment automation, PyPI publishing, MCP Registry publishing,
+release workflow behavior, live hardware validation, model training/export/sync,
+real microphone validation, or broad release validation was added.
+
+## Implementation Summary
+
+`server.json` now declares the current MCP Registry schema URI, server metadata,
+repository metadata, and one PyPI package entry:
+
+- `name`: `io.github.syamaner/coffee-roaster-mcp`
+- `title`: `RoastPilot`
+- `package`: `coffee-roaster-mcp`
+- `runtimeHint`: `uvx`
+- `transport.type`: `stdio`
+
+`tests/test_server_json.py` loads the repository `server.json`, validates it
+against the relevant MCP Registry schema constraints, and pins the E6-S3
+acceptance fields. `jsonschema` is declared in the dev dependency group for the
+schema validation test.
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E6-S3` complete and sets
+  the active story to `E6-S4`.
+- `docs/state/registry.md` says the next story is `E6-S4: add a version
+  alignment check`.
+
+## Validation
+
+Focused validation:
+
+- `./.venv/bin/python -m pytest tests/test_server_json.py`: 2 passed
+- `./.venv/bin/python -m ruff check tests/test_server_json.py pyproject.toml`:
+  passed
+- `./.venv/bin/python -m ruff format --check tests/test_server_json.py`: passed
+- `./.venv/bin/python -m pyright tests/test_server_json.py`: 0 errors
+
+Full validation:
+
+- `./.venv/bin/python -m pytest`: 346 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+## Restart Prompt
+
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E6-S3 should
+be checked first. If it has merged, verify issue #51 is closed, check out
+`main`, run `git pull --ff-only origin main`, then begin E6-S4 from updated
+main on the appropriate `feature/52-...` branch after reading the registry,
+active epic, this summary, and the GitHub issue for E6-S4. Keep E6-S4 scoped to
+version alignment unless the issue explicitly expands the work.

--- a/docs/session-summaries/2026-05-24-e6-s3-server-json.md
+++ b/docs/session-summaries/2026-05-24-e6-s3-server-json.md
@@ -49,7 +49,7 @@ Durable state updates:
 
 Focused validation:
 
-- `./.venv/bin/python -m pytest tests/test_server_json.py`: 2 passed
+- `./.venv/bin/python -m pytest tests/test_server_json.py`: 3 passed
 - `./.venv/bin/python -m ruff check tests/test_server_json.py pyproject.toml`:
   passed
 - `./.venv/bin/python -m ruff format --check tests/test_server_json.py`: passed
@@ -57,7 +57,7 @@ Focused validation:
 
 Full validation:
 
-- `./.venv/bin/python -m pytest`: 346 passed
+- `./.venv/bin/python -m pytest`: 347 passed
 - `./.venv/bin/python -m ruff check .`: passed
 - `./.venv/bin/python -m ruff format --check .`: passed
 - `./.venv/bin/python -m pyright`: 0 errors
@@ -75,6 +75,28 @@ Publishing is not usable, release environment approvals, protected-tag rules,
 and dry-run validation before live publishing.
 
 GitHub issue `#53` was updated with the same detailed E6-S5 requirements.
+
+## Review Agent Comparison
+
+PR `#131` received review comments from CodeRabbit and Codex.
+
+- CodeRabbit posted one valid actionable inline comment on
+  `tests/test_server_json.py`: `Draft7Validator(...).validate(...)` does not
+  enforce JSON Schema `format: uri` without a format checker. It also posted a
+  pre-merge docstring-coverage warning, but that warning does not map to the
+  repository's configured local gates for this PR.
+- Codex posted the same valid actionable inline comment, with a more direct
+  explanation that malformed URI fields such as `websiteUrl` or repository URLs
+  could otherwise pass CI and fail later during registry publishing.
+
+Outcome: both agents found the same real issue. Codex's comment was cleaner and
+more project-relevant. CodeRabbit's actionable comment was useful, but its
+additional docstring-coverage warning was noisy for this repository because the
+current required gates are `pytest`, `ruff`, `pyright`, and CLI smoke checks.
+
+Action taken: `tests/test_server_json.py` now constructs `Draft7Validator` with
+a URI `FormatChecker` and includes a malformed-URI regression test so URI fields
+are validated by the schema test.
 
 ## Restart Prompt
 

--- a/docs/session-summaries/2026-05-24-e6-s3-server-json.md
+++ b/docs/session-summaries/2026-05-24-e6-s3-server-json.md
@@ -64,6 +64,18 @@ Full validation:
 - `./.venv/bin/coffee-roaster-mcp --help`: passed
 - `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
 
+## Follow-Up State Clarification
+
+After PR creation, E6-S5 was clarified to include the operator prerequisites for
+PyPI publishing. The active epic and overall plan now require PyPI account
+access, optional TestPyPI access, PyPI project ownership or reservation, PyPI
+two-factor authentication and recovery codes, PyPI Trusted Publishing setup for
+the GitHub release workflow, fallback-token documentation only if Trusted
+Publishing is not usable, release environment approvals, protected-tag rules,
+and dry-run validation before live publishing.
+
+GitHub issue `#53` was updated with the same detailed E6-S5 requirements.
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E6-S3 should

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -667,7 +667,22 @@ Goal: make RoastPilot installable and discoverable through PyPI and the MCP Regi
   - Done when package version and `server.json.version` cannot drift unnoticed.
 
 - [ ] `E6-S5` Add release workflow.
-  - Done when CI can build, test, publish to PyPI, and publish registry metadata after tag release.
+  - Done when CI can build, test, publish to PyPI, and publish registry
+    metadata after tag release.
+  - Operator prerequisites must be documented before workflow implementation:
+    - PyPI account exists for the release owner.
+    - TestPyPI account exists if the workflow supports TestPyPI rehearsal.
+    - PyPI project name `coffee-roaster-mcp` ownership is confirmed or reserved.
+    - PyPI two-factor authentication and recovery codes are configured.
+    - PyPI Trusted Publishing is configured for this GitHub repository,
+      release workflow filename, release environment, and tag-triggered
+      publishing job.
+    - A token-based fallback is documented only if Trusted Publishing is not
+      usable, including the exact GitHub secret names and rotation notes.
+    - Required GitHub release environment approvals and protected-tag rules are
+      documented before live publishing is enabled.
+    - Workflow dry run proves build/test/package steps without uploading to
+      production PyPI.
 
 - [ ] `E6-S6` Run MCP Registry publishing verification spike.
   - Done when `server.json`, PyPI verification, and `mcp-publisher` flow are documented and tested before v0.1 release.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -1689,13 +1689,13 @@ After completing a story:
     publishing, release workflow behavior, live hardware validation, model
     training/export/sync, real microphone validation, and broad release
     validation out of scope.
-  - Ran `./.venv/bin/python -m pytest tests/test_server_json.py`: 2 passed.
+  - Ran `./.venv/bin/python -m pytest tests/test_server_json.py`: 3 passed.
   - Ran `./.venv/bin/python -m ruff check tests/test_server_json.py pyproject.toml`:
     passed.
   - Ran `./.venv/bin/python -m ruff format --check tests/test_server_json.py`:
     passed.
   - Ran `./.venv/bin/python -m pyright tests/test_server_json.py`: 0 errors.
-  - Ran `./.venv/bin/python -m pytest`: 346 passed.
+  - Ran `./.venv/bin/python -m pytest`: 347 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E6-S3`
-- Current target: Add `server.json`
+- Active story: `E6-S4`
+- Current target: Add version alignment check
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -303,6 +303,15 @@ The first implementation milestone is a mock vertical slice that requires no roa
   publishing, release workflow behavior, live hardware validation, model
   training/export/sync, real microphone validation, or broad release
   validation.
+- `E6-S3` adds the root MCP Registry `server.json` only. Registry metadata now
+  declares the server name `io.github.syamaner/coffee-roaster-mcp`, display
+  title `RoastPilot`, PyPI package `coffee-roaster-mcp`, package runtime hint
+  `uvx`, stdio transport, repository metadata, and the current MCP schema URI.
+  Focused coverage validates the metadata shape against the relevant MCP
+  Registry schema constraints and pins the E6-S3 acceptance fields. Version
+  alignment automation, PyPI publishing, MCP Registry publishing, release
+  workflow behavior, live hardware validation, model training/export/sync, real
+  microphone validation, and broad release validation remain later stories.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -651,7 +660,7 @@ Goal: make RoastPilot installable and discoverable through PyPI and the MCP Regi
 - [x] `E6-S2` Add README MCP verification string.
   - Done when README includes `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`.
 
-- [ ] `E6-S3` Add `server.json`.
+- [x] `E6-S3` Add `server.json`.
   - Done when registry metadata uses name `io.github.syamaner/coffee-roaster-mcp`, title `RoastPilot`, package `coffee-roaster-mcp`, and stdio transport.
 
 - [ ] `E6-S4` Add version alignment check.
@@ -1648,6 +1657,30 @@ After completing a story:
   - Ran `./.venv/bin/python -m ruff format --check tests/test_readme.py`:
     passed.
   - Ran `./.venv/bin/python -m pytest`: 344 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E6-S3:
+  - Added root `server.json` with MCP Registry metadata for
+    `io.github.syamaner/coffee-roaster-mcp`.
+  - Declared title `RoastPilot`, PyPI package `coffee-roaster-mcp`, runtime hint
+    `uvx`, and stdio transport.
+  - Added focused schema and acceptance coverage in `tests/test_server_json.py`.
+  - Declared `jsonschema` in the dev dependency group for the schema validation
+    test.
+  - Kept version alignment automation, PyPI publishing, MCP Registry
+    publishing, release workflow behavior, live hardware validation, model
+    training/export/sync, real microphone validation, and broad release
+    validation out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_server_json.py`: 2 passed.
+  - Ran `./.venv/bin/python -m ruff check tests/test_server_json.py pyproject.toml`:
+    passed.
+  - Ran `./.venv/bin/python -m ruff format --check tests/test_server_json.py`:
+    passed.
+  - Ran `./.venv/bin/python -m pyright tests/test_server_json.py`: 0 errors.
+  - Ran `./.venv/bin/python -m pytest`: 346 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -266,13 +266,22 @@ MCP Registry publishing, release workflow behavior, live hardware validation,
 model training/export/sync, real microphone validation, and broad release
 validation remain out of scope for E6-S2.
 
+E6-S3 added the root MCP Registry `server.json` with metadata for
+`io.github.syamaner/coffee-roaster-mcp`: title `RoastPilot`, PyPI package
+`coffee-roaster-mcp`, runtime hint `uvx`, stdio transport, repository metadata,
+and the current MCP schema URI. Focused schema and acceptance coverage now pins
+the story fields. Version alignment automation, PyPI publishing, MCP Registry
+publishing, release workflow behavior, live hardware validation, model
+training/export/sync, real microphone validation, and broad release validation
+remain later stories.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E6-S3: add `server.json`.
+The next story is E6-S4: add a version alignment check.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ coffee-roaster-mcp = "coffee_roaster_mcp.cli:main"
 [dependency-groups]
 dev = [
   "build>=1.2",
+  "jsonschema>=4.0,<5",
   "pytest>=8.0",
   "pytest-cov>=5.0",
   "ruff>=0.8",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.syamaner/coffee-roaster-mcp",
+  "title": "RoastPilot",
+  "description": "RoastPilot controls coffee roasting sessions through local stdio MCP tools and exports logs.",
+  "version": "0.1.0",
+  "websiteUrl": "https://github.com/syamaner/coffee-roaster-mcp#readme",
+  "repository": {
+    "url": "https://github.com/syamaner/coffee-roaster-mcp",
+    "source": "github",
+    "id": "1228141156"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "coffee-roaster-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/tests/test_server_json.py
+++ b/tests/test_server_json.py
@@ -1,0 +1,89 @@
+"""MCP Registry server.json metadata coverage."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft7Validator  # type: ignore[import-untyped]
+
+SCHEMA_URI = "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+
+SERVER_JSON_SCHEMA: dict[str, Any] = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": SCHEMA_URI,
+    "type": "object",
+    "required": ["name", "description", "version"],
+    "properties": {
+        "$schema": {"type": "string", "format": "uri"},
+        "name": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 200,
+            "pattern": r"^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$",
+        },
+        "title": {"type": "string", "minLength": 1, "maxLength": 100},
+        "description": {"type": "string", "minLength": 1, "maxLength": 100},
+        "version": {"type": "string", "maxLength": 255},
+        "websiteUrl": {"type": "string", "format": "uri"},
+        "repository": {
+            "type": "object",
+            "required": ["url", "source"],
+            "properties": {
+                "url": {"type": "string", "format": "uri"},
+                "source": {"type": "string"},
+                "id": {"type": "string"},
+            },
+        },
+        "packages": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["registryType", "identifier", "transport"],
+                "properties": {
+                    "registryType": {"type": "string"},
+                    "identifier": {"type": "string"},
+                    "version": {"type": "string", "minLength": 1, "not": {"const": "latest"}},
+                    "runtimeHint": {"type": "string"},
+                    "transport": {
+                        "type": "object",
+                        "required": ["type"],
+                        "properties": {
+                            "type": {"enum": ["stdio"]},
+                        },
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+def test_server_json_validates_against_mcp_registry_schema() -> None:
+    """Validate server.json against the current MCP Registry schema constraints."""
+    server_json = _load_server_json()
+
+    Draft7Validator(SERVER_JSON_SCHEMA).validate(server_json)  # type: ignore[reportUnknownMemberType]
+
+
+def test_server_json_declares_roastpilot_pypi_stdio_package() -> None:
+    """Check server.json declares the expected RoastPilot PyPI stdio metadata."""
+    server_json = _load_server_json()
+    packages = server_json["packages"]
+
+    assert server_json["$schema"] == SCHEMA_URI
+    assert server_json["name"] == "io.github.syamaner/coffee-roaster-mcp"
+    assert server_json["title"] == "RoastPilot"
+    assert packages == [
+        {
+            "registryType": "pypi",
+            "identifier": "coffee-roaster-mcp",
+            "version": "0.1.0",
+            "runtimeHint": "uvx",
+            "transport": {"type": "stdio"},
+        }
+    ]
+
+
+def _load_server_json() -> dict[str, Any]:
+    path = Path(__file__).resolve().parents[1] / "server.json"
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/tests/test_server_json.py
+++ b/tests/test_server_json.py
@@ -3,10 +3,27 @@
 import json
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
-from jsonschema import Draft7Validator  # type: ignore[import-untyped]
+import pytest
+from jsonschema import (  # type: ignore[import-untyped]
+    Draft7Validator,
+    FormatChecker,
+    ValidationError,
+)
 
 SCHEMA_URI = "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+URI_FORMAT_CHECKER = FormatChecker()
+
+
+def _is_uri(value: object) -> bool:
+    if not isinstance(value, str):
+        return True
+    parsed = urlparse(value)
+    return bool(parsed.scheme) and not any(character.isspace() for character in value)
+
+
+URI_FORMAT_CHECKER.checks("uri")(_is_uri)
 
 SERVER_JSON_SCHEMA: dict[str, Any] = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -62,7 +79,7 @@ def test_server_json_validates_against_mcp_registry_schema() -> None:
     """Validate server.json against the current MCP Registry schema constraints."""
     server_json = _load_server_json()
 
-    Draft7Validator(SERVER_JSON_SCHEMA).validate(server_json)  # type: ignore[reportUnknownMemberType]
+    _validate_server_json(server_json)
 
 
 def test_server_json_declares_roastpilot_pypi_stdio_package() -> None:
@@ -84,6 +101,22 @@ def test_server_json_declares_roastpilot_pypi_stdio_package() -> None:
     ]
 
 
+def test_server_json_schema_rejects_malformed_uri_fields() -> None:
+    """Check schema validation enforces URI formats for registry metadata."""
+    server_json = _load_server_json()
+    server_json["websiteUrl"] = "not a uri"
+
+    with pytest.raises(ValidationError):
+        _validate_server_json(server_json)
+
+
 def _load_server_json() -> dict[str, Any]:
     path = Path(__file__).resolve().parents[1] / "server.json"
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_server_json(server_json: dict[str, Any]) -> None:
+    Draft7Validator(
+        SERVER_JSON_SCHEMA,
+        format_checker=URI_FORMAT_CHECKER,
+    ).validate(server_json)  # type: ignore[reportUnknownMemberType]


### PR DESCRIPTION
## Summary
- Add root `server.json` for MCP Registry metadata using `io.github.syamaner/coffee-roaster-mcp`, title `RoastPilot`, PyPI package `coffee-roaster-mcp`, and stdio transport
- Add focused `server.json` schema and acceptance coverage, including URI format enforcement for registry metadata
- Update durable state docs and add the E6-S3 session summary
- Clarify future E6-S5 PyPI release-workflow prerequisites in local state docs and issue #53, including PyPI/TestPyPI account ownership, Trusted Publishing, fallback-token documentation, release environment approvals, protected-tag rules, and dry-run expectations
- Record CodeRabbit vs Codex review-agent comparison in the E6-S3 session summary

## Validation
- `./.venv/bin/python -m pytest tests/test_server_json.py` - 3 passed
- `./.venv/bin/python -m ruff check tests/test_server_json.py pyproject.toml` - passed
- `./.venv/bin/python -m ruff format --check tests/test_server_json.py` - passed
- `./.venv/bin/python -m pyright tests/test_server_json.py` - 0 errors
- `./.venv/bin/python -m pytest` - 347 passed
- `./.venv/bin/python -m ruff check .` - passed
- `./.venv/bin/python -m ruff format --check .` - passed
- `./.venv/bin/python -m pyright` - 0 errors
- `./.venv/bin/coffee-roaster-mcp --help` - passed
- `./.venv/bin/coffee-roaster-mcp --version` - `coffee-roaster-mcp 0.1.0`

Closes #51