### PR TITLE
E6-S4: Add version alignment check

### DIFF
--- a/docs/session-summaries/2026-05-24-e6-s4-version-alignment.md
+++ b/docs/session-summaries/2026-05-24-e6-s4-version-alignment.md
@@ -54,6 +54,10 @@ Full validation:
 - `./.venv/bin/coffee-roaster-mcp --help`: passed
 - `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
 
+## Context Usage
+
+- Context token usage snapshot: `123K used`
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E6-S4 should

--- a/docs/session-summaries/2026-05-24-e6-s4-version-alignment.md
+++ b/docs/session-summaries/2026-05-24-e6-s4-version-alignment.md
@@ -1,0 +1,65 @@
+# E6-S4 Version Alignment
+
+This summary captures the E6-S4 implementation, validation state, and restart
+context.
+
+## Scope
+
+Story: `E6-S4` / issue `#52`, add version alignment check.
+
+Branch: `feature/52-version-alignment-check`
+
+The implementation stayed inside the E6-S4 boundary:
+
+- add a focused version alignment test
+- ensure top-level `server.json.version` matches the package version
+- ensure the PyPI package entry version in `server.json` matches the package
+  version
+
+No PyPI publishing, MCP Registry publishing, release workflow behavior, live
+hardware validation, model training/export/sync, real microphone validation, or
+broad release validation was added.
+
+## Implementation Summary
+
+`tests/test_server_json.py` now imports `coffee_roaster_mcp.__version__` and
+checks that both registry version fields in `server.json` equal the package
+version:
+
+- `server.json.version`
+- `server.json.packages[0].version`
+
+This keeps the package version and registry metadata from drifting unnoticed
+while preserving the existing E6-S3 schema and acceptance coverage.
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E6-S4` complete and sets
+  the active story to `E6-S5`.
+- `docs/state/registry.md` says the next story is `E6-S5: add the release
+  workflow`.
+
+## Validation
+
+Focused validation:
+
+- `./.venv/bin/python -m pytest tests/test_server_json.py`: 4 passed
+
+Full validation:
+
+- `./.venv/bin/python -m pytest`: 348 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+## Restart Prompt
+
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E6-S4 should
+be checked first. If it has merged, verify issue #52 is closed, check out
+`main`, run `git pull --ff-only origin main`, then begin E6-S5 from updated
+main on the appropriate `feature/53-...` branch after reading the registry,
+active epic, this summary, and the GitHub issue for E6-S5. Keep E6-S5 scoped to
+the release workflow and operator prerequisites unless the issue explicitly
+expands the work.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E6-S4`
-- Current target: Add version alignment check
+- Active story: `E6-S5`
+- Current target: Add release workflow
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -308,10 +308,18 @@ The first implementation milestone is a mock vertical slice that requires no roa
   title `RoastPilot`, PyPI package `coffee-roaster-mcp`, package runtime hint
   `uvx`, stdio transport, repository metadata, and the current MCP schema URI.
   Focused coverage validates the metadata shape against the relevant MCP
-  Registry schema constraints and pins the E6-S3 acceptance fields. Version
-  alignment automation, PyPI publishing, MCP Registry publishing, release
-  workflow behavior, live hardware validation, model training/export/sync, real
-  microphone validation, and broad release validation remain later stories.
+  Registry schema constraints, including URI format validation, and pins the
+  E6-S3 acceptance fields. Version alignment automation, PyPI publishing, MCP
+  Registry publishing, release workflow behavior, live hardware validation,
+  model training/export/sync, real microphone validation, and broad release
+  validation remain later stories.
+- `E6-S4` adds the version alignment check only. Focused `server.json` coverage
+  now compares both top-level `server.json.version` and the PyPI package entry
+  version against `coffee_roaster_mcp.__version__`, so registry metadata and
+  package metadata cannot drift unnoticed. PyPI publishing, MCP Registry
+  publishing, release workflow behavior, live hardware validation, model
+  training/export/sync, real microphone validation, and broad release validation
+  remain later stories.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -663,7 +671,7 @@ Goal: make RoastPilot installable and discoverable through PyPI and the MCP Regi
 - [x] `E6-S3` Add `server.json`.
   - Done when registry metadata uses name `io.github.syamaner/coffee-roaster-mcp`, title `RoastPilot`, package `coffee-roaster-mcp`, and stdio transport.
 
-- [ ] `E6-S4` Add version alignment check.
+- [x] `E6-S4` Add version alignment check.
   - Done when package version and `server.json.version` cannot drift unnoticed.
 
 - [ ] `E6-S5` Add release workflow.
@@ -852,6 +860,22 @@ After completing a story:
   - Wired the MCP server lifespan to own one authoritative `RoastSessionStore` for later tool stories.
   - Added `tests/test_session.py` covering session creation, single-owner enforcement, clean stop semantics, and rolling telemetry retention.
   - Ran `./.venv/bin/python -m pytest`: 24 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+
+- Validation run for E6-S4:
+  - Added focused version alignment coverage in `tests/test_server_json.py`.
+  - Pinned top-level `server.json.version` to `coffee_roaster_mcp.__version__`.
+  - Pinned the PyPI package entry version in `server.json` to
+    `coffee_roaster_mcp.__version__`.
+  - Kept PyPI publishing, MCP Registry publishing, release workflow behavior,
+    live hardware validation, model training/export/sync, real microphone
+    validation, and broad release validation out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_server_json.py`: 4 passed.
+  - Ran `./.venv/bin/python -m pytest`: 348 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -270,8 +270,16 @@ E6-S3 added the root MCP Registry `server.json` with metadata for
 `io.github.syamaner/coffee-roaster-mcp`: title `RoastPilot`, PyPI package
 `coffee-roaster-mcp`, runtime hint `uvx`, stdio transport, repository metadata,
 and the current MCP schema URI. Focused schema and acceptance coverage now pins
-the story fields. Version alignment automation, PyPI publishing, MCP Registry
-publishing, release workflow behavior, live hardware validation, model
+the story fields, including URI format validation for registry URL fields.
+Version alignment automation, PyPI publishing, MCP Registry publishing, release
+workflow behavior, live hardware validation, model training/export/sync, real
+microphone validation, and broad release validation remain later stories.
+
+E6-S4 added the version alignment check only. Focused `server.json` coverage
+now compares both top-level `server.json.version` and the PyPI package entry
+version against the package `coffee_roaster_mcp.__version__`, so registry
+metadata and package metadata cannot drift unnoticed. PyPI publishing, MCP
+Registry publishing, release workflow behavior, live hardware validation, model
 training/export/sync, real microphone validation, and broad release validation
 remain later stories.
 
@@ -281,7 +289,7 @@ first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E6-S4: add a version alignment check.
+The next story is E6-S5: add the release workflow.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/tests/test_server_json.py
+++ b/tests/test_server_json.py
@@ -12,6 +12,8 @@ from jsonschema import (  # type: ignore[import-untyped]
     ValidationError,
 )
 
+from coffee_roaster_mcp import __version__
+
 SCHEMA_URI = "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
 URI_FORMAT_CHECKER = FormatChecker()
 
@@ -108,6 +110,14 @@ def test_server_json_schema_rejects_malformed_uri_fields() -> None:
 
     with pytest.raises(ValidationError):
         _validate_server_json(server_json)
+
+
+def test_server_json_versions_match_package_version() -> None:
+    """Check registry metadata versions stay aligned with the package version."""
+    server_json = _load_server_json()
+
+    assert server_json["version"] == __version__
+    assert server_json["packages"][0]["version"] == __version__
 
 
 def _load_server_json() -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- add focused server.json version alignment coverage
- pin top-level server.json.version and the PyPI package entry version to coffee_roaster_mcp.__version__
- update E6 state docs and add the E6-S4 session summary

## Scope
- version alignment only for issue #52
- no PyPI publishing, MCP Registry publishing, release workflow behavior, live hardware validation, model training/export/sync, real microphone validation, or broad release validation

## Validation
- ./.venv/bin/python -m pytest tests/test_server_json.py: 4 passed
- ./.venv/bin/python -m pytest: 348 passed
- ./.venv/bin/python -m ruff check .: passed
- ./.venv/bin/python -m ruff format --check .: passed
- ./.venv/bin/python -m pyright: 0 errors
- ./.venv/bin/coffee-roaster-mcp --help: passed
- ./.venv/bin/coffee-roaster-mcp --version: coffee-roaster-mcp 0.1.0

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated verification ensuring registry metadata versions match the published package version.

* **Documentation**
  * Added a session summary documenting the version-alignment validation, test results, and restart instructions.
  * Updated epic/state registry notes to mark the version-alignment story complete and advance the project to the next story (release workflow).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->