### PR TITLE
E6-S8: Record live PyPI and MCP Registry publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 RoastPilot is a spec-driven MCP server for autonomous coffee roasting.
 
-The package name is `coffee-roaster-mcp`. PyPI publishing is planned for the v0.1 release; this repository currently contains the local package scaffold, release workflow, registry metadata, and project plan.
+The package name is `coffee-roaster-mcp`. Version `0.1.0` is published on
+production PyPI and listed in the MCP Registry as
+`io.github.syamaner/coffee-roaster-mcp`.
 
 RoastPilot will provide one local MCP runtime for roaster control, telemetry, first-crack detection integration, roast metrics, and log export.
 
@@ -35,7 +37,11 @@ python -m pip install --upgrade pip
 python -m pip install -e . --group dev
 ```
 
-The future user-facing install target is the `coffee-roaster-mcp` package. PyPI publication is planned later in v0.1 after the controlled live release story lands.
+The user-facing install target is the published `coffee-roaster-mcp` package:
+
+```bash
+python -m pip install coffee-roaster-mcp
+```
 
 For operator setup, including mock install, Hottop configuration, Hugging Face
 model configuration, offline model paths, and log output paths, see

--- a/docs/release.md
+++ b/docs/release.md
@@ -155,3 +155,76 @@ listing data can change or reset before general availability. A failed publish
 after PyPI succeeds leaves PyPI live without Registry discoverability and should
 be retried only after checking Registry status and confirming no partial
 version entry was created.
+
+## v0.1.0 Live Publish Outcome
+
+The first live release completed on 2026-05-24 through GitHub Actions run
+`26367482422`:
+
+- Tag: `v0.1.0`
+- Commit: `276ec81056e05ed8a863c5e5bb9bf28e45308383`
+- Workflow: `https://github.com/syamaner/coffee-roaster-mcp/actions/runs/26367482422`
+- PyPI project: `https://pypi.org/project/coffee-roaster-mcp/`
+- PyPI release: `https://pypi.org/project/coffee-roaster-mcp/0.1.0/`
+- MCP Registry search:
+  `https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.syamaner/coffee-roaster-mcp`
+
+Release job outcomes:
+
+- `Validate Release Metadata`: success
+- `Checks`: success
+- `Build Package`: success
+- `Publish PyPI`: success after `release` environment approval
+- `Publish MCP Registry`: success after PyPI publish
+- `Release Dry Run`: skipped, as expected for a tag push
+
+Verification commands and outcomes:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+curl -L https://pypi.org/pypi/coffee-roaster-mcp/json
+curl -L https://pypi.org/pypi/coffee-roaster-mcp/json | jq -r '.info.version, (.info.description | contains("<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->")), .info.package_url, .info.release_url, (.urls[] | [.filename, .packagetype, .digests.sha256] | @tsv)'
+/tmp/mcp-publisher validate server.json
+curl -L 'https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.syamaner/coffee-roaster-mcp'
+python3.11 -m venv /tmp/coffee-roaster-mcp-pypi-smoke
+/tmp/coffee-roaster-mcp-pypi-smoke/bin/python -m pip install --no-cache-dir coffee-roaster-mcp==0.1.0
+/tmp/coffee-roaster-mcp-pypi-smoke/bin/coffee-roaster-mcp --help
+/tmp/coffee-roaster-mcp-pypi-smoke/bin/coffee-roaster-mcp --version
+/tmp/coffee-roaster-mcp-pypi-smoke/bin/python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
+```
+
+Confirmed outcomes:
+
+- Production PyPI exposes `coffee-roaster-mcp` version `0.1.0`.
+- The published PyPI long description contains
+  `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`.
+- PyPI artifacts:
+  - `coffee_roaster_mcp-0.1.0-py3-none-any.whl`, SHA-256
+    `d8cd00257bf30ddf89b98eff07d2b3d93369e3b441d9ef60f99b825e45436f33`
+  - `coffee_roaster_mcp-0.1.0.tar.gz`, SHA-256
+    `8c6ea87f4ccbae4654ac6df2c1588b86f79bdf1e54e19ec301aa7ef87b283e0c`
+- `mcp-publisher validate server.json` returned `server.json is valid`.
+- Registry search returns `io.github.syamaner/coffee-roaster-mcp` with
+  PyPI package `coffee-roaster-mcp`, version `0.1.0`, runtime hint `uvx`, and
+  stdio transport.
+- Clean production-PyPI install succeeded in
+  `/tmp/coffee-roaster-mcp-pypi-smoke`.
+- Installed-package smokes returned `coffee-roaster-mcp 0.1.0` and
+  mock-safe defaults `mock disabled int8`.
+
+Retry and rollback notes:
+
+- The `v0.1.0` tag creation bypassed a protected-tag creation rule, as reported
+  by GitHub during `git push origin v0.1.0`; keep tag protection and release
+  environment ownership under review before the next release.
+- PyPI releases cannot be overwritten. If a package problem is found, fix
+  forward with a new version and document the issue; yank `0.1.0` only if the
+  package is actively harmful.
+- If the Registry listing drifts or resets while the preview Registry is still
+  mutable, rerun `mcp-publisher validate server.json`, confirm PyPI still
+  exposes the matching package and marker, then retry the Registry publish path.
+- The published `0.1.0` long description came from the pre-release README text
+  and still says PyPI publication was planned. The verification marker and
+  package metadata are correct; README wording was corrected after release for
+  future publications.

--- a/docs/session-summaries/2026-05-24-e6-s8-live-pypi-and-mcp-registry-publish.md
+++ b/docs/session-summaries/2026-05-24-e6-s8-live-pypi-and-mcp-registry-publish.md
@@ -149,6 +149,10 @@ Final documentation and repo validation after updating release/state docs:
   still says PyPI publication was planned. The marker and metadata are correct;
   README wording was corrected after release for future publications.
 
+## Usage Snapshot
+
+- Token usage: `448K used`
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. E6-S8 live PyPI and

--- a/docs/session-summaries/2026-05-24-e6-s8-live-pypi-and-mcp-registry-publish.md
+++ b/docs/session-summaries/2026-05-24-e6-s8-live-pypi-and-mcp-registry-publish.md
@@ -1,0 +1,160 @@
+# E6-S8 Live PyPI And MCP Registry Publish
+
+This summary captures the controlled E6-S8 live publish, validation state, and
+restart context.
+
+## Scope
+
+Story: `E6-S8` / issue `#135`, execute live PyPI and MCP Registry publish.
+
+Branch: `feature/135-live-pypi-and-mcp-registry-publish`
+
+The implementation stayed inside the live distribution boundary:
+
+- verify release prerequisites before publishing
+- publish production PyPI package `coffee-roaster-mcp` `0.1.0`
+- confirm the published PyPI long description includes the exact
+  `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->` marker
+- run clean install and CLI smokes from the production PyPI package
+- validate `server.json` with `mcp-publisher`
+- publish MCP Registry metadata only after PyPI succeeds
+- confirm Registry search returns the expected listing, PyPI package, version,
+  runtime hint, and stdio transport
+- record commands, links, outcomes, risks, and retry/rollback notes
+
+No hardware validation, model training/export/sync, or real microphone
+validation was performed.
+
+## Publish Summary
+
+Prerequisite gate:
+
+- PR #136 was merged.
+- Issue #55 was closed.
+- `main` was fast-forwarded to
+  `276ec81056e05ed8a863c5e5bb9bf28e45308383`.
+- Branch
+  `feature/135-live-pypi-and-mcp-registry-publish` was created from updated
+  `main`.
+
+Pre-publish checks:
+
+- No local or remote `v0.1.0` tag existed.
+- `server.json.version`, `server.json.packages[0].version`, and
+  `coffee_roaster_mcp.__version__` were aligned at `0.1.0`.
+- Production PyPI returned `Not Found` for `coffee-roaster-mcp` before release.
+- Registry search returned no listing for
+  `io.github.syamaner/coffee-roaster-mcp` before release.
+- `/tmp/mcp-publisher validate server.json` returned `server.json is valid`.
+
+Live publish:
+
+- Created and pushed tag `v0.1.0`.
+- GitHub reported a protected-tag creation rule was bypassed for this tag.
+- GitHub Actions release run:
+  `https://github.com/syamaner/coffee-roaster-mcp/actions/runs/26367482422`
+- Run result: success.
+- `Publish PyPI` succeeded after `release` environment approval.
+- `Publish MCP Registry` succeeded after `Publish PyPI`.
+
+Live links:
+
+- PyPI project: `https://pypi.org/project/coffee-roaster-mcp/`
+- PyPI release: `https://pypi.org/project/coffee-roaster-mcp/0.1.0/`
+- Registry search:
+  `https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.syamaner/coffee-roaster-mcp`
+
+Confirmed PyPI artifacts:
+
+- `coffee_roaster_mcp-0.1.0-py3-none-any.whl`
+  - SHA-256:
+    `d8cd00257bf30ddf89b98eff07d2b3d93369e3b441d9ef60f99b825e45436f33`
+- `coffee_roaster_mcp-0.1.0.tar.gz`
+  - SHA-256:
+    `8c6ea87f4ccbae4654ac6df2c1588b86f79bdf1e54e19ec301aa7ef87b283e0c`
+
+Confirmed Registry listing:
+
+- Name: `io.github.syamaner/coffee-roaster-mcp`
+- Package registry: PyPI
+- Package identifier: `coffee-roaster-mcp`
+- Version: `0.1.0`
+- Runtime hint: `uvx`
+- Transport: `stdio`
+
+## Validation
+
+Local prerelease validation:
+
+- `./.venv/bin/python -m pytest`: 356 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/python -m build`: built source distribution and wheel
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
+- `/tmp/mcp-publisher validate server.json`: `server.json is valid`
+
+Release workflow validation:
+
+- `Validate Release Metadata`: success
+- `Checks`: success
+- `Build Package`: success
+- `Publish PyPI`: success
+- `Publish MCP Registry`: success
+- `Release Dry Run`: skipped as expected for a tag push
+
+Post-release PyPI validation:
+
+- `curl -L https://pypi.org/pypi/coffee-roaster-mcp/json`: returned version
+  `0.1.0`.
+- The PyPI long description contains the exact verification marker:
+  `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`.
+- Clean install command:
+  `/tmp/coffee-roaster-mcp-pypi-smoke/bin/python -m pip install --no-cache-dir coffee-roaster-mcp==0.1.0`
+  succeeded.
+- Installed CLI help smoke passed from `/tmp`.
+- Installed CLI version smoke returned `coffee-roaster-mcp 0.1.0`.
+- Installed config smoke from an empty temporary directory returned
+  `mock disabled int8`.
+
+Post-release Registry validation:
+
+- `/tmp/mcp-publisher validate server.json`: `server.json is valid`.
+- Registry search returned one listing for
+  `io.github.syamaner/coffee-roaster-mcp` with PyPI package
+  `coffee-roaster-mcp` and stdio transport.
+
+Final documentation and repo validation after updating release/state docs:
+
+- `./.venv/bin/python -m pytest tests/test_readme.py tests/test_release_workflow.py`:
+  9 passed.
+- `./.venv/bin/python -m pytest`: 356 passed.
+- `./.venv/bin/python -m ruff check .`: passed.
+- `./.venv/bin/python -m ruff format --check .`: passed.
+- `./.venv/bin/python -m pyright`: 0 errors.
+- `./.venv/bin/coffee-roaster-mcp --help`: passed.
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+
+## Risks And Retry Notes
+
+- PyPI packages cannot be overwritten. If the `0.1.0` package has a defect,
+  fix forward with a new version; yank only if the release is actively harmful.
+- The MCP Registry is still preview. If listing data resets or drifts, rerun
+  `mcp-publisher validate server.json`, confirm PyPI still exposes the matching
+  package and marker, then retry the Registry publish path.
+- The `v0.1.0` tag push reported a protected-tag creation rule bypass. Review
+  tag protection before the next live release.
+- The published `0.1.0` long description came from the pre-release README and
+  still says PyPI publication was planned. The marker and metadata are correct;
+  README wording was corrected after release for future publications.
+
+## Restart Prompt
+
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. E6-S8 live PyPI and
+MCP Registry publish has completed successfully for `0.1.0`. Before the next
+story, verify the E6-S8 PR is merged and issue #135 is closed, then sync
+`main`. Route next work to Epic 7 broad mock-safe release validation unless the
+operator explicitly selects a different story. Do not run hardware validation,
+model training/export/sync, or real microphone validation unless the selected
+story explicitly requires it.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E6-S8`
-- Current target: Execute live PyPI and MCP Registry publish
+- Active story: `E7-S1`
+- Current target: Broad mock-safe release validation
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -352,15 +352,23 @@ The first implementation milestone is a mock vertical slice that requires no roa
   offline model directory layout, and log output paths. README and
   `docs/release.md` cross-reference that setup guide for release and operator
   readiness.
+- `E6-S8` executed the controlled live release for `coffee-roaster-mcp`
+  `0.1.0`. The tag-triggered GitHub Actions release run published to production
+  PyPI, then published MCP Registry metadata after PyPI succeeded. Production
+  PyPI exposes the matching version and exact `mcp-name` marker, a clean PyPI
+  install smoke passed, `mcp-publisher validate server.json` passed, and
+  Registry search returns `io.github.syamaner/coffee-roaster-mcp` pointing to
+  PyPI package `coffee-roaster-mcp` with stdio transport. `docs/release.md`
+  records commands, links, outcomes, risks, and retry/rollback notes.
 - Configuration loads from mock-safe defaults, optional `coffee-roaster-mcp.yaml`, and environment overrides. YAML file support uses PyYAML as a declared runtime dependency.
 - Agent rules and repo-local workflows are now part of the scaffold. `AGENTS.md`, `.claude/skills/code-quality`, `.claude/skills/mcp-dev`, `.claude/skills/mock-roast`, `.claude/skills/hottop-validation`, `.claude/skills/release-registry`, and Copilot review instructions should be kept current as story workflow changes.
 - The old `coffee-roasting` POC is a behavior reference for Epic 2, especially `roaster_control/mcp_server.py`, `roaster_control/server.py`, `roaster_control/session_manager.py`, and `roaster_control/roast_tracker.py`. It is not a template for carrying forward the old split MCP, Auth0, SSE, or `n8n` architecture.
 
 ## Current Risks
 
-- MCP Registry publishing is preview; live publish can still fail or reset even
-  though the metadata template and publisher flow have been verified
-  non-destructively.
+- MCP Registry publishing is preview; the live `0.1.0` listing is published,
+  but preview Registry data can still reset or change before general
+  availability.
 - First-crack event integration must preserve one authoritative session timeline.
 - Log schema changes need compatibility discipline once users start collecting roast logs.
 
@@ -740,7 +748,7 @@ Goal: make RoastPilot installable and discoverable through PyPI and the MCP Regi
 - [x] `E6-S7` Document install and hardware setup.
   - Done when docs cover mock install, Hottop config, Hugging Face model config, offline model path, and log output paths.
 
-- [ ] `E6-S8` Execute live PyPI and MCP Registry publish.
+- [x] `E6-S8` Execute live PyPI and MCP Registry publish.
   - GitHub issue: #135
   - Done when production PyPI contains the matching `coffee-roaster-mcp`
     version, the published PyPI long description includes
@@ -924,6 +932,47 @@ After completing a story:
   - Ran `./.venv/bin/python -m pyright`: 0 errors.
   - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
   - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E6-S8:
+  - Verified PR #136 was merged and issue #55 was closed before starting.
+  - Synced `main` to merge commit `276ec81056e05ed8a863c5e5bb9bf28e45308383`
+    and created branch `feature/135-live-pypi-and-mcp-registry-publish`.
+  - Confirmed no local or remote `v0.1.0` tag existed before release.
+  - Confirmed production PyPI returned `Not Found` before release and Registry
+    search returned no listing for `io.github.syamaner/coffee-roaster-mcp`.
+  - Ran `./.venv/bin/python -m pytest`: 356 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/python -m build`: built
+    `coffee_roaster_mcp-0.1.0.tar.gz` and
+    `coffee_roaster_mcp-0.1.0-py3-none-any.whl`.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`:
+    `coffee-roaster-mcp 0.1.0`.
+  - Ran `/tmp/mcp-publisher validate server.json`: `server.json is valid`.
+  - Pushed tag `v0.1.0`; GitHub reported a protected-tag creation rule was
+    bypassed for this tag.
+  - Confirmed GitHub Actions release run `26367482422` completed successfully:
+    `Validate Release Metadata`, `Checks`, `Build Package`, `Publish PyPI`,
+    and `Publish MCP Registry` all succeeded.
+  - Confirmed PyPI project `https://pypi.org/project/coffee-roaster-mcp/` and
+    release `https://pypi.org/project/coffee-roaster-mcp/0.1.0/` expose version
+    `0.1.0` with the exact `mcp-name` marker in the long description.
+  - Confirmed PyPI artifact SHA-256 hashes:
+    `coffee_roaster_mcp-0.1.0-py3-none-any.whl`
+    `d8cd00257bf30ddf89b98eff07d2b3d93369e3b441d9ef60f99b825e45436f33` and
+    `coffee_roaster_mcp-0.1.0.tar.gz`
+    `8c6ea87f4ccbae4654ac6df2c1588b86f79bdf1e54e19ec301aa7ef87b283e0c`.
+  - Ran a clean production-PyPI install smoke in
+    `/tmp/coffee-roaster-mcp-pypi-smoke`: `coffee-roaster-mcp==0.1.0`
+    installed successfully, `coffee-roaster-mcp --help` passed,
+    `coffee-roaster-mcp --version` returned `coffee-roaster-mcp 0.1.0`, and
+    the mock-safe default config smoke returned `mock disabled int8`.
+  - Confirmed Registry search returns `io.github.syamaner/coffee-roaster-mcp`
+    with PyPI package `coffee-roaster-mcp`, version `0.1.0`, runtime hint
+    `uvx`, and stdio transport.
+  - Did not run hardware validation, model training/export/sync, or real
+    microphone validation.
 
 - Validation run for E6-S4:
   - Added focused version alignment coverage in `tests/test_server_json.py`.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -316,10 +316,19 @@ Registry search API returns no current listing for
 `io.github.syamaner/coffee-roaster-mcp`; the first destructive step remains the
 tag-triggered live release path after PyPI publication succeeds.
 
-Epic 6 now includes follow-up issue #135, `E6-S8: Execute live PyPI and MCP
-Registry publish`, for the controlled live publish after PyPI contains the
-matching package version and the published long description exposes the exact
-`mcp-name` verification marker.
+E6-S8 executed the controlled live PyPI and MCP Registry publish for
+`coffee-roaster-mcp` `0.1.0`. GitHub Actions release run `26367482422`
+published the production PyPI package from tag `v0.1.0` and then published
+MCP Registry metadata only after the PyPI job succeeded. Production PyPI now
+exposes version `0.1.0`, the published long description contains the exact
+`<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->` verification
+marker, and a clean PyPI install smoke passed from
+`/tmp/coffee-roaster-mcp-pypi-smoke`. `mcp-publisher validate server.json`
+passed against the live Registry API, and Registry search now returns
+`io.github.syamaner/coffee-roaster-mcp` with PyPI package
+`coffee-roaster-mcp`, version `0.1.0`, runtime hint `uvx`, and stdio
+transport. `docs/release.md` records links, commands, outcomes, risks, and
+retry/rollback notes.
 
 E6-S7 added `docs/install-and-hardware-setup.md` as the setup runbook for mock
 install, Hottop configuration, Hugging Face model configuration, offline model
@@ -336,9 +345,8 @@ first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E6-S8: execute live PyPI and MCP Registry publish after
-production PyPI exposes the matching package version and README verification
-marker.
+The next story is E7-S1: run broad mock-safe release validation before any
+hardware-ready labeling or full end-to-end agent roast validation.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 


### PR DESCRIPTION
## Summary
- executed the live `v0.1.0` release path and verified GitHub Actions published PyPI before MCP Registry metadata
- confirmed production PyPI version, long-description `mcp-name` marker, clean PyPI install smokes, `mcp-publisher validate server.json`, and Registry search listing
- updated README, release docs, registry/epic state, and the E6-S8 session summary with commands, links, outcomes, risks, and retry/rollback notes

## Validation
- `./.venv/bin/python -m pytest tests/test_readme.py tests/test_release_workflow.py`: 9 passed
- `./.venv/bin/python -m pytest`: 356 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: passed
- `./.venv/bin/python -m pyright`: 0 errors
- `./.venv/bin/coffee-roaster-mcp --help`: passed
- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
- `/tmp/mcp-publisher validate server.json`: `server.json is valid`
- `curl -L https://pypi.org/pypi/coffee-roaster-mcp/json`: version `0.1.0`, marker present, artifact hashes captured
- `/tmp/coffee-roaster-mcp-pypi-smoke/bin/python -m pip install --no-cache-dir coffee-roaster-mcp==0.1.0`: passed
- `/tmp/coffee-roaster-mcp-pypi-smoke/bin/coffee-roaster-mcp --help`: passed
- `/tmp/coffee-roaster-mcp-pypi-smoke/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
- installed-package config smoke: `mock disabled int8`
- Registry search returned `io.github.syamaner/coffee-roaster-mcp` with PyPI package `coffee-roaster-mcp`, version `0.1.0`, runtime hint `uvx`, and stdio transport

Closes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated install instructions: coffee-roaster-mcp v0.1.0 is published and installable via pip.
  * Added release notes and session summary documenting the live v0.1.0 publish, post-release verification steps, registry listing confirmation, and follow-up guidance for next validation steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->