### PR TITLE
E6-S5: Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,13 @@ jobs:
               sys.exit(1)
 
           package = packages[0]
+          if not isinstance(package, dict) or not isinstance(package.get("version"), str):
+              print(
+                  "server.json packages[0] must be an object with a string 'version' field.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
           if package["version"] != version:
               print("server.json package version must match the package version.", file=sys.stderr)
               sys.exit(1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -58,10 +60,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
@@ -102,10 +106,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
@@ -119,7 +125,7 @@ jobs:
         run: python -m build
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: python-package-distributions
           path: dist/
@@ -133,7 +139,7 @@ jobs:
 
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: python-package-distributions
           path: dist/
@@ -160,13 +166,13 @@ jobs:
 
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
   publish-mcp-registry:
     name: Publish MCP Registry
@@ -180,11 +186,21 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install mcp-publisher
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          set -euo pipefail
+          MCP_PUBLISHER_VERSION="v1.7.9"
+          MCP_PUBLISHER_SHA256="ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac"
+          MCP_PUBLISHER_ASSET="mcp-publisher_linux_amd64.tar.gz"
+          MCP_PUBLISHER_URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/${MCP_PUBLISHER_ASSET}"
+
+          curl -fsSLo /tmp/mcp-publisher.tar.gz "${MCP_PUBLISHER_URL}"
+          echo "${MCP_PUBLISHER_SHA256}  /tmp/mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf /tmp/mcp-publisher.tar.gz mcp-publisher
           chmod +x mcp-publisher
 
       - name: Authenticate to MCP Registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,16 @@ jobs:
           from pathlib import Path
 
           ref = os.environ["GITHUB_REF"]
-          version = re.search(r'__version__ = "([^"]+)"', Path("src/coffee_roaster_mcp/__init__.py").read_text()).group(1)
+          init_path = Path("src/coffee_roaster_mcp/__init__.py")
+          version_match = re.search(r'__version__ = "([^"]+)"', init_path.read_text())
+          if version_match is None:
+              print(
+                  f"Could not find __version__ in {init_path}. Expected __version__ = \"...\".",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          version = version_match.group(1)
           server_json = json.loads(Path("server.json").read_text())
 
           expected_tag = f"refs/tags/v{version}"
@@ -91,7 +100,12 @@ jobs:
               print("server.json.version must match the package version.", file=sys.stderr)
               sys.exit(1)
 
-          package = server_json["packages"][0]
+          packages = server_json.get("packages")
+          if not isinstance(packages, list) or len(packages) == 0:
+              print("server.json must contain a non-empty 'packages' array.", file=sys.stderr)
+              sys.exit(1)
+
+          package = packages[0]
           if package["version"] != version:
               print("server.json package version must match the package version.", file=sys.stderr)
               sys.exit(1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,194 @@
+name: Release
+
+"on":
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build and validate without publishing to PyPI or the MCP Registry."
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    name: Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . --group dev
+
+      - name: Run tests
+        run: python -m pytest
+
+      - name: Run lint
+        run: python -m ruff check .
+
+      - name: Run format check
+        run: python -m ruff format --check .
+
+      - name: Run typecheck
+        run: python -m pyright --pythonpath "${pythonLocation}/bin/python"
+
+      - name: Run CLI smoke checks
+        run: |
+          coffee-roaster-mcp --help
+          coffee-roaster-mcp --version
+
+  validate-release-metadata:
+    name: Validate Release Metadata
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate release tag, package version, and registry metadata
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          ref = os.environ["GITHUB_REF"]
+          version = re.search(r'__version__ = "([^"]+)"', Path("src/coffee_roaster_mcp/__init__.py").read_text()).group(1)
+          server_json = json.loads(Path("server.json").read_text())
+
+          expected_tag = f"refs/tags/v{version}"
+          if ref.startswith("refs/tags/") and ref != expected_tag:
+              print(f"Release tag {ref!r} must match package version tag {expected_tag!r}.", file=sys.stderr)
+              sys.exit(1)
+
+          if server_json["version"] != version:
+              print("server.json.version must match the package version.", file=sys.stderr)
+              sys.exit(1)
+
+          package = server_json["packages"][0]
+          if package["version"] != version:
+              print("server.json package version must match the package version.", file=sys.stderr)
+              sys.exit(1)
+          PY
+
+  build-package:
+    name: Build Package
+    runs-on: ubuntu-latest
+    needs:
+      - checks
+      - validate-release-metadata
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . --group dev
+
+      - name: Build distribution artifacts
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+
+  release-dry-run:
+    name: Release Dry Run
+    runs-on: ubuntu-latest
+    needs: build-package
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Confirm dry-run artifacts
+        run: |
+          test -n "$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)"
+          {
+            echo "## Release Dry Run"
+            echo
+            echo "Checks passed and package artifacts were built. No upload steps ran."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish-pypi:
+    name: Publish PyPI
+    runs-on: ubuntu-latest
+    needs: build-package
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-mcp-registry:
+    name: Publish MCP Registry
+    runs-on: ubuntu-latest
+    needs: publish-pypi
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server metadata to MCP Registry
+        run: ./mcp-publisher publish --file=server.json

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,96 @@
+# RoastPilot Release Workflow
+
+This runbook documents the operator prerequisites and CI release path for
+`coffee-roaster-mcp`.
+
+The release workflow is `.github/workflows/release.yml`. It supports two paths:
+
+- Manual dry run through `workflow_dispatch` with `dry_run: true`.
+- Live release through a pushed version tag such as `v0.1.0`.
+
+## Operator Prerequisites
+
+Before enabling a live release, the release owner must confirm:
+
+- A PyPI account exists for the release owner.
+- The PyPI project name `coffee-roaster-mcp` is owned or reserved by the
+  release owner.
+- PyPI two-factor authentication is enabled and recovery codes are stored in
+  the project owner password manager.
+- PyPI Trusted Publishing is configured for:
+  - owner: `syamaner`
+  - repository: `coffee-roaster-mcp`
+  - workflow filename: `release.yml`
+  - environment: `release`
+  - tag-triggered job: `publish-pypi`
+- The GitHub environment named `release` exists and requires manual approval by
+  the release owner before deployment jobs can run.
+- Protected tag rules block unapproved creation or update of `v*` tags.
+- The release tag matches the package version exactly, for example package
+  version `0.1.0` must use tag `v0.1.0`.
+- No model weights, audio files, roast logs, serial captures, `.env` files, or
+  local IDE folders are included in the release artifact.
+
+TestPyPI rehearsal is not enabled in the workflow. If a later story adds it,
+the release owner must create a TestPyPI account and configure matching Trusted
+Publishing or token fallback before the TestPyPI job is enabled.
+
+## Token Fallback
+
+Trusted Publishing is the intended PyPI publishing path. Token publishing should
+only be enabled if Trusted Publishing is unavailable for a release.
+
+If token fallback is required:
+
+- Create a scoped PyPI project token for `coffee-roaster-mcp`.
+- Store it as the GitHub environment secret `PYPI_API_TOKEN` on the `release`
+  environment, not as a repository-wide secret.
+- Use username `__token__` and the `PYPI_API_TOKEN` value only in the PyPI
+  publish job.
+- Rotate the token immediately after any failed, interrupted, or suspected
+  exposed release attempt.
+- Delete the token fallback secret after Trusted Publishing is restored.
+
+The checked-in workflow does not reference `PYPI_API_TOKEN`; enabling fallback
+requires a deliberate workflow change.
+
+## Dry Run
+
+Run the workflow manually with `dry_run: true`.
+
+The dry run:
+
+- Runs the full test, lint, format, typecheck, and CLI smoke gate.
+- Validates release tag, package version, and `server.json` version alignment.
+- Builds the wheel and source distribution.
+- Confirms both distribution artifacts exist.
+- Does not publish to PyPI or the MCP Registry.
+
+## Live Release
+
+After all prerequisites are confirmed:
+
+1. Ensure `server.json.version`, `server.json.packages[0].version`, and
+   `coffee_roaster_mcp.__version__` are aligned.
+2. Push the matching version tag:
+
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+
+3. Approve the `release` environment deployment in GitHub Actions.
+4. Confirm the workflow completes in this order:
+   - `checks`
+   - `validate-release-metadata`
+   - `build-package`
+   - `publish-pypi`
+   - `publish-mcp-registry`
+5. Confirm PyPI shows the expected `coffee-roaster-mcp` version.
+6. Confirm the MCP Registry entry for
+   `io.github.syamaner/coffee-roaster-mcp` shows the expected PyPI package and
+   stdio transport.
+
+MCP Registry publishing runs only after the PyPI publish job succeeds. The
+registry job authenticates with GitHub OIDC through `mcp-publisher login
+github-oidc` and then publishes `server.json`.

--- a/docs/session-summaries/2026-05-24-e6-s5-release-workflow.md
+++ b/docs/session-summaries/2026-05-24-e6-s5-release-workflow.md
@@ -1,0 +1,102 @@
+# E6-S5 Release Workflow
+
+This summary captures the E6-S5 implementation, validation state, and restart
+context.
+
+## Scope
+
+Story: `E6-S5` / issue `#53`, add release workflow.
+
+Branch: `feature/53-release-workflow`
+
+The implementation stayed inside the E6-S5 boundary:
+
+- add a guarded GitHub Actions release workflow
+- run tests, lint, format, typecheck, CLI smoke checks, metadata validation, and
+  package build before any publish step
+- support a manual release dry run that proves checks and package artifacts
+  without uploading to production PyPI
+- publish to PyPI through Trusted Publishing on tag releases after `release`
+  environment approval
+- publish MCP Registry metadata with `mcp-publisher` GitHub OIDC only after the
+  PyPI publish job succeeds
+- document operator prerequisites for PyPI, Trusted Publishing, release
+  environment approvals, protected tags, TestPyPI status, and token fallback
+
+No live PyPI upload, live MCP Registry publish, TestPyPI rehearsal, hardware
+validation, model training/export/sync, real microphone validation, or broad
+release validation was performed.
+
+## Implementation Summary
+
+`.github/workflows/release.yml` now defines the release path:
+
+- `workflow_dispatch` with `dry_run: true` builds and validates without upload.
+- `push` tags matching `v*` run the live release path.
+- `checks` runs pytest, ruff, format check, pyright, and CLI smoke checks.
+- `validate-release-metadata` requires a tag such as `v0.1.0` to match
+  `coffee_roaster_mcp.__version__` and both `server.json` version fields.
+- `build-package` builds and uploads wheel/source distribution artifacts.
+- `release-dry-run` confirms wheel and source distribution artifacts exist and
+  does not run upload actions.
+- `publish-pypi` uses the `release` GitHub environment, `id-token: write`, and
+  `pypa/gh-action-pypi-publish@release/v1`.
+- `publish-mcp-registry` depends on `publish-pypi`, uses the same `release`
+  environment and OIDC permission, installs `mcp-publisher`, authenticates with
+  `github-oidc`, and publishes `server.json`.
+
+`docs/release.md` documents the operator prerequisites before live publishing:
+
+- PyPI account and project ownership/reservation for `coffee-roaster-mcp`
+- PyPI 2FA and recovery-code handling
+- Trusted Publishing configuration for repository `syamaner/coffee-roaster-mcp`,
+  workflow file `release.yml`, environment `release`, and job `publish-pypi`
+- GitHub `release` environment approvals
+- protected `v*` tag rules
+- TestPyPI not enabled in this workflow
+- token fallback with exact environment secret name `PYPI_API_TOKEN`
+
+`tests/test_release_workflow.py` pins the release workflow and runbook contract:
+
+- tag and manual dry-run triggers
+- build/test before publish ordering
+- PyPI publish before MCP Registry publish ordering
+- `release` environment and `id-token: write` permissions for live publish jobs
+- PyPI Trusted Publishing action
+- MCP Registry `mcp-publisher login github-oidc` and `publish --file=server.json`
+- required operator prerequisite runbook text
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E6-S5` complete and sets
+  the active story to `E6-S6`.
+- `docs/state/registry.md` says the next story is `E6-S6: run the MCP Registry
+  publishing verification spike`.
+
+## Validation
+
+Focused validation:
+
+- `./.venv/bin/python -m pytest tests/test_release_workflow.py`: 4 passed
+
+Full validation:
+
+- `./.venv/bin/python -m pytest`: 352 passed
+- `./.venv/bin/python -m build`: built
+  `coffee_roaster_mcp-0.1.0.tar.gz` and
+  `coffee_roaster_mcp-0.1.0-py3-none-any.whl`
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+## Restart Prompt
+
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E6-S5 should
+be checked first. If it has merged, verify issue #53 is closed, check out
+`main`, run `git pull --ff-only origin main`, then begin E6-S6 from updated
+main on the appropriate `feature/54-...` branch after reading the registry,
+active epic, this summary, and the GitHub issue for E6-S6. Keep E6-S6 scoped to
+the MCP Registry publishing verification spike unless the issue explicitly
+expands the work.

--- a/docs/session-summaries/2026-05-24-e6-s5-release-workflow.md
+++ b/docs/session-summaries/2026-05-24-e6-s5-release-workflow.md
@@ -75,6 +75,8 @@ Pre-review context token usage snapshot: `386K used`
 
 Post-review context token usage snapshot: `495K used`
 
+Final context token usage snapshot after all review follow-ups: `769K used`
+
 CodeRabbit and Codex review comments raised overlapping supply-chain hardening
 concerns:
 
@@ -102,6 +104,13 @@ The review concerns were valid and addressed locally:
   with explicit release-operator error messages instead of generic Python
   exceptions. The first package entry is also validated before reading its
   `version` field.
+- The final CodeRabbit review thread on PR #133 asked for an explicit
+  `packages[0]` shape check. Commit `73b227b` addressed it by requiring the
+  first package entry to be an object with a string `version` field before the
+  workflow reads `package["version"]`; CodeRabbit marked the thread resolved.
+- GitHub checks on commit `73b227b` passed for `Build Package` and `Checks`.
+  CodeRabbit was still processing when the final token usage snapshot was
+  recorded.
 
 Durable state updates:
 

--- a/docs/session-summaries/2026-05-24-e6-s5-release-workflow.md
+++ b/docs/session-summaries/2026-05-24-e6-s5-release-workflow.md
@@ -40,9 +40,10 @@ release validation was performed.
 - `release-dry-run` confirms wheel and source distribution artifacts exist and
   does not run upload actions.
 - `publish-pypi` uses the `release` GitHub environment, `id-token: write`, and
-  `pypa/gh-action-pypi-publish@release/v1`.
+  a commit-pinned `pypa/gh-action-pypi-publish` action.
 - `publish-mcp-registry` depends on `publish-pypi`, uses the same `release`
-  environment and OIDC permission, installs `mcp-publisher`, authenticates with
+  environment and OIDC permission, installs the pinned `mcp-publisher` v1.7.9
+  Linux amd64 asset after SHA-256 verification, authenticates with
   `github-oidc`, and publishes `server.json`.
 
 `docs/release.md` documents the operator prerequisites before live publishing:
@@ -62,9 +63,40 @@ release validation was performed.
 - build/test before publish ordering
 - PyPI publish before MCP Registry publish ordering
 - `release` environment and `id-token: write` permissions for live publish jobs
+- commit-pinned GitHub Actions refs and disabled checkout credential persistence
 - PyPI Trusted Publishing action
+- pinned and SHA-256 verified `mcp-publisher` install
 - MCP Registry `mcp-publisher login github-oidc` and `publish --file=server.json`
 - required operator prerequisite runbook text
+
+## Review Follow-Up
+
+Pre-review context token usage snapshot: `386K used`
+
+Post-review context token usage snapshot: `495K used`
+
+CodeRabbit and Codex review comments raised overlapping supply-chain hardening
+concerns:
+
+- Add `persist-credentials: false` to every checkout step.
+- Pin mutable GitHub Actions refs to immutable commit SHAs.
+- Stop downloading `mcp-publisher` from `releases/latest`.
+- Verify the downloaded `mcp-publisher` asset before executing it.
+- Update workflow tests so the PyPI publish action expectation requires an
+  immutable 40-character SHA ref.
+
+The review concerns were valid and addressed locally:
+
+- All `actions/checkout`, `actions/setup-python`, `actions/upload-artifact`,
+  `actions/download-artifact`, and `pypa/gh-action-pypi-publish` references are
+  now pinned to commit SHAs.
+- Every checkout step sets `persist-credentials: false`.
+- `mcp-publisher` is pinned to `v1.7.9` and the Linux amd64 release asset is
+  checked against SHA-256
+  `ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac` before
+  extraction.
+- `tests/test_release_workflow.py` now verifies pinned action refs, checkout
+  credential hardening, and the pinned/checksum-verified publisher install.
 
 Durable state updates:
 
@@ -77,11 +109,11 @@ Durable state updates:
 
 Focused validation:
 
-- `./.venv/bin/python -m pytest tests/test_release_workflow.py`: 4 passed
+- `./.venv/bin/python -m pytest tests/test_release_workflow.py`: 6 passed
 
 Full validation:
 
-- `./.venv/bin/python -m pytest`: 352 passed
+- `./.venv/bin/python -m pytest`: 354 passed
 - `./.venv/bin/python -m build`: built
   `coffee_roaster_mcp-0.1.0.tar.gz` and
   `coffee_roaster_mcp-0.1.0-py3-none-any.whl`

--- a/docs/session-summaries/2026-05-24-e6-s5-release-workflow.md
+++ b/docs/session-summaries/2026-05-24-e6-s5-release-workflow.md
@@ -100,7 +100,8 @@ The review concerns were valid and addressed locally:
 - Follow-up CodeRabbit metadata-validation comments were also addressed:
   missing `__version__` and missing or empty `server.json.packages` now fail
   with explicit release-operator error messages instead of generic Python
-  exceptions.
+  exceptions. The first package entry is also validated before reading its
+  `version` field.
 
 Durable state updates:
 

--- a/docs/session-summaries/2026-05-24-e6-s5-release-workflow.md
+++ b/docs/session-summaries/2026-05-24-e6-s5-release-workflow.md
@@ -97,6 +97,10 @@ The review concerns were valid and addressed locally:
   extraction.
 - `tests/test_release_workflow.py` now verifies pinned action refs, checkout
   credential hardening, and the pinned/checksum-verified publisher install.
+- Follow-up CodeRabbit metadata-validation comments were also addressed:
+  missing `__version__` and missing or empty `server.json.packages` now fail
+  with explicit release-operator error messages instead of generic Python
+  exceptions.
 
 Durable state updates:
 
@@ -109,11 +113,11 @@ Durable state updates:
 
 Focused validation:
 
-- `./.venv/bin/python -m pytest tests/test_release_workflow.py`: 6 passed
+- `./.venv/bin/python -m pytest tests/test_release_workflow.py`: 7 passed
 
 Full validation:
 
-- `./.venv/bin/python -m pytest`: 354 passed
+- `./.venv/bin/python -m pytest`: 355 passed
 - `./.venv/bin/python -m build`: built
   `coffee_roaster_mcp-0.1.0.tar.gz` and
   `coffee_roaster_mcp-0.1.0-py3-none-any.whl`

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -1748,20 +1748,23 @@ After completing a story:
     Trusted Publishing, and MCP Registry publishing after PyPI succeeds.
     Review hardening pins GitHub Actions refs to commit SHAs, disables checkout
     credential persistence, and verifies the pinned `mcp-publisher` v1.7.9
-    Linux amd64 asset SHA-256 before execution.
+    Linux amd64 asset SHA-256 before execution. Follow-up metadata-validation
+    hardening gives explicit release-operator errors for missing `__version__`
+    and missing or empty `server.json.packages`.
   - Added `docs/release.md` documenting PyPI owner prerequisites, 2FA and
     recovery-code setup, Trusted Publishing configuration for
     `release.yml`/`release`/`publish-pypi`, protected `v*` tag rules, TestPyPI
     status, and the `PYPI_API_TOKEN` fallback secret name.
   - Added focused release workflow coverage in `tests/test_release_workflow.py`,
     including pinned action refs, checkout credential persistence, and
-    `mcp-publisher` checksum verification.
+    `mcp-publisher` checksum verification. Follow-up coverage pins the clear
+    metadata-validation failure messages.
   - Kept live PyPI upload, live MCP Registry publish, TestPyPI rehearsal,
     hardware validation, model training/export/sync, real microphone
     validation, and broad release validation out of scope.
   - Ran `./.venv/bin/python -m pytest tests/test_release_workflow.py`:
-    6 passed.
-  - Ran `./.venv/bin/python -m pytest`: 354 passed.
+    7 passed.
+  - Ran `./.venv/bin/python -m pytest`: 355 passed.
   - Ran `./.venv/bin/python -m build`: built
     `coffee_roaster_mcp-0.1.0.tar.gz` and
     `coffee_roaster_mcp-0.1.0-py3-none-any.whl`.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E6-S5`
-- Current target: Add release workflow
+- Active story: `E6-S6`
+- Current target: Run MCP Registry publishing verification spike
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -320,6 +320,16 @@ The first implementation milestone is a mock vertical slice that requires no roa
   publishing, release workflow behavior, live hardware validation, model
   training/export/sync, real microphone validation, and broad release validation
   remain later stories.
+- `E6-S5` adds the guarded release workflow and operator prerequisite runbook.
+  `.github/workflows/release.yml` runs checks, validates tag/version alignment,
+  builds distribution artifacts, supports manual dry run without uploading,
+  publishes to PyPI through Trusted Publishing after `release` environment
+  approval, and publishes MCP Registry metadata with `mcp-publisher` GitHub
+  OIDC only after PyPI succeeds. `docs/release.md` documents PyPI ownership,
+  2FA/recovery codes, Trusted Publishing setup for `release.yml`/`release`/
+  `publish-pypi`, protected `v*` tag rules, TestPyPI status, and the
+  `PYPI_API_TOKEN` fallback secret name. Live publishing was not executed by
+  this story; E6-S6 remains the MCP Registry publishing verification spike.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -674,7 +684,7 @@ Goal: make RoastPilot installable and discoverable through PyPI and the MCP Regi
 - [x] `E6-S4` Add version alignment check.
   - Done when package version and `server.json.version` cannot drift unnoticed.
 
-- [ ] `E6-S5` Add release workflow.
+- [x] `E6-S5` Add release workflow.
   - Done when CI can build, test, publish to PyPI, and publish registry
     metadata after tag release.
   - Operator prerequisites must be documented before workflow implementation:
@@ -691,6 +701,10 @@ Goal: make RoastPilot installable and discoverable through PyPI and the MCP Regi
       documented before live publishing is enabled.
     - Workflow dry run proves build/test/package steps without uploading to
       production PyPI.
+  - Implemented in `.github/workflows/release.yml` and documented in
+    `docs/release.md`. Live PyPI and MCP Registry publishing remain guarded by
+    tag trigger plus the `release` GitHub environment; this story did not run a
+    live release.
 
 - [ ] `E6-S6` Run MCP Registry publishing verification spike.
   - Done when `server.json`, PyPI verification, and `mcp-publisher` flow are documented and tested before v0.1 release.
@@ -1720,6 +1734,29 @@ After completing a story:
     passed.
   - Ran `./.venv/bin/python -m pyright tests/test_server_json.py`: 0 errors.
   - Ran `./.venv/bin/python -m pytest`: 347 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E6-S5:
+  - Added `.github/workflows/release.yml` with a manual dry-run path, tag-based
+    live release path, checks, release metadata validation, package build, PyPI
+    Trusted Publishing, and MCP Registry publishing after PyPI succeeds.
+  - Added `docs/release.md` documenting PyPI owner prerequisites, 2FA and
+    recovery-code setup, Trusted Publishing configuration for
+    `release.yml`/`release`/`publish-pypi`, protected `v*` tag rules, TestPyPI
+    status, and the `PYPI_API_TOKEN` fallback secret name.
+  - Added focused release workflow coverage in `tests/test_release_workflow.py`.
+  - Kept live PyPI upload, live MCP Registry publish, TestPyPI rehearsal,
+    hardware validation, model training/export/sync, real microphone
+    validation, and broad release validation out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_release_workflow.py`:
+    4 passed.
+  - Ran `./.venv/bin/python -m pytest`: 352 passed.
+  - Ran `./.venv/bin/python -m build`: built
+    `coffee_roaster_mcp-0.1.0.tar.gz` and
+    `coffee_roaster_mcp-0.1.0-py3-none-any.whl`.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -325,8 +325,11 @@ The first implementation milestone is a mock vertical slice that requires no roa
   builds distribution artifacts, supports manual dry run without uploading,
   publishes to PyPI through Trusted Publishing after `release` environment
   approval, and publishes MCP Registry metadata with `mcp-publisher` GitHub
-  OIDC only after PyPI succeeds. `docs/release.md` documents PyPI ownership,
-  2FA/recovery codes, Trusted Publishing setup for `release.yml`/`release`/
+  OIDC only after PyPI succeeds. Review hardening pins GitHub Actions refs to
+  commit SHAs, disables checkout credential persistence, and pins the
+  `mcp-publisher` v1.7.9 Linux amd64 asset with SHA-256 verification before
+  execution. `docs/release.md` documents PyPI ownership, 2FA/recovery codes,
+  Trusted Publishing setup for `release.yml`/`release`/
   `publish-pypi`, protected `v*` tag rules, TestPyPI status, and the
   `PYPI_API_TOKEN` fallback secret name. Live publishing was not executed by
   this story; E6-S6 remains the MCP Registry publishing verification spike.
@@ -1743,17 +1746,22 @@ After completing a story:
   - Added `.github/workflows/release.yml` with a manual dry-run path, tag-based
     live release path, checks, release metadata validation, package build, PyPI
     Trusted Publishing, and MCP Registry publishing after PyPI succeeds.
+    Review hardening pins GitHub Actions refs to commit SHAs, disables checkout
+    credential persistence, and verifies the pinned `mcp-publisher` v1.7.9
+    Linux amd64 asset SHA-256 before execution.
   - Added `docs/release.md` documenting PyPI owner prerequisites, 2FA and
     recovery-code setup, Trusted Publishing configuration for
     `release.yml`/`release`/`publish-pypi`, protected `v*` tag rules, TestPyPI
     status, and the `PYPI_API_TOKEN` fallback secret name.
-  - Added focused release workflow coverage in `tests/test_release_workflow.py`.
+  - Added focused release workflow coverage in `tests/test_release_workflow.py`,
+    including pinned action refs, checkout credential persistence, and
+    `mcp-publisher` checksum verification.
   - Kept live PyPI upload, live MCP Registry publish, TestPyPI rehearsal,
     hardware validation, model training/export/sync, real microphone
     validation, and broad release validation out of scope.
   - Ran `./.venv/bin/python -m pytest tests/test_release_workflow.py`:
-    4 passed.
-  - Ran `./.venv/bin/python -m pytest`: 352 passed.
+    6 passed.
+  - Ran `./.venv/bin/python -m pytest`: 354 passed.
   - Ran `./.venv/bin/python -m build`: built
     `coffee_roaster_mcp-0.1.0.tar.gz` and
     `coffee_roaster_mcp-0.1.0-py3-none-any.whl`.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -1749,8 +1749,9 @@ After completing a story:
     Review hardening pins GitHub Actions refs to commit SHAs, disables checkout
     credential persistence, and verifies the pinned `mcp-publisher` v1.7.9
     Linux amd64 asset SHA-256 before execution. Follow-up metadata-validation
-    hardening gives explicit release-operator errors for missing `__version__`
-    and missing or empty `server.json.packages`.
+    hardening gives explicit release-operator errors for missing `__version__`,
+    missing or empty `server.json.packages`, and malformed first package
+    entries.
   - Added `docs/release.md` documenting PyPI owner prerequisites, 2FA and
     recovery-code setup, Trusted Publishing configuration for
     `release.yml`/`release`/`publish-pypi`, protected `v*` tag rules, TestPyPI

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -288,13 +288,17 @@ E6-S5 added the guarded release workflow and operator prerequisite runbook.
 alignment, builds package artifacts, supports a manual dry run that does not
 upload, publishes to PyPI through Trusted Publishing after `release`
 environment approval, and publishes MCP Registry metadata with `mcp-publisher`
-GitHub OIDC only after the PyPI publish job succeeds. `docs/release.md`
+GitHub OIDC only after the PyPI publish job succeeds. Review hardening pins
+GitHub Actions refs to commit SHAs, disables checkout credential persistence,
+and pins the `mcp-publisher` v1.7.9 Linux amd64 asset with SHA-256
+verification before execution. `docs/release.md`
 documents PyPI account ownership, 2FA/recovery codes, Trusted Publishing setup
 for `release.yml`/`release`/`publish-pypi`, protected `v*` tag rules, TestPyPI
 status, and the exact `PYPI_API_TOKEN` fallback secret name. Focused workflow
-tests pin the trigger, job ordering, environment/OIDC permissions, publish
-actions, and prerequisite runbook text. Live publishing is not executed by this
-story; E6-S6 remains the MCP Registry verification spike.
+tests pin the trigger, job ordering, environment/OIDC permissions, immutable
+action refs, publisher verification, publish actions, and prerequisite runbook
+text. Live publishing is not executed by this story; E6-S6 remains the MCP
+Registry verification spike.
 
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -291,14 +291,16 @@ environment approval, and publishes MCP Registry metadata with `mcp-publisher`
 GitHub OIDC only after the PyPI publish job succeeds. Review hardening pins
 GitHub Actions refs to commit SHAs, disables checkout credential persistence,
 and pins the `mcp-publisher` v1.7.9 Linux amd64 asset with SHA-256
-verification before execution. `docs/release.md`
+verification before execution. Follow-up metadata-validation hardening gives
+explicit release-operator errors for missing `__version__` and missing or empty
+`server.json.packages`. `docs/release.md`
 documents PyPI account ownership, 2FA/recovery codes, Trusted Publishing setup
 for `release.yml`/`release`/`publish-pypi`, protected `v*` tag rules, TestPyPI
 status, and the exact `PYPI_API_TOKEN` fallback secret name. Focused workflow
 tests pin the trigger, job ordering, environment/OIDC permissions, immutable
-action refs, publisher verification, publish actions, and prerequisite runbook
-text. Live publishing is not executed by this story; E6-S6 remains the MCP
-Registry verification spike.
+action refs, publisher verification, release metadata failure messages, publish
+actions, and prerequisite runbook text. Live publishing is not executed by this
+story; E6-S6 remains the MCP Registry verification spike.
 
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -293,7 +293,7 @@ GitHub Actions refs to commit SHAs, disables checkout credential persistence,
 and pins the `mcp-publisher` v1.7.9 Linux amd64 asset with SHA-256
 verification before execution. Follow-up metadata-validation hardening gives
 explicit release-operator errors for missing `__version__` and missing or empty
-`server.json.packages`. `docs/release.md`
+`server.json.packages`, plus malformed first package entries. `docs/release.md`
 documents PyPI account ownership, 2FA/recovery codes, Trusted Publishing setup
 for `release.yml`/`release`/`publish-pypi`, protected `v*` tag rules, TestPyPI
 status, and the exact `PYPI_API_TOKEN` fallback secret name. Focused workflow

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -283,13 +283,26 @@ Registry publishing, release workflow behavior, live hardware validation, model
 training/export/sync, real microphone validation, and broad release validation
 remain later stories.
 
+E6-S5 added the guarded release workflow and operator prerequisite runbook.
+`.github/workflows/release.yml` now runs checks, validates release tag/version
+alignment, builds package artifacts, supports a manual dry run that does not
+upload, publishes to PyPI through Trusted Publishing after `release`
+environment approval, and publishes MCP Registry metadata with `mcp-publisher`
+GitHub OIDC only after the PyPI publish job succeeds. `docs/release.md`
+documents PyPI account ownership, 2FA/recovery codes, Trusted Publishing setup
+for `release.yml`/`release`/`publish-pypi`, protected `v*` tag rules, TestPyPI
+status, and the exact `PYPI_API_TOKEN` fallback secret name. Focused workflow
+tests pin the trigger, job ordering, environment/OIDC permissions, publish
+actions, and prerequisite runbook text. Live publishing is not executed by this
+story; E6-S6 remains the MCP Registry verification spike.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E6-S5: add the release workflow.
+The next story is E6-S6: run the MCP Registry publishing verification spike.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,89 @@
+"""Release workflow coverage for PyPI and MCP Registry publishing."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release.yml"
+
+
+def test_release_workflow_runs_on_tags_and_manual_dry_run() -> None:
+    """Check release workflow trigger coverage for dry run and live tag releases."""
+    workflow = _load_release_workflow()
+
+    trigger = workflow["on"]
+    assert trigger["push"]["tags"] == ["v*"]
+    assert trigger["workflow_dispatch"]["inputs"]["dry_run"] == {
+        "description": "Build and validate without publishing to PyPI or the MCP Registry.",
+        "required": True,
+        "type": "boolean",
+        "default": True,
+    }
+
+
+def test_release_workflow_builds_before_publishing() -> None:
+    """Check release workflow orders checks, package build, PyPI, and registry publish."""
+    jobs = _load_release_workflow()["jobs"]
+
+    assert set(jobs) == {
+        "checks",
+        "validate-release-metadata",
+        "build-package",
+        "release-dry-run",
+        "publish-pypi",
+        "publish-mcp-registry",
+    }
+    assert jobs["build-package"]["needs"] == ["checks", "validate-release-metadata"]
+    assert jobs["release-dry-run"]["needs"] == "build-package"
+    assert jobs["publish-pypi"]["needs"] == "build-package"
+    assert jobs["publish-mcp-registry"]["needs"] == "publish-pypi"
+
+
+def test_release_workflow_uses_trusted_publishing_and_release_environment() -> None:
+    """Check live publish jobs use the protected release environment and OIDC."""
+    jobs = _load_release_workflow()["jobs"]
+    pypi_job = jobs["publish-pypi"]
+    registry_job = jobs["publish-mcp-registry"]
+
+    assert pypi_job["environment"] == "release"
+    assert pypi_job["permissions"] == {"contents": "read", "id-token": "write"}
+    assert _step_uses(pypi_job, "pypa/gh-action-pypi-publish@release/v1")
+
+    assert registry_job["environment"] == "release"
+    assert registry_job["permissions"] == {"contents": "read", "id-token": "write"}
+    assert _step_runs(registry_job, "./mcp-publisher login github-oidc")
+    assert _step_runs(registry_job, "./mcp-publisher publish --file=server.json")
+
+
+def test_release_runbook_documents_operator_prerequisites() -> None:
+    """Check the release runbook documents the operator setup required by E6-S5."""
+    runbook = (Path(__file__).resolve().parents[1] / "docs" / "release.md").read_text(
+        encoding="utf-8"
+    )
+
+    expected_phrases = [
+        "workflow filename: `release.yml`",
+        "environment: `release`",
+        "tag-triggered job: `publish-pypi`",
+        "Protected tag rules block unapproved creation or update of `v*` tags.",
+        "GitHub environment named `release` exists and requires manual approval",
+        "GitHub environment secret `PYPI_API_TOKEN`",
+        "TestPyPI rehearsal is not enabled in the workflow.",
+        "MCP Registry publishing runs only after the PyPI publish job succeeds.",
+    ]
+
+    for phrase in expected_phrases:
+        assert phrase in runbook
+
+
+def _load_release_workflow() -> dict[str, Any]:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
+
+
+def _step_uses(job: dict[str, Any], action: str) -> bool:
+    return any(step.get("uses") == action for step in job["steps"])
+
+
+def _step_runs(job: dict[str, Any], command: str) -> bool:
+    return any(step.get("run") == command for step in job["steps"])

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,11 +1,13 @@
 """Release workflow coverage for PyPI and MCP Registry publishing."""
 
+import re
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 WORKFLOW_PATH = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release.yml"
+PINNED_ACTION_REF = re.compile(r"^[\w.-]+/[\w.-]+@[0-9a-f]{40}$")
 
 
 def test_release_workflow_runs_on_tags_and_manual_dry_run() -> None:
@@ -48,12 +50,43 @@ def test_release_workflow_uses_trusted_publishing_and_release_environment() -> N
 
     assert pypi_job["environment"] == "release"
     assert pypi_job["permissions"] == {"contents": "read", "id-token": "write"}
-    assert _step_uses(pypi_job, "pypa/gh-action-pypi-publish@release/v1")
+    assert _step_uses_pinned_action(pypi_job, "pypa/gh-action-pypi-publish")
 
     assert registry_job["environment"] == "release"
     assert registry_job["permissions"] == {"contents": "read", "id-token": "write"}
     assert _step_runs(registry_job, "./mcp-publisher login github-oidc")
     assert _step_runs(registry_job, "./mcp-publisher publish --file=server.json")
+
+
+def test_release_workflow_pins_actions_and_checkout_credentials() -> None:
+    """Check action steps use immutable refs and checkout does not persist credentials."""
+    jobs = _load_release_workflow()["jobs"]
+
+    for job in jobs.values():
+        for step in job["steps"]:
+            action = step.get("uses")
+            if action is None:
+                continue
+            assert PINNED_ACTION_REF.match(action), action
+            if action.startswith("actions/checkout@"):
+                assert step["with"]["persist-credentials"] is False
+
+
+def test_release_workflow_pins_and_verifies_mcp_publisher() -> None:
+    """Check MCP Registry publishing does not execute an unverified latest binary."""
+    registry_job = _load_release_workflow()["jobs"]["publish-mcp-registry"]
+    install_step = _step_named(registry_job, "Install mcp-publisher")
+    run_script = install_step["run"]
+
+    assert 'MCP_PUBLISHER_VERSION="v1.7.9"' in run_script
+    assert (
+        'MCP_PUBLISHER_SHA256="ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac"'
+        in run_script
+    )
+    assert "releases/download/${MCP_PUBLISHER_VERSION}" in run_script
+    assert "releases/latest" not in run_script
+    assert "sha256sum -c -" in run_script
+    assert "curl" in run_script and "| tar" not in run_script
 
 
 def test_release_runbook_documents_operator_prerequisites() -> None:
@@ -81,9 +114,19 @@ def _load_release_workflow() -> dict[str, Any]:
     return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
 
 
-def _step_uses(job: dict[str, Any], action: str) -> bool:
-    return any(step.get("uses") == action for step in job["steps"])
+def _step_uses_pinned_action(job: dict[str, Any], action_name: str) -> bool:
+    return any(
+        step.get("uses", "").startswith(f"{action_name}@") and PINNED_ACTION_REF.match(step["uses"])
+        for step in job["steps"]
+    )
 
 
 def _step_runs(job: dict[str, Any], command: str) -> bool:
     return any(step.get("run") == command for step in job["steps"])
+
+
+def _step_named(job: dict[str, Any], name: str) -> dict[str, Any]:
+    for step in job["steps"]:
+        if step.get("name") == name:
+            return step  # type: ignore[no-any-return]
+    raise AssertionError(f"Step {name!r} was not found.")

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -106,6 +106,9 @@ def test_release_workflow_metadata_validation_reports_clear_shape_errors() -> No
     assert "not isinstance(packages, list)" in run_script
     assert "len(packages) == 0" in run_script
     assert "server.json must contain a non-empty 'packages' array." in run_script
+    assert "not isinstance(package, dict)" in run_script
+    assert 'not isinstance(package.get("version"), str)' in run_script
+    assert "server.json packages[0] must be an object with a string 'version' field." in run_script
 
 
 def test_release_runbook_documents_operator_prerequisites() -> None:

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -89,6 +89,25 @@ def test_release_workflow_pins_and_verifies_mcp_publisher() -> None:
     assert "curl" in run_script and "| tar" not in run_script
 
 
+def test_release_workflow_metadata_validation_reports_clear_shape_errors() -> None:
+    """Check release metadata validation guards produce clear operator errors."""
+    validation_job = _load_release_workflow()["jobs"]["validate-release-metadata"]
+    validation_step = _step_named(
+        validation_job,
+        "Validate release tag, package version, and registry metadata",
+    )
+    run_script = validation_step["run"]
+
+    assert "version_match = re.search" in run_script
+    assert "if version_match is None:" in run_script
+    assert "Could not find __version__" in run_script
+    assert "Expected __version__" in run_script
+    assert 'packages = server_json.get("packages")' in run_script
+    assert "not isinstance(packages, list)" in run_script
+    assert "len(packages) == 0" in run_script
+    assert "server.json must contain a non-empty 'packages' array." in run_script
+
+
 def test_release_runbook_documents_operator_prerequisites() -> None:
     """Check the release runbook documents the operator setup required by E6-S5."""
     runbook = (Path(__file__).resolve().parents[1] / "docs" / "release.md").read_text(


### PR DESCRIPTION
## Summary
- add a guarded tag/manual release workflow with checks, release metadata validation, package build, PyPI Trusted Publishing, and MCP Registry publish after PyPI succeeds
- harden the release workflow by pinning GitHub Actions refs, disabling checkout credential persistence, checksum-verifying the pinned `mcp-publisher` asset, and surfacing clear release-operator metadata validation errors
- document operator prerequisites for PyPI ownership, Trusted Publishing, release environment approvals, protected tags, TestPyPI status, and token fallback
- add focused workflow/runbook coverage and update E6 state docs/session summary

## Scope
- release workflow and operator prerequisites only for issue #53
- no live PyPI upload, live MCP Registry publish, TestPyPI rehearsal, hardware validation, model training/export/sync, real microphone validation, or broad release validation

## Validation
- ./.venv/bin/python -m pytest tests/test_release_workflow.py: 7 passed
- ./.venv/bin/python -m pytest: 355 passed
- ./.venv/bin/python -m build: built coffee_roaster_mcp-0.1.0.tar.gz and coffee_roaster_mcp-0.1.0-py3-none-any.whl
- ./.venv/bin/python -m ruff check .: passed
- ./.venv/bin/python -m ruff format --check .: passed
- ./.venv/bin/python -m pyright: 0 errors
- ./.venv/bin/coffee-roaster-mcp --help: passed
- ./.venv/bin/coffee-roaster-mcp --version: coffee-roaster-mcp 0.1.0

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive release runbook, session notes, and epic/state updates describing manual dry-run vs live tag-triggered release paths, operator prerequisites, approvals, and publish ordering.

* **Chores**
  * Added a guarded automated release workflow supporting manual dry-runs and tag-triggered live publishing to PyPI and the MCP Registry, with version/tag alignment checks, artifact verification, gated environments, pinned refs, credential hardening, and publisher checksum verification.

* **Tests**
  * Added tests validating workflow triggers, job sequencing, metadata validation with clear operator-facing errors, artifact presence, pinned refs, credential hardening, and runbook content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->