### PR TITLE
E6-S7: Document install and hardware setup

### DIFF
--- a/.claude/skills/hottop-validation/SKILL.md
+++ b/.claude/skills/hottop-validation/SKILL.md
@@ -10,9 +10,12 @@ Use this skill for Hottop-facing work and release-readiness review.
 ## Current Scope
 
 - Hottop lifecycle, command-loop streaming, packet build/parse, control command state, and temperature-unit handling exist behind the `HottopRoasterDriver` boundary.
-- The MCP roast-session tools still preserve their current one-session store semantics; do not assume MCP heat, fan, drop, or cooling tools are wired to live Hottop hardware until a later story explicitly does that work.
+- The MCP roast-session tools call the configured `RoasterDriver` boundary
+  while preserving the one-session store semantics and fail-closed behavior.
 - The runnable validation entrypoint is `coffee-roaster-mcp hottop-validate`.
 - Hardware stories are not complete from mock tests alone.
+- For operator setup details, including the Hottop config block and log output
+  paths, use `docs/install-and-hardware-setup.md`.
 
 ## Pre-Validation Gates
 

--- a/.claude/skills/mock-roast/SKILL.md
+++ b/.claude/skills/mock-roast/SKILL.md
@@ -11,7 +11,9 @@ Use this skill for the mock-first local workflow.
 
 - `E2-S1` provides a real stdio MCP server entrypoint.
 - `E2-S4` now provides the first roast-session MCP tool surface on the mock path.
-- This workflow validates the mock-safe bootstrap path and the early in-process tool flow without claiming the final export/logging slice is done yet.
+- This workflow validates the mock-safe bootstrap path and the in-process tool
+  flow without roaster hardware, microphone access, model download, or network.
+  For full operator setup details, use `docs/install-and-hardware-setup.md`.
 
 ## Current Validation
 
@@ -38,9 +40,9 @@ mock disabled int8
 - Local bootstrap does not require roaster hardware, microphone access, or model download.
 - The MCP server now exposes the first session-control tool surface for the mock path.
 
-## Do Not Claim Yet
+## Do Not Claim Here
 
-- Do not claim a fully exported mock roast before `E2-S7`, `E5`, and `E7-S1`.
+- Do not claim final end-to-end release readiness before `E7-S1`.
 - Do not add model download, model export, or Hugging Face sync steps here. Those stay in `coffee-first-crack-detection`.
 
 ## Current MCP Tool Flow
@@ -59,11 +61,12 @@ The current mock-path tools are:
 - `export_roast_log`
 - `emergency_stop`
 
-`export_roast_log` currently returns the planned export manifest only. The real JSONL, CSV, and summary writers land in Epic 5.
+`export_roast_log` writes `roast.jsonl`, `roast.csv`, and `summary.json` under
+the configured log directory for the active session.
 
 ## Extend Later
 
-Once the MCP runtime exists, extend this workflow with:
+Extend this workflow with:
 
 - full mock roast start-to-export smoke checks
 - log file content validation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 RoastPilot is a spec-driven MCP server for autonomous coffee roasting.
 
-The package name is `coffee-roaster-mcp`. PyPI publishing is planned for the v0.1 release; this repository currently contains the local package scaffold and project plan.
+The package name is `coffee-roaster-mcp`. PyPI publishing is planned for the v0.1 release; this repository currently contains the local package scaffold, release workflow, registry metadata, and project plan.
 
 RoastPilot will provide one local MCP runtime for roaster control, telemetry, first-crack detection integration, roast metrics, and log export.
 
@@ -22,7 +22,7 @@ The v0.1 direction is one local stdio MCP server that will own:
 - derived roast metrics
 - roast log export
 
-The current repo state is still bootstrap. The package scaffold, config loading, local development commands, pull-request CI, stdio MCP entrypoint, mock roast-session tool surface, and one-process mock vertical slice are in place.
+The current repo state is still bootstrap. The package scaffold, config loading, local development commands, pull-request CI, stdio MCP entrypoint, mock roast-session tool surface, one-process mock vertical slice, release workflow, and MCP Registry metadata are in place.
 
 ## Install
 
@@ -35,7 +35,11 @@ python -m pip install --upgrade pip
 python -m pip install -e . --group dev
 ```
 
-The future user-facing install target is the `coffee-roaster-mcp` package. PyPI publication is planned later in v0.1 after the runtime and distribution stories land.
+The future user-facing install target is the `coffee-roaster-mcp` package. PyPI publication is planned later in v0.1 after the controlled live release story lands.
+
+For operator setup, including mock install, Hottop configuration, Hugging Face
+model configuration, offline model paths, and log output paths, see
+`docs/install-and-hardware-setup.md`.
 
 ## Local Development
 
@@ -121,7 +125,9 @@ The current MCP tool surface includes:
 - `export_roast_log`
 - `emergency_stop`
 
-`export_roast_log` writes snapshot `roast.jsonl`, `roast.csv`, and `summary.json` files for the current in-process session. Append-only telemetry writers and final log schemas land in Epic 5.
+`export_roast_log` writes `roast.jsonl`, `roast.csv`, and `summary.json` files
+for the current in-process session. Runtime events and sampled telemetry are
+also appended to `roast.jsonl` during the roast.
 
 ### Operational MCP Flow
 
@@ -189,6 +195,9 @@ This confirms the bootstrap defaults are still aligned with the mock vertical-sl
 
 ## Hottop Configuration And Validation
 
+The concise setup path is in `docs/install-and-hardware-setup.md`; this section
+summarizes the guarded validation workflow.
+
 Hottop support lives behind the `RoasterDriver` abstraction. The current driver has lifecycle, command-loop, packet, control-state, and temperature-unit support, but it still requires guarded manual validation before any hardware-ready release label.
 
 Configuration lives in `coffee-roaster-mcp.yaml`. Keep local development on the mock driver unless you are intentionally validating connected Hottop hardware:
@@ -242,6 +251,10 @@ be treated as a failed validation and should not be required by normal CI.
 ## Configuration
 
 RoastPilot loads configuration from `coffee-roaster-mcp.yaml` in the current directory by default. If the file is absent, mock-safe defaults are used so local development does not require roaster hardware, audio hardware, or model downloads.
+
+See `docs/install-and-hardware-setup.md` for setup-focused examples covering
+mock install, Hottop configuration, Hugging Face model configuration, offline
+model paths, and log output paths.
 
 ```yaml
 transport:
@@ -389,5 +402,5 @@ Current export files:
   metrics, roaster driver, and first-crack model metadata
 - output under `logs/roasts/{session_id}/`
 
-Final cross-format log schema completeness tests and broad release validation
-land in later stories.
+Cross-format log schema completeness tests are in place. Broad release
+validation and end-to-end agent roast validation land in later stories.

--- a/docs/install-and-hardware-setup.md
+++ b/docs/install-and-hardware-setup.md
@@ -1,0 +1,291 @@
+# RoastPilot Install And Hardware Setup
+
+This guide covers the operator setup path for `coffee-roaster-mcp` before live
+PyPI and MCP Registry publication. It is intentionally documentation-only:
+do not use it as evidence that a live PyPI publish, MCP Registry publish,
+hardware validation, model training, model export, model sync, or real
+microphone validation has been executed.
+
+## Mock Install
+
+The default RoastPilot path is mock-safe:
+
+- `roaster.driver: mock`
+- `first_crack.mode: disabled`
+- no Hottop hardware
+- no microphone
+- no Hugging Face model download
+- logs written under `./logs` unless configured otherwise
+
+For local development from a clone:
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e . --group dev
+coffee-roaster-mcp --help
+coffee-roaster-mcp --version
+```
+
+For the installed package after the live PyPI release:
+
+```bash
+python -m pip install coffee-roaster-mcp
+coffee-roaster-mcp --help
+coffee-roaster-mcp --version
+coffee-roaster-mcp serve
+```
+
+The MCP Registry metadata advertises a `uvx` runtime hint. After PyPI publish,
+an MCP client can launch the package through the registry or equivalent local
+stdio command that runs `coffee-roaster-mcp serve`. Before PyPI publish, use the
+editable install path above.
+
+Confirm the defaults from an empty directory:
+
+```bash
+python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision, c.logging.log_dir); tmp.cleanup()"
+```
+
+Expected output:
+
+```text
+mock disabled int8 logs
+```
+
+## Configuration File
+
+RoastPilot loads `coffee-roaster-mcp.yaml` from the current working directory by
+default. Use `COFFEE_ROASTER_MCP_CONFIG` to point at another file.
+
+Start from this mock-safe configuration:
+
+```yaml
+transport:
+  type: stdio
+
+roaster:
+  driver: mock
+  port: null
+  baudrate: 115200
+  temperature_unit: celsius
+  command_interval_seconds: 0.3
+
+first_crack:
+  mode: disabled
+  repo_id: syamaner/coffee-first-crack-detection
+  revision: null
+  precision: int8
+  local_model_dir: null
+  onnx_threads: 2
+  allow_manual_override: true
+
+audio:
+  source: microphone
+  input_device: null
+  sample_rate: 16000
+  wav_path: null
+
+logging:
+  log_dir: ./logs
+  sample_interval_seconds: 5.0
+  export_formats:
+    - jsonl
+    - csv
+    - summary
+
+session:
+  auto_t0_detection_enabled: false
+  auto_t0_drop_threshold_c: 25.0
+  ror_window_seconds: 60
+  ror_min_sample_seconds: 10
+```
+
+Supported environment overrides:
+
+- `COFFEE_ROASTER_MCP_CONFIG`
+- `COFFEE_ROASTER_DRIVER`
+- `COFFEE_ROASTER_PORT`
+- `COFFEE_ROASTER_TEMP_UNIT`
+- `COFFEE_FIRST_CRACK_MODE`
+- `COFFEE_FIRST_CRACK_REPO_ID`
+- `COFFEE_FIRST_CRACK_REVISION`
+- `COFFEE_FIRST_CRACK_PRECISION`
+- `COFFEE_FIRST_CRACK_LOCAL_MODEL_DIR`
+- `COFFEE_FIRST_CRACK_ONNX_THREADS`
+- `COFFEE_AUDIO_SOURCE`
+- `COFFEE_AUDIO_INPUT_DEVICE`
+- `COFFEE_AUDIO_SAMPLE_RATE`
+- `COFFEE_AUDIO_WAV_PATH`
+- `COFFEE_ROAST_LOG_DIR`
+- `COFFEE_AUTO_T0_DROP_THRESHOLD_C`
+- `HF_HOME`
+
+`HF_HOME` is consumed by Hugging Face tooling directly. It is not copied into
+the RoastPilot config object.
+
+## Hottop Configuration
+
+Keep normal setup on the mock driver until you intentionally operate connected
+Hottop hardware. To configure the supported Hottop driver, set:
+
+```yaml
+roaster:
+  driver: hottop_kn8828b_2k_plus
+  port: /dev/cu.usbserial-XXXX
+  baudrate: 115200
+  temperature_unit: auto
+  command_interval_seconds: 0.3
+```
+
+Port discovery is platform-specific:
+
+- macOS USB serial adapters usually appear under `/dev/cu.*`.
+- Linux and Raspberry Pi USB serial adapters commonly appear under
+  `/dev/ttyUSB*` or `/dev/ttyACM*`.
+- Confirm the device appears after plugging in the adapter and that no other
+  process has the port open.
+
+Hottop operation is hardware-facing. Only use this config with a supervised
+roaster, a known stop plan, and an operator who understands heat, fan, drop,
+cooling, emergency stop, and physical power-off expectations.
+
+The guarded driver validation harness is:
+
+```bash
+coffee-roaster-mcp hottop-validate \
+  --config coffee-roaster-mcp.yaml \
+  --output docs/validation/hottop-non-destructive.json \
+  --i-understand-this-controls-hardware
+```
+
+The irreversible drop and emergency-stop checks are opt-in and remain outside
+this setup story:
+
+```bash
+coffee-roaster-mcp hottop-validate \
+  --config coffee-roaster-mcp.yaml \
+  --output docs/validation/hottop-full.json \
+  --i-understand-this-controls-hardware \
+  --include-drop \
+  --include-emergency-stop
+```
+
+Do not commit generated validation JSON, raw serial captures, roast logs, or
+local environment files unless a later validation story explicitly calls for a
+sanitized artifact.
+
+## Hugging Face Model Configuration
+
+This repository consumes released first-crack artifacts only. Model training,
+ONNX export, Hugging Face sync, model cards, and dataset cards stay in
+`coffee-first-crack-detection`.
+
+The safe default is disabled:
+
+```yaml
+first_crack:
+  mode: disabled
+  repo_id: syamaner/coffee-first-crack-detection
+  revision: null
+  precision: int8
+  local_model_dir: null
+  onnx_threads: 2
+  allow_manual_override: true
+```
+
+To enable the released Hugging Face ONNX detector deliberately:
+
+```yaml
+first_crack:
+  mode: audio
+  repo_id: syamaner/coffee-first-crack-detection
+  revision: <pinned-hub-revision>
+  precision: int8
+  local_model_dir: null
+  onnx_threads: 2
+  allow_manual_override: true
+
+audio:
+  source: microphone
+  input_device: null
+  sample_rate: 16000
+  wav_path: null
+```
+
+`precision: int8` selects `onnx/int8/model_quantized.onnx`.
+`precision: fp32` selects `onnx/fp32/model.onnx`. Both precisions also require
+the matching `onnx/{precision}/preprocessor_config.json` artifact.
+
+For recorded replay instead of a microphone:
+
+```yaml
+audio:
+  source: wav
+  input_device: null
+  sample_rate: 16000
+  wav_path: /path/to/replay.wav
+```
+
+The WAV sample rate must match `audio.sample_rate`. Real microphone validation
+is gated manual work and is not required for normal CI or this story.
+
+## Offline Model Path
+
+Set `first_crack.local_model_dir` to consume an already downloaded model tree
+without Hugging Face network access:
+
+```yaml
+first_crack:
+  mode: audio
+  repo_id: syamaner/coffee-first-crack-detection
+  revision: <recorded-local-artifact-revision>
+  precision: int8
+  local_model_dir: /opt/roastpilot/models/coffee-first-crack-detection
+  onnx_threads: 2
+  allow_manual_override: true
+```
+
+The local directory must preserve the released repository-relative paths:
+
+```text
+/opt/roastpilot/models/coffee-first-crack-detection/
+  onnx/
+    int8/
+      model_quantized.onnx
+      preprocessor_config.json
+    fp32/
+      model.onnx
+      preprocessor_config.json
+```
+
+Configure only the precision you intend to run. If the selected ONNX model or
+preprocessor config is missing, audio-mode startup reports first-crack status as
+`unavailable` rather than falling back to a different artifact.
+
+## Log Output Paths
+
+`logging.log_dir` controls the root log directory and defaults to `./logs`.
+Use `COFFEE_ROAST_LOG_DIR` to override it without changing YAML.
+
+Runtime and snapshot logs are written under:
+
+```text
+{logging.log_dir}/roasts/{session_id}/
+```
+
+Current files are:
+
+- `roast.jsonl`: append-only event rows plus sampled telemetry rows during the
+  roast
+- `roast.csv`: exported telemetry and event rows
+- `summary.json`: exported session summary, metrics, configured roaster driver,
+  and first-crack model metadata
+
+Telemetry rows are sampled at `logging.sample_interval_seconds`, defaulting to
+5 seconds. Event rows are written immediately when session events are recorded.
+
+Do not commit generated files under `logs/`. For release or hardware evidence,
+record sanitized paths and checksums in the relevant validation issue or session
+summary instead of committing local roast output.

--- a/docs/release.md
+++ b/docs/release.md
@@ -15,6 +15,9 @@ Before enabling a live release, the release owner must confirm:
 - A PyPI account exists for the release owner.
 - The PyPI project name `coffee-roaster-mcp` is owned or reserved by the
   release owner.
+- `docs/install-and-hardware-setup.md` has been reviewed for the target release
+  install mode, Hottop configuration, Hugging Face model configuration, offline
+  model path, and log output paths.
 - PyPI two-factor authentication is enabled and recovery codes are stored in
   the project owner password manager.
 - PyPI Trusted Publishing is configured for:
@@ -90,6 +93,9 @@ After all prerequisites are confirmed:
 6. Confirm the MCP Registry entry for
    `io.github.syamaner/coffee-roaster-mcp` shows the expected PyPI package and
    stdio transport.
+7. Run the install smoke and setup checks from
+   `docs/install-and-hardware-setup.md` for the intended deployment mode before
+   any hardware-ready labeling.
 
 MCP Registry publishing runs only after the PyPI publish job succeeds. The
 registry job validates `server.json` against the preview Registry API before

--- a/docs/session-summaries/2026-05-24-e6-s7-install-and-hardware-setup-docs.md
+++ b/docs/session-summaries/2026-05-24-e6-s7-install-and-hardware-setup-docs.md
@@ -72,6 +72,10 @@ Full validation:
 - `./.venv/bin/coffee-roaster-mcp --help`: passed
 - `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
 
+## Usage Snapshot
+
+- Token usage: `261K used`
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E6-S7 should

--- a/docs/session-summaries/2026-05-24-e6-s7-install-and-hardware-setup-docs.md
+++ b/docs/session-summaries/2026-05-24-e6-s7-install-and-hardware-setup-docs.md
@@ -1,0 +1,83 @@
+# E6-S7 Install And Hardware Setup Docs
+
+This summary captures the E6-S7 documentation update, validation state, and
+restart context.
+
+## Scope
+
+Story: `E6-S7` / issue `#55`, document install and hardware setup.
+
+Branch: `feature/55-install-and-hardware-setup-docs`
+
+The implementation stayed inside the E6-S7 documentation boundary:
+
+- document mock install from a local clone and the later PyPI package path
+- document `coffee-roaster-mcp.yaml` and supported environment overrides
+- document Hottop configuration and guarded validation commands
+- document Hugging Face released-model configuration
+- document offline model directory layout
+- document runtime and snapshot log output paths
+- cross-reference the setup guide from README and release readiness docs
+
+No live PyPI publish, live MCP Registry publish, hardware validation, model
+training/export/sync, real microphone validation, or broad release validation
+was performed.
+
+## Implementation Summary
+
+Added `docs/install-and-hardware-setup.md` as the dedicated setup runbook for
+operators and release readiness. The guide covers:
+
+- mock-safe defaults and local editable install
+- the planned installed-package command path after PyPI publication
+- `coffee-roaster-mcp.yaml` defaults and environment overrides
+- Hottop serial configuration, supervised-operation cautions, and guarded
+  `hottop-validate` commands
+- released Hugging Face ONNX detector configuration for audio mode
+- offline `first_crack.local_model_dir` layout using repository-relative
+  artifact paths
+- log output under `{logging.log_dir}/roasts/{session_id}/`, including
+  `roast.jsonl`, `roast.csv`, and `summary.json`
+
+Updated README to link the setup guide from the install and configuration
+sections, and corrected stale wording that implied append-only telemetry writers
+and final log schemas had not landed.
+
+Updated `docs/release.md` so live release operators review the setup guide
+before publishing and before any hardware-ready labeling.
+
+Added focused documentation coverage in `tests/test_readme.py` for the E6-S7
+required topics and the README/release cross-references.
+
+Durable state updates:
+
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md` marks `E6-S7` complete and
+  sets the active story to `E6-S8`.
+- `docs/state/registry.md` records the setup guide and says the next story is
+  `E6-S8: Execute live PyPI and MCP Registry publish`.
+
+## Validation
+
+Focused validation:
+
+- `./.venv/bin/python -m pytest tests/test_readme.py tests/test_release_workflow.py`:
+  9 passed
+
+Full validation:
+
+- `./.venv/bin/python -m pytest`: 356 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+
+## Restart Prompt
+
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. PR for E6-S7 should
+be checked first. If it has merged, verify issue #55 is closed, check out
+`main`, run `git pull --ff-only origin main`, then begin E6-S8 from updated
+main on the appropriate `feature/135-...` branch after reading the registry,
+active epic, this summary, and GitHub issue #135. Keep E6-S8 scoped to the
+controlled live PyPI and MCP Registry publish, and do not conflate it with
+hardware validation, model training/export/sync, or real microphone validation.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E6-S7`
-- Current target: Document install and hardware setup
+- Active story: `E6-S8`
+- Current target: Execute live PyPI and MCP Registry publish
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -345,6 +345,13 @@ The first implementation milestone is a mock vertical slice that requires no roa
   live publish stop point, prerequisites, expected outcome, and preview
   Registry risk. The remaining destructive step is the tag-triggered live
   release path after production PyPI publication succeeds.
+- `E6-S7` documents install and hardware setup without executing any live
+  publishing, hardware validation, model training/export/sync, or real
+  microphone validation. `docs/install-and-hardware-setup.md` now covers the
+  mock install path, Hottop configuration, Hugging Face model configuration,
+  offline model directory layout, and log output paths. README and
+  `docs/release.md` cross-reference that setup guide for release and operator
+  readiness.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
@@ -730,7 +737,7 @@ Goal: make RoastPilot installable and discoverable through PyPI and the MCP Regi
     guarded behind the release workflow because it requires production PyPI
     publication and Registry mutation.
 
-- [ ] `E6-S7` Document install and hardware setup.
+- [x] `E6-S7` Document install and hardware setup.
   - Done when docs cover mock install, Hottop config, Hugging Face model config, offline model path, and log output paths.
 
 - [ ] `E6-S8` Execute live PyPI and MCP Registry publish.
@@ -1827,3 +1834,24 @@ After completing a story:
     `coffee-roaster-mcp` and the Registry search API returns no current listing
     for `io.github.syamaner/coffee-roaster-mcp`; live publish remains the first
     destructive decision point after production PyPI publication.
+- Validation run for E6-S7:
+  - Added `docs/install-and-hardware-setup.md` with setup-focused coverage for
+    mock install, `coffee-roaster-mcp.yaml`, Hottop configuration, Hugging Face
+    model configuration, offline model directory layout, and log output paths.
+  - Updated README to point operators at the setup guide and corrected current
+    log-export wording now that append-only JSONL, CSV, and summary schemas
+    exist.
+  - Updated `docs/release.md` so release operators review the setup guide
+    before live release and before hardware-ready labeling.
+  - Added focused documentation coverage in `tests/test_readme.py` to pin the
+    E6-S7 required topics and cross-references.
+  - Kept live PyPI publish, live MCP Registry publish, hardware validation,
+    model training/export/sync, and real microphone validation out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_readme.py tests/test_release_workflow.py`:
+    9 passed.
+  - Ran `./.venv/bin/python -m pytest`: 356 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -321,13 +321,24 @@ Registry publish`, for the controlled live publish after PyPI contains the
 matching package version and the published long description exposes the exact
 `mcp-name` verification marker.
 
+E6-S7 added `docs/install-and-hardware-setup.md` as the setup runbook for mock
+install, Hottop configuration, Hugging Face model configuration, offline model
+paths, and log output paths. README and the release runbook now cross-reference
+that setup guide so release operators can distinguish mock-safe setup from
+guarded Hottop operation, audio-mode model setup, and later live validation.
+This documentation story did not execute live PyPI publish, live MCP Registry
+publish, hardware validation, model training/export/sync, or real microphone
+validation.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E6-S7: document install and hardware setup.
+The next story is E6-S8: execute live PyPI and MCP Registry publish after
+production PyPI exposes the matching package version and README verification
+marker.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,4 +1,4 @@
-"""README coverage for public MCP Registry verification metadata."""
+"""Documentation coverage for public setup and registry metadata."""
 
 from pathlib import Path
 
@@ -11,3 +11,31 @@ def test_readme_includes_mcp_verification_string() -> None:
     readme_text = readme.read_text(encoding="utf-8")
 
     assert readme_text.count(verification_string) == 1
+
+
+def test_install_and_hardware_setup_docs_cover_required_topics() -> None:
+    """Check the E6-S7 setup docs cover the required operator topics."""
+    docs_root = Path(__file__).resolve().parents[1] / "docs"
+    setup_doc = (docs_root / "install-and-hardware-setup.md").read_text(encoding="utf-8")
+    readme = (Path(__file__).resolve().parents[1] / "README.md").read_text(encoding="utf-8")
+    release_doc = (docs_root / "release.md").read_text(encoding="utf-8")
+
+    expected_phrases = [
+        "## Mock Install",
+        "## Hottop Configuration",
+        "## Hugging Face Model Configuration",
+        "## Offline Model Path",
+        "## Log Output Paths",
+        "roaster.driver: mock",
+        "hottop_kn8828b_2k_plus",
+        "syamaner/coffee-first-crack-detection",
+        "first_crack.local_model_dir",
+        "{logging.log_dir}/roasts/{session_id}/",
+        "Do not commit generated files under `logs/`.",
+    ]
+
+    for phrase in expected_phrases:
+        assert phrase in setup_doc
+
+    assert "docs/install-and-hardware-setup.md" in readme
+    assert "docs/install-and-hardware-setup.md" in release_doc


### PR DESCRIPTION
## Summary
- add `docs/install-and-hardware-setup.md` covering mock install, Hottop configuration, Hugging Face model configuration, offline model paths, and log output paths
- cross-reference the setup guide from README, release readiness docs, and repo-local readiness runbooks
- mark E6-S7 complete in state docs, add the E6-S7 session summary, and route the next story to E6-S8 live PyPI and MCP Registry publish
- add focused documentation coverage for the required setup topics and cross-references

## Validation
- `./.venv/bin/python -m pytest tests/test_readme.py tests/test_release_workflow.py`: 9 passed
- `./.venv/bin/python -m pytest`: 356 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: passed
- `./.venv/bin/python -m pyright`: 0 errors
- `./.venv/bin/coffee-roaster-mcp --help`: passed
- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive install-and-hardware-setup runbook covering mock-safe install, Hottop hardware setup, model/offline paths, logging conventions, and guarded vs full validation; updated README, release guide, registry/epic docs, session summaries, and skill docs to cross-reference and clarify validation/export behavior.
* **Tests**
  * Added test ensuring install-and-hardware-setup and related docs cover required operator/setup topics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->