### PR TITLE
E6-S6: Verify MCP Registry publishing flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,8 +224,11 @@ jobs:
           tar xzf /tmp/mcp-publisher.tar.gz mcp-publisher
           chmod +x mcp-publisher
 
+      - name: Validate server metadata with MCP Registry
+        run: ./mcp-publisher validate server.json
+
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github-oidc
 
       - name: Publish server metadata to MCP Registry
-        run: ./mcp-publisher publish --file=server.json
+        run: ./mcp-publisher publish server.json

--- a/docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md
+++ b/docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md
@@ -511,6 +511,9 @@ Stories:
   publish after PyPI succeeds.
 - Add MCP Registry publishing verification spike.
 - Document install and hardware setup.
+- Execute live PyPI and MCP Registry publish after the package is present on
+  production PyPI and the published long description exposes the exact
+  `mcp-name` verification marker.
 
 Acceptance criteria:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -92,5 +92,60 @@ After all prerequisites are confirmed:
    stdio transport.
 
 MCP Registry publishing runs only after the PyPI publish job succeeds. The
-registry job authenticates with GitHub OIDC through `mcp-publisher login
-github-oidc` and then publishes `server.json`.
+registry job validates `server.json` against the preview Registry API before
+authenticating, authenticates with GitHub OIDC through `mcp-publisher login
+github-oidc`, and then publishes `server.json`.
+
+## MCP Registry Verification
+
+The MCP Registry is preview. Before a live v0.1 release, use the current
+official registry docs and schema, then repeat the non-destructive checks below:
+
+1. Confirm `server.json` uses the current schema URI:
+   `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`.
+2. Confirm `server.json.name` is `io.github.syamaner/coffee-roaster-mcp`.
+3. Confirm the PyPI package entry uses `registryType: pypi`, identifier
+   `coffee-roaster-mcp`, package version `0.1.0`, runtime hint `uvx`, and
+   stdio transport.
+4. Confirm README contains exactly one PyPI ownership verification marker:
+   `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`.
+5. Download the pinned `mcp-publisher` release asset and verify its SHA-256
+   before execution. The release workflow uses
+   `mcp-publisher_linux_amd64.tar.gz` from `v1.7.9` with SHA-256
+   `ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac`.
+6. Run `./mcp-publisher validate server.json` before authenticating.
+
+E6-S6 verified the template and flow non-destructively:
+
+- `server.json` validated against the downloaded `2025-12-11` JSON schema.
+- `./mcp-publisher validate server.json` returned
+  `server.json is valid` against the preview Registry API.
+- The pinned Linux workflow asset checksum matched the expected SHA-256.
+- The same `mcp-publisher` version's Darwin arm64 build showed the publishing
+  flow as `login github-oidc` followed by `publish server.json`.
+- `mcp-publisher login github-oidc` fails outside GitHub Actions without
+  `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, confirming this authentication path must
+  run from a job with `id-token: write`.
+- `https://pypi.org/pypi/coffee-roaster-mcp/json` returned `Not Found` before
+  the first live release.
+- The Registry search API returned no existing listing for
+  `io.github.syamaner/coffee-roaster-mcp` before the first live release.
+
+The first destructive registry operation is `./mcp-publisher publish server.json`.
+Execute it only after:
+
+- the matching package version exists on production PyPI
+- the PyPI package README includes the exact `mcp-name` verification marker
+- the GitHub `release` environment has been approved
+- `./mcp-publisher validate server.json` has passed
+
+Expected outcome: the Registry accepts the metadata and the search endpoint
+`https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.syamaner/coffee-roaster-mcp`
+returns a listing whose package identifier is `coffee-roaster-mcp` and whose
+transport is `stdio`.
+
+Risk: Registry preview behavior, schema validation, package verification, or
+listing data can change or reset before general availability. A failed publish
+after PyPI succeeds leaves PyPI live without Registry discoverability and should
+be retried only after checking Registry status and confirming no partial
+version entry was created.

--- a/docs/session-summaries/2026-05-24-e6-s6-mcp-registry-publishing-verification.md
+++ b/docs/session-summaries/2026-05-24-e6-s6-mcp-registry-publishing-verification.md
@@ -96,6 +96,9 @@ Durable state updates:
   the active story to `E6-S7`.
 - `docs/state/registry.md` says the next story is `E6-S7: document install and
   hardware setup`.
+- Follow-up GitHub issue #135 now tracks `E6-S8: Execute live PyPI and MCP
+  Registry publish` in Epic 6 for the controlled live publish after PyPI
+  publication and verification-marker checks.
 
 ## Decision Point
 
@@ -150,4 +153,5 @@ be checked first. If it has merged, verify issue #54 is closed, check out
 main on the appropriate `feature/55-...` branch after reading the registry,
 active epic, this summary, and the GitHub issue for E6-S7. Keep E6-S7 scoped to
 install and hardware setup documentation unless the issue explicitly expands
-the work.
+the work. E6-S8 is now tracked separately as issue #135 for the later live PyPI
+and MCP Registry publish.

--- a/docs/session-summaries/2026-05-24-e6-s6-mcp-registry-publishing-verification.md
+++ b/docs/session-summaries/2026-05-24-e6-s6-mcp-registry-publishing-verification.md
@@ -1,0 +1,153 @@
+# E6-S6 MCP Registry Publishing Verification
+
+This summary captures the E6-S6 implementation, validation state, and restart
+context.
+
+## Scope
+
+Story: `E6-S6` / issue `#54`, run MCP Registry publishing verification spike.
+
+Branch: `feature/54-mcp-registry-publishing-verification`
+
+The implementation stayed inside the E6-S6 boundary:
+
+- verify `server.json` against the current MCP Registry preview schema
+- verify the PyPI README ownership marker for
+  `io.github.syamaner/coffee-roaster-mcp`
+- inspect and test the pinned `mcp-publisher` v1.7.9 flow non-destructively
+- update the release workflow to validate `server.json` before authentication
+  and publish
+- document the live-publish decision point, prerequisites, expected outcome,
+  and Registry preview risk
+
+No live PyPI upload, live MCP Registry publish, TestPyPI rehearsal, hardware
+validation, model training/export/sync, real microphone validation, or broad
+release validation was performed.
+
+## Verification Results
+
+Official MCP Registry docs checked on 2026-05-24 still describe the Registry as
+preview, use schema URI
+`https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`,
+support PyPI package entries with `registryType: pypi`, and verify PyPI package
+ownership by looking for an `mcp-name: $SERVER_NAME` string in the package
+README.
+
+`server.json` currently declares:
+
+- schema URI: `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
+- name: `io.github.syamaner/coffee-roaster-mcp`
+- title: `RoastPilot`
+- package registry type: `pypi`
+- package identifier: `coffee-roaster-mcp`
+- version: `0.1.0`
+- runtime hint: `uvx`
+- transport: `stdio`
+
+README contains exactly one verification marker:
+`<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`.
+
+Non-destructive live-service checks:
+
+- downloaded the official `2025-12-11` JSON schema and validated
+  `server.json` locally
+- downloaded `mcp-publisher` v1.7.9 Linux amd64 and verified SHA-256
+  `ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac`
+- downloaded the same version's Darwin arm64 build to inspect runnable CLI
+  behavior locally
+- ran `./mcp-publisher validate server.json` against the preview Registry API:
+  passed
+- ran `./mcp-publisher login github-oidc` locally: failed as expected because
+  `ACTIONS_ID_TOKEN_REQUEST_TOKEN` is only available inside GitHub Actions with
+  `id-token: write`
+- checked `https://pypi.org/pypi/coffee-roaster-mcp/json`: `Not Found`
+- checked
+  `https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.syamaner/coffee-roaster-mcp`:
+  no current listing
+
+## Implementation Summary
+
+`.github/workflows/release.yml` now runs
+`./mcp-publisher validate server.json` in the `publish-mcp-registry` job after
+installing the verified publisher binary and before `login github-oidc`.
+
+The final live Registry mutation command is now documented and tested as:
+
+```bash
+./mcp-publisher publish server.json
+```
+
+`docs/release.md` now includes an MCP Registry verification section with:
+
+- schema and metadata checks
+- PyPI README marker check
+- publisher checksum check
+- non-destructive validate command
+- live publish prerequisites
+- expected Registry search result
+- preview Registry risk and retry guidance
+
+`tests/test_release_workflow.py` pins the validation step and release runbook
+text.
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E6-S6` complete and sets
+  the active story to `E6-S7`.
+- `docs/state/registry.md` says the next story is `E6-S7: document install and
+  hardware setup`.
+
+## Decision Point
+
+Stop before executing the first destructive command:
+
+```bash
+./mcp-publisher publish server.json
+```
+
+Prerequisites before running it:
+
+- production PyPI contains the matching `coffee-roaster-mcp` package version
+- the published PyPI long description includes
+  `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`
+- the GitHub `release` environment has been approved
+- `./mcp-publisher validate server.json` has passed
+
+Expected outcome: the MCP Registry accepts the metadata and its search API
+returns a listing for `io.github.syamaner/coffee-roaster-mcp` with PyPI package
+identifier `coffee-roaster-mcp` and stdio transport.
+
+Risk: the Registry is still preview. Schema validation, package verification,
+listing behavior, or stored data can change or reset before general
+availability. A failure after PyPI publish leaves PyPI live without Registry
+discoverability and should be retried only after checking Registry status and
+confirming no partial version entry was created.
+
+## Validation
+
+Focused validation:
+
+- `./.venv/bin/python -m pytest tests/test_release_workflow.py tests/test_server_json.py tests/test_readme.py`:
+  12 passed
+
+Full validation:
+
+- `./.venv/bin/python -m pytest`: 355 passed
+- `./.venv/bin/python -m build`: built
+  `coffee_roaster_mcp-0.1.0.tar.gz` and
+  `coffee_roaster_mcp-0.1.0-py3-none-any.whl`
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+## Restart Prompt
+
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E6-S6 should
+be checked first. If it has merged, verify issue #54 is closed, check out
+`main`, run `git pull --ff-only origin main`, then begin E6-S7 from updated
+main on the appropriate `feature/55-...` branch after reading the registry,
+active epic, this summary, and the GitHub issue for E6-S7. Keep E6-S7 scoped to
+install and hardware setup documentation unless the issue explicitly expands
+the work.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -733,6 +733,23 @@ Goal: make RoastPilot installable and discoverable through PyPI and the MCP Regi
 - [ ] `E6-S7` Document install and hardware setup.
   - Done when docs cover mock install, Hottop config, Hugging Face model config, offline model path, and log output paths.
 
+- [ ] `E6-S8` Execute live PyPI and MCP Registry publish.
+  - GitHub issue: #135
+  - Done when production PyPI contains the matching `coffee-roaster-mcp`
+    version, the published PyPI long description includes
+    `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`, the package
+    installs from PyPI with CLI smoke checks passing, `mcp-publisher validate
+    server.json` passes against the live package and preview Registry API, the
+    guarded release workflow publishes Registry metadata after PyPI succeeds,
+    Registry search returns `io.github.syamaner/coffee-roaster-mcp`, and the
+    listing points to PyPI package `coffee-roaster-mcp` with stdio transport.
+  - Live publish outcome, links, commands, risks, and any rollback or retry
+    notes must be recorded in `docs/release.md`, this active epic, registry
+    state, and a session summary.
+  - Do not run the live Registry publish until production PyPI shows the
+    matching package version and its long description includes the exact
+    `mcp-name` marker.
+
 ### Epic Acceptance Criteria
 
 - Package installs from PyPI.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E6-S6`
-- Current target: Run MCP Registry publishing verification spike
+- Active story: `E6-S7`
+- Current target: Document install and hardware setup
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -332,14 +332,28 @@ The first implementation milestone is a mock vertical slice that requires no roa
   Trusted Publishing setup for `release.yml`/`release`/
   `publish-pypi`, protected `v*` tag rules, TestPyPI status, and the
   `PYPI_API_TOKEN` fallback secret name. Live publishing was not executed by
-  this story; E6-S6 remains the MCP Registry publishing verification spike.
+  E6-S5.
+- `E6-S6` completes the MCP Registry publishing verification spike without
+  executing a live PyPI release or live Registry publish. `server.json`
+  validated against the downloaded official `2025-12-11` Registry schema and
+  against the preview Registry API through `mcp-publisher validate server.json`.
+  The pinned `mcp-publisher` v1.7.9 Linux amd64 workflow asset checksum matched
+  the expected SHA-256, GitHub OIDC authentication was confirmed to require the
+  GitHub Actions OIDC environment, and the release workflow now validates
+  `server.json` before authenticating and publishing. `docs/release.md`
+  documents the PyPI verification marker, non-destructive validation commands,
+  live publish stop point, prerequisites, expected outcome, and preview
+  Registry risk. The remaining destructive step is the tag-triggered live
+  release path after production PyPI publication succeeds.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
 
 ## Current Risks
 
-- MCP Registry publishing is preview and needs verification before release.
+- MCP Registry publishing is preview; live publish can still fail or reset even
+  though the metadata template and publisher flow have been verified
+  non-destructively.
 - First-crack event integration must preserve one authoritative session timeline.
 - Log schema changes need compatibility discipline once users start collecting roast logs.
 
@@ -709,8 +723,12 @@ Goal: make RoastPilot installable and discoverable through PyPI and the MCP Regi
     tag trigger plus the `release` GitHub environment; this story did not run a
     live release.
 
-- [ ] `E6-S6` Run MCP Registry publishing verification spike.
+- [x] `E6-S6` Run MCP Registry publishing verification spike.
   - Done when `server.json`, PyPI verification, and `mcp-publisher` flow are documented and tested before v0.1 release.
+  - Verified against the official `2025-12-11` schema and preview Registry API
+    with `mcp-publisher validate server.json`. The live publish command remains
+    guarded behind the release workflow because it requires production PyPI
+    publication and Registry mutation.
 
 - [ ] `E6-S7` Document install and hardware setup.
   - Done when docs cover mock install, Hottop config, Hugging Face model config, offline model path, and log output paths.
@@ -1774,3 +1792,21 @@ After completing a story:
   - Ran `./.venv/bin/python -m pyright`: 0 errors.
   - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
   - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E6-S6:
+  - Confirmed official MCP Registry docs still mark the Registry as preview,
+    use schema URI
+    `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`,
+    require PyPI packages to use `registryType: pypi`, and verify PyPI
+    ownership through an `mcp-name: $SERVER_NAME` README marker.
+  - Validated `server.json` against the downloaded `2025-12-11` JSON schema.
+  - Ran `./mcp-publisher validate server.json` with pinned `mcp-publisher`
+    v1.7.9: passed against the preview Registry API.
+  - Verified the workflow's pinned Linux amd64 `mcp-publisher` asset SHA-256:
+    `ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac`.
+  - Confirmed `mcp-publisher login github-oidc` fails outside GitHub Actions
+    without `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, so live auth must run from the
+    release job with `id-token: write`.
+  - Confirmed production PyPI currently returns `Not Found` for
+    `coffee-roaster-mcp` and the Registry search API returns no current listing
+    for `io.github.syamaner/coffee-roaster-mcp`; live publish remains the first
+    destructive decision point after production PyPI publication.

--- a/docs/state/github-issues.md
+++ b/docs/state/github-issues.md
@@ -93,6 +93,7 @@ Milestone: `v0.1`
 - #53 E6-S5: Add release workflow
 - #54 E6-S6: Run MCP Registry publishing verification spike
 - #55 E6-S7: Document install and hardware setup
+- #135 E6-S8: Execute live PyPI and MCP Registry publish
 
 ## Epic 7 Stories
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -300,7 +300,21 @@ status, and the exact `PYPI_API_TOKEN` fallback secret name. Focused workflow
 tests pin the trigger, job ordering, environment/OIDC permissions, immutable
 action refs, publisher verification, release metadata failure messages, publish
 actions, and prerequisite runbook text. Live publishing is not executed by this
-story; E6-S6 remains the MCP Registry verification spike.
+story.
+
+E6-S6 completed the MCP Registry publishing verification spike without a live
+PyPI release or live Registry publish. `server.json` validated against the
+downloaded official `2025-12-11` Registry JSON schema and the preview Registry
+API through `mcp-publisher validate server.json`. The pinned
+`mcp-publisher` v1.7.9 Linux amd64 workflow asset checksum matched the expected
+SHA-256, and the workflow now validates `server.json` before GitHub OIDC
+authentication and publish. `docs/release.md` documents the PyPI README
+verification marker, non-destructive validation commands, exact live-publish
+stop point, prerequisites, expected outcome, and preview Registry risk.
+Production PyPI still returns `Not Found` for `coffee-roaster-mcp`, and the
+Registry search API returns no current listing for
+`io.github.syamaner/coffee-roaster-mcp`; the first destructive step remains the
+tag-triggered live release path after PyPI publication succeeds.
 
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
@@ -308,7 +322,7 @@ first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E6-S6: run the MCP Registry publishing verification spike.
+The next story is E6-S7: document install and hardware setup.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -316,6 +316,11 @@ Registry search API returns no current listing for
 `io.github.syamaner/coffee-roaster-mcp`; the first destructive step remains the
 tag-triggered live release path after PyPI publication succeeds.
 
+Epic 6 now includes follow-up issue #135, `E6-S8: Execute live PyPI and MCP
+Registry publish`, for the controlled live publish after PyPI contains the
+matching package version and the published long description exposes the exact
+`mcp-name` verification marker.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -54,8 +54,9 @@ def test_release_workflow_uses_trusted_publishing_and_release_environment() -> N
 
     assert registry_job["environment"] == "release"
     assert registry_job["permissions"] == {"contents": "read", "id-token": "write"}
+    assert _step_runs(registry_job, "./mcp-publisher validate server.json")
     assert _step_runs(registry_job, "./mcp-publisher login github-oidc")
-    assert _step_runs(registry_job, "./mcp-publisher publish --file=server.json")
+    assert _step_runs(registry_job, "./mcp-publisher publish server.json")
 
 
 def test_release_workflow_pins_actions_and_checkout_credentials() -> None:
@@ -126,6 +127,8 @@ def test_release_runbook_documents_operator_prerequisites() -> None:
         "GitHub environment secret `PYPI_API_TOKEN`",
         "TestPyPI rehearsal is not enabled in the workflow.",
         "MCP Registry publishing runs only after the PyPI publish job succeeds.",
+        "Run `./mcp-publisher validate server.json` before authenticating.",
+        "The first destructive registry operation is `./mcp-publisher publish server.json`.",
     ]
 
     for phrase in expected_phrases:


### PR DESCRIPTION
## Summary
- add non-destructive `mcp-publisher validate server.json` to the release Registry job before OIDC auth and publish
- document current MCP Registry preview verification, PyPI marker checks, live-publish stop point, prerequisites, expected outcome, and risk in `docs/release.md`
- mark E6-S6 complete in state docs and add the E6-S6 session summary
- add follow-up Epic 6 issue #135 for the controlled live PyPI and MCP Registry publish story

## Validation
- `./.venv/bin/python -m pytest tests/test_release_workflow.py tests/test_server_json.py tests/test_readme.py`: 12 passed
- `./.venv/bin/python -m pytest`: 355 passed
- `./.venv/bin/python -m build`: built wheel and sdist
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: passed
- `./.venv/bin/python -m pyright`: 0 errors
- `./.venv/bin/coffee-roaster-mcp --help`: passed
- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`

Closes #54