### PR TITLE
E7-S1: Verify full mock roast MCP exports

### DIFF
--- a/docs/session-summaries/2026-05-24-e7-s1-full-mock-roast-mcp-tools.md
+++ b/docs/session-summaries/2026-05-24-e7-s1-full-mock-roast-mcp-tools.md
@@ -85,6 +85,10 @@ Commands run:
   public `mark_first_crack` override while default first-crack mode remains
   `disabled`.
 
+## Usage Snapshot
+
+- Token usage: `275K used`
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. E7-S1 is complete

--- a/docs/session-summaries/2026-05-24-e7-s1-full-mock-roast-mcp-tools.md
+++ b/docs/session-summaries/2026-05-24-e7-s1-full-mock-roast-mcp-tools.md
@@ -1,0 +1,97 @@
+# E7-S1 Full Mock Roast MCP Tools
+
+This summary captures the E7-S1 mock-safe validation story, implementation
+scope, validation evidence, and restart context.
+
+## Scope
+
+Story: `E7-S1` / issue `#56`, test a full mock roast through MCP tools.
+
+Branch: `feature/56-full-mock-roast-mcp-tools`
+
+The work stayed inside the public stdio MCP mock-roast validation boundary:
+
+- start the MCP server with default config from an empty temporary directory
+- confirm the runtime config uses roaster driver `mock`
+- confirm first-crack mode stays `disabled`
+- confirm automatic T0 detection stays disabled
+- run a mock roast through public MCP tools from session start through export
+- verify exported `roast.jsonl`, `roast.csv`, and `summary.json` outputs
+- add focused end-to-end mock roast coverage
+- update durable state and handoff notes
+
+No Hottop hardware validation, model training/export/sync, real microphone
+validation, or live release publishing was performed.
+
+## Implementation Summary
+
+- Updated `tests/test_package.py` so
+  `test_stdio_server_supports_basic_mock_roast_tool_flow` now verifies the
+  default runtime config before driving the mock roast.
+- The stdio MCP flow now verifies:
+  - `roaster_driver` is `mock`
+  - `first_crack_mode` is `disabled`
+  - `auto_t0_detection_enabled` is `False`
+  - the mock roast reaches `complete`
+  - the device state comes from the mock driver
+  - first crack is present only because the public manual override tool was
+    called
+  - `export_roast_log` returns absolute paths for `roast.jsonl`, `roast.csv`,
+    and `summary.json`
+- The export assertions now read all three files produced by the MCP export:
+  - `roast.jsonl` contains the expected event order:
+    `beans_added`, `first_crack_detected`, `beans_dropped`,
+    `cooling_started`, `cooling_stopped`
+  - `roast.csv` contains the same event order with lifecycle phases
+    `roasting`, `development`, `dropped`, `cooling`, `complete`
+  - `summary.json` records phase `complete`, event count `5`, roaster driver
+    `mock`, empty first-crack model metadata for disabled mode, and populated
+    roast/development metrics
+
+## Validation
+
+Preflight:
+
+- PR #137 was merged.
+- Issue #135 was closed.
+- `main` was fast-forwarded to
+  `5052ab29ec142cfe6e28bfb3e5bf17d529d006c3`.
+- Branch `feature/56-full-mock-roast-mcp-tools` was created from updated
+  `main`.
+
+Commands run:
+
+- `./.venv/bin/python -m pytest tests/test_package.py::test_stdio_server_supports_basic_mock_roast_tool_flow`:
+  1 passed.
+- `./.venv/bin/python -m pytest tests/test_package.py`: 19 passed.
+- `./.venv/bin/python -m pytest`: 356 passed.
+- `./.venv/bin/python -m ruff check .`: passed.
+- `./.venv/bin/python -m ruff format --check .`: 30 files already formatted.
+- `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations.
+- `./.venv/bin/coffee-roaster-mcp --help`: passed.
+- `./.venv/bin/coffee-roaster-mcp --version`:
+  `coffee-roaster-mcp 0.1.0`.
+
+## Risks And Notes
+
+- This story proves the default mock-safe stdio MCP path only. It does not
+  prove package installation from PyPI or a built wheel; that is E7-S2.
+- This story does not prove discovery through an external MCP client beyond the
+  stdio test client harness; that is E7-S3.
+- This story does not exercise Hottop hardware, real microphone input, or the
+  released Hugging Face ONNX audio path. Those remain later Epic 7 validation
+  stories.
+- The first-crack event in this story is intentionally produced through the
+  public `mark_first_crack` override while default first-crack mode remains
+  `disabled`.
+
+## Restart Prompt
+
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. E7-S1 is complete
+on branch `feature/56-full-mock-roast-mcp-tools`: the public stdio MCP mock
+roast flow now verifies default mock/disabled configuration and exported JSONL,
+CSV, and summary outputs. After the E7-S1 PR merges and issue #56 closes, sync
+`main` and route next work to E7-S2 package install smoke validation unless the
+operator selects a different story. Do not run hardware validation, model
+training/export/sync, real microphone validation, or live release publishing
+unless the selected story explicitly requires it.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E7-S1`
-- Current target: Broad mock-safe release validation
+- Active story: `E7-S2`
+- Current target: Package install smoke validation
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -31,6 +31,10 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - Agent and n8n orchestration are out of scope.
 - Default roaster driver is `mock`.
 - First-crack mode defaults to `disabled` so mock install and registry smoke tests do not require audio hardware or model download.
+- `E7-S1` keeps broad mock-safe validation on the public stdio MCP tool path:
+  a default-config server uses the mock driver, first-crack mode remains
+  disabled, auto-T0 remains disabled, and exported JSONL, CSV, and
+  `summary.json` outputs are verified from the completed mock roast.
 - `E2-S1` keeps the initial MCP tool surface bootstrap-safe with `get_server_info` and `get_runtime_config`. Roast-session lifecycle and roast-control tools remain later Epic 2 work.
 - `E2-S2` uses one in-process `RoastSessionStore` with at most one active `RoastSession` at a time. Session state now owns monotonic timing, phase, event timeline storage, telemetry retention, and log-writer references before tool wiring lands.
 - `E2-S3` keeps event writes behind `RoastSessionStore.record_event(...)`. The session timeline now records deterministic append order, authoritative UTC plus monotonic timestamps for core roast events, and idempotent singleton handling for beans added, first crack, bean drop, and cooling transitions.
@@ -778,7 +782,7 @@ Goal: prove the package works from install through mock roast, MCP client calls,
 
 ### Stories
 
-- [ ] `E7-S1` Test full mock roast through MCP tools.
+- [x] `E7-S1` Test full mock roast through MCP tools.
   - Done when a mock roast works from session start to exported logs.
 
 - [ ] `E7-S2` Test package install smoke flow.
@@ -973,6 +977,35 @@ After completing a story:
     `uvx`, and stdio transport.
   - Did not run hardware validation, model training/export/sync, or real
     microphone validation.
+- Validation run for E7-S1:
+  - Verified PR #137 was merged and issue #135 was closed before starting.
+  - Synced `main` to merge commit `5052ab29ec142cfe6e28bfb3e5bf17d529d006c3`
+    and created branch `feature/56-full-mock-roast-mcp-tools`.
+  - Tightened the stdio MCP mock-roast flow in `tests/test_package.py` so it
+    verifies the default runtime config stays on roaster driver `mock`,
+    first-crack mode `disabled`, and automatic T0 disabled before driving the
+    public MCP tools.
+  - Verified the mock roast from `start_roast_session` through heat/fan,
+    manual beans-added and first-crack override, drop, cooling stop, state read,
+    and `export_roast_log` using stdio MCP calls.
+  - Verified exported `roast.jsonl`, `roast.csv`, and `summary.json` outputs
+    from the MCP export result, including event order, CSV lifecycle phases,
+    mock roaster metadata, empty model metadata for disabled first crack, and
+    populated roast/development metrics.
+  - Kept hardware validation, model training/export/sync, real microphone
+    validation, and live release publishing out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_package.py::test_stdio_server_supports_basic_mock_roast_tool_flow`:
+    1 passed.
+  - Ran `./.venv/bin/python -m pytest tests/test_package.py`: 19 passed.
+  - Ran `./.venv/bin/python -m pytest`: 356 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: 30 files already
+    formatted.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors, 0 warnings,
+    0 informations.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`:
+    `coffee-roaster-mcp 0.1.0`.
 
 - Validation run for E6-S4:
   - Added focused version alignment coverage in `tests/test_server_json.py`.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -788,11 +788,18 @@ Goal: prove the package works from install through mock roast, MCP client calls,
 - [ ] `E7-S2` Test package install smoke flow.
   - Done when a built wheel can be installed and `coffee-roaster-mcp --help` works.
 
-- [ ] `E7-S3` Test MCP client connection.
-  - Done when a real MCP client can discover and call the server tools.
+- [ ] `E7-S3` Test Warp MCP client connection.
+  - Done when Warp can configure, start, discover, and call the local stdio
+    MCP server on the mock-safe path, confirm `mock` / `disabled` defaults,
+    complete a full mock roast through public MCP tools, and verify exported
+    JSONL, CSV, and summary outputs.
 
-- [ ] `E7-S4` Run Hottop manual hardware validation.
-  - Done when manual validation results are recorded against the checklist.
+- [ ] `E7-S4` Run Warp manual Hottop MCP control validation.
+  - Done when Warp can connect to the Hottop-configured RoastPilot MCP server
+    and the operator manually approves each hardware-affecting tool call for
+    connect, telemetry, heat, fan, drop, cooling, stop-cooling, emergency stop,
+    and exported-log review. No autonomous hardware-control decisions are in
+    scope.
 
 - [ ] `E7-S5` Produce v0.1 release checklist.
   - Done when release steps cover tests, package build, version alignment, HF revision pin, PyPI publish, registry publish, GitHub release, and hardware-ready labeling.
@@ -809,8 +816,9 @@ Goal: prove the package works from install through mock roast, MCP client calls,
 ### Epic Acceptance Criteria
 
 - Full mock roast works from install to exported logs.
-- MCP client can discover and call tools.
-- Manual hardware results are recorded.
+- Warp can discover and call tools through the local stdio MCP server.
+- Warp manual Hottop hardware-control results are recorded with explicit
+  operator approvals.
 - A real MCP client or agent can complete an end-to-end roast validation using
   configured hardware, real audio, and released Hugging Face ONNX first-crack
   artifacts, with correct state, stats, and exported logs recorded as evidence.

--- a/docs/state/github-issues.md
+++ b/docs/state/github-issues.md
@@ -99,8 +99,8 @@ Milestone: `v0.1`
 
 - #56 E7-S1: Test full mock roast through MCP tools
 - #57 E7-S2: Test package install smoke flow
-- #58 E7-S3: Test MCP client connection
-- #59 E7-S4: Run Hottop manual hardware validation
+- #58 E7-S3: Test Warp MCP client connection
+- #59 E7-S4: Run Warp manual Hottop MCP control validation
 - #60 E7-S5: Produce v0.1 release checklist
 - #112 E7-S6: Run end-to-end agent roast validation with HF ONNX audio path
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -339,14 +339,25 @@ This documentation story did not execute live PyPI publish, live MCP Registry
 publish, hardware validation, model training/export/sync, or real microphone
 validation.
 
+E7-S1 completed broad mock-safe validation on the public stdio MCP tool path.
+The default validation path starts the server with roaster driver `mock`,
+first-crack mode `disabled`, and automatic T0 disabled; it then drives a full
+mock roast from `start_roast_session` through heat/fan controls, manual
+beans-added and first-crack override, drop, cooling stop, state read, and
+`export_roast_log`. The focused stdio coverage now verifies exported
+`roast.jsonl`, `roast.csv`, and `summary.json` outputs from the MCP export
+result without hardware, model download, real microphone input, or live release
+publishing.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E7-S1: run broad mock-safe release validation before any
-hardware-ready labeling or full end-to-end agent roast validation.
+The next story is E7-S2: test the package install smoke flow before hardware
+validation, real MCP client connection validation, or full end-to-end agent
+roast validation.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -355,9 +355,14 @@ first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
 surface to prove the release candidate can support full roasts with recorded
 evidence.
 
-The next story is E7-S2: test the package install smoke flow before hardware
-validation, real MCP client connection validation, or full end-to-end agent
-roast validation.
+Epic 7 client validation is routed through Warp, not ChatGPT. E7-S3 validates
+Warp as the local MCP client on the mock-safe path. E7-S4 validates manual
+operator-approved Hottop device control through Warp MCP tool calls, with no
+autonomous hardware-control decisions.
+
+The next story is E7-S2: test the package install smoke flow before Warp MCP
+client connection validation, Warp manual Hottop control validation, or full
+end-to-end agent roast validation.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,6 +1,7 @@
 """Package and CLI smoke coverage for RoastPilot."""
 
 import asyncio
+import csv
 import json
 import os
 import sys
@@ -265,6 +266,13 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
     async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
         await _call_with_timeout(session.initialize())
 
+        runtime_config = cast(
+            Any, await _call_with_timeout(session.call_tool("get_runtime_config", {}))
+        )
+        assert runtime_config.structuredContent["roaster_driver"] == "mock"
+        assert runtime_config.structuredContent["first_crack_mode"] == "disabled"
+        assert runtime_config.structuredContent["auto_t0_detection_enabled"] is False
+
         start_result = cast(
             Any,
             await _call_with_timeout(session.call_tool("start_roast_session", {})),
@@ -432,6 +440,7 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         assert export_jsonl_path.exists()
         assert export_csv_path.exists()
         assert export_summary_path.exists()
+
         exported_rows = [
             json.loads(line) for line in export_jsonl_path.read_text(encoding="utf-8").splitlines()
         ]
@@ -443,10 +452,34 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
             "cooling_started",
             "cooling_stopped",
         ]
+
+        with export_csv_path.open(encoding="utf-8", newline="") as export_csv:
+            csv_rows = list(csv.DictReader(export_csv))
+        assert [row["event"] for row in csv_rows] == [
+            "beans_added",
+            "first_crack_detected",
+            "beans_dropped",
+            "cooling_started",
+            "cooling_stopped",
+        ]
+        assert csv_rows[0]["phase"] == "roasting"
+        assert csv_rows[1]["phase"] == "development"
+        assert csv_rows[2]["phase"] == "dropped"
+        assert csv_rows[3]["phase"] == "cooling"
+        assert csv_rows[4]["phase"] == "complete"
+        assert csv_rows[1]["first_crack_detected"] == "True"
+
         export_summary = json.loads(export_summary_path.read_text(encoding="utf-8"))
         assert export_summary["session_id"] == session_id
         assert export_summary["phase"] == "complete"
         assert export_summary["event_count"] == 5
+        assert export_summary["roaster_driver"] == "mock"
+        assert export_summary["first_crack_model"] == {
+            "repo_id": None,
+            "revision": None,
+            "precision": None,
+        }
+        assert export_summary["metrics"]["development_percent"] is not None
         assert export_summary["metrics"]["roast_elapsed_seconds"] is not None
         assert export_summary["metrics"]["development_time_seconds"] is not None
 


### PR DESCRIPTION
## Summary
- strengthened the stdio MCP mock-roast flow to assert the default runtime stays on roaster driver `mock`, first-crack mode `disabled`, and auto-T0 disabled before running the roast
- verified the public MCP tool flow from `start_roast_session` through heat/fan controls, manual beans-added and first-crack override, drop, cooling stop, state read, and `export_roast_log`
- verified exported `roast.jsonl`, `roast.csv`, and `summary.json` contents from the MCP export result, then updated registry/epic state and added the E7-S1 session summary

## Validation
- `./.venv/bin/python -m pytest tests/test_package.py::test_stdio_server_supports_basic_mock_roast_tool_flow`: 1 passed
- `./.venv/bin/python -m pytest tests/test_package.py`: 19 passed
- `./.venv/bin/python -m pytest`: 356 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: 30 files already formatted
- `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations
- `./.venv/bin/coffee-roaster-mcp --help`: passed
- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`

Closes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a complete mock-roast MCP tools validation page; expanded Epic 7 planning to mark E7-S1 complete, advance target to E7-S2, clarify Warp-based sequencing, explicit out-of-scope boundaries, and update related issue/epic entries.
* **Tests**
  * Extended tests to assert mock runtime config (auto-T0 disabled) and enhanced export verification by validating CSV event/phase ordering and expanded summary/first-crack checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->