### PR TITLE
E7-S2: Add package install smoke validation

### DIFF
--- a/.github/scripts/smoke_install_built_wheel.py
+++ b/.github/scripts/smoke_install_built_wheel.py
@@ -1,0 +1,98 @@
+"""Smoke install the built RoastPilot wheel in a clean virtual environment."""
+
+import argparse
+import os
+import shutil
+import subprocess
+import venv
+from pathlib import Path
+
+EXPECTED_DEFAULT_CONFIG = "mock disabled int8"
+
+
+def main() -> int:
+    """Run the built-wheel install smoke check."""
+    parser = argparse.ArgumentParser(
+        description="Install the built coffee-roaster-mcp wheel and run CLI/config smokes."
+    )
+    parser.add_argument(
+        "--dist-dir",
+        default="dist",
+        type=Path,
+        help="Directory containing built distribution artifacts.",
+    )
+    parser.add_argument(
+        "--venv-path",
+        default=Path("/tmp/coffee-roaster-mcp-wheel-smoke"),
+        type=Path,
+        help="Virtual environment path to recreate for the smoke install.",
+    )
+    args = parser.parse_args()
+
+    dist_dir = args.dist_dir.resolve()
+    venv_path = args.venv_path.resolve()
+    wheel = _find_single_wheel(dist_dir)
+    _recreate_venv(venv_path)
+
+    python = _venv_bin(venv_path) / "python"
+    coffee_roaster_mcp = _venv_bin(venv_path) / "coffee-roaster-mcp"
+
+    _run([python, "-m", "pip", "install", "--upgrade", "pip"])
+    _run([python, "-m", "pip", "install", str(wheel)])
+    _run([coffee_roaster_mcp, "--help"])
+    _run([coffee_roaster_mcp, "--version"])
+    _assert_installed_default_config(python)
+
+    return 0
+
+
+def _find_single_wheel(dist_dir: Path) -> Path:
+    wheels = sorted(dist_dir.glob("coffee_roaster_mcp-*.whl"))
+    if len(wheels) != 1:
+        raise SystemExit(f"Expected exactly one built wheel in {dist_dir}, found {len(wheels)}")
+    return wheels[0]
+
+
+def _recreate_venv(venv_path: Path) -> None:
+    shutil.rmtree(venv_path, ignore_errors=True)
+    venv.create(venv_path, with_pip=True)
+
+
+def _venv_bin(venv_path: Path) -> Path:
+    if os.name == "nt":
+        return venv_path / "Scripts"
+    return venv_path / "bin"
+
+
+def _run(command: list[Path | str]) -> None:
+    subprocess.run([str(part) for part in command], check=True)
+
+
+def _assert_installed_default_config(python: Path) -> None:
+    code = f"""
+import os
+import tempfile
+
+from coffee_roaster_mcp.config import load_config
+
+expected = {EXPECTED_DEFAULT_CONFIG!r}
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    os.chdir(tmpdir)
+    config = load_config(environ={{}})
+    output = (
+        f"{{config.roaster.driver}} "
+        f"{{config.first_crack.mode}} "
+        f"{{config.first_crack.precision}}"
+    )
+
+if output != expected:
+    raise SystemExit(f"Expected {{expected!r}}, got {{output!r}}")
+
+print(output)
+"""
+    _run([python, "-c", code])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/smoke_install_built_wheel.py
+++ b/.github/scripts/smoke_install_built_wheel.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import re
 import shutil
 import subprocess
 import venv
@@ -39,8 +40,8 @@ def main() -> int:
 
     _run([python, "-m", "pip", "install", "--upgrade", "pip"])
     _run([python, "-m", "pip", "install", str(wheel)])
-    _run([coffee_roaster_mcp, "--help"])
-    _run([coffee_roaster_mcp, "--version"])
+    _assert_cli_help(coffee_roaster_mcp)
+    _assert_cli_version(coffee_roaster_mcp)
     _assert_installed_default_config(python)
 
     return 0
@@ -66,6 +67,31 @@ def _venv_bin(venv_path: Path) -> Path:
 
 def _run(command: list[Path | str]) -> None:
     subprocess.run([str(part) for part in command], check=True)
+
+
+def _run_capture(command: list[Path | str]) -> str:
+    completed = subprocess.run(
+        [str(part) for part in command],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _assert_cli_help(coffee_roaster_mcp: Path) -> None:
+    help_output = _run_capture([coffee_roaster_mcp, "--help"])
+    normalized_help = help_output.lower()
+    if "usage:" not in normalized_help or "roastpilot" not in normalized_help:
+        raise SystemExit("CLI --help output did not include expected help text.")
+    print(help_output)
+
+
+def _assert_cli_version(coffee_roaster_mcp: Path) -> None:
+    version_output = _run_capture([coffee_roaster_mcp, "--version"])
+    if re.fullmatch(r"coffee-roaster-mcp \d+\.\d+\.\d+", version_output) is None:
+        raise SystemExit(f"Unexpected --version output: {version_output!r}")
+    print(version_output)
 
 
 def _assert_installed_default_config(python: Path) -> None:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,24 @@ jobs:
       - name: Build distribution artifacts
         run: python -m build
 
+      - name: Smoke install built wheel
+        run: |
+          python -m venv /tmp/coffee-roaster-mcp-wheel-smoke
+          wheel="$(python - <<'PY'
+          from pathlib import Path
+
+          wheels = sorted(Path("dist").glob("coffee_roaster_mcp-*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"Expected exactly one built wheel, found {len(wheels)}")
+          print(wheels[0])
+          PY
+          )"
+          /tmp/coffee-roaster-mcp-wheel-smoke/bin/python -m pip install --upgrade pip
+          /tmp/coffee-roaster-mcp-wheel-smoke/bin/python -m pip install "$wheel"
+          /tmp/coffee-roaster-mcp-wheel-smoke/bin/coffee-roaster-mcp --help
+          /tmp/coffee-roaster-mcp-wheel-smoke/bin/coffee-roaster-mcp --version
+          /tmp/coffee-roaster-mcp-wheel-smoke/bin/python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
+
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,22 +90,7 @@ jobs:
         run: python -m build
 
       - name: Smoke install built wheel
-        run: |
-          python -m venv /tmp/coffee-roaster-mcp-wheel-smoke
-          wheel="$(python - <<'PY'
-          from pathlib import Path
-
-          wheels = sorted(Path("dist").glob("coffee_roaster_mcp-*.whl"))
-          if len(wheels) != 1:
-              raise SystemExit(f"Expected exactly one built wheel, found {len(wheels)}")
-          print(wheels[0])
-          PY
-          )"
-          /tmp/coffee-roaster-mcp-wheel-smoke/bin/python -m pip install --upgrade pip
-          /tmp/coffee-roaster-mcp-wheel-smoke/bin/python -m pip install "$wheel"
-          /tmp/coffee-roaster-mcp-wheel-smoke/bin/coffee-roaster-mcp --help
-          /tmp/coffee-roaster-mcp-wheel-smoke/bin/coffee-roaster-mcp --version
-          /tmp/coffee-roaster-mcp-wheel-smoke/bin/python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
+        run: python .github/scripts/smoke_install_built_wheel.py
 
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,22 +146,7 @@ jobs:
         run: python -m build
 
       - name: Smoke install built wheel
-        run: |
-          python -m venv /tmp/coffee-roaster-mcp-wheel-smoke
-          wheel="$(python - <<'PY'
-          from pathlib import Path
-
-          wheels = sorted(Path("dist").glob("coffee_roaster_mcp-*.whl"))
-          if len(wheels) != 1:
-              raise SystemExit(f"Expected exactly one built wheel, found {len(wheels)}")
-          print(wheels[0])
-          PY
-          )"
-          /tmp/coffee-roaster-mcp-wheel-smoke/bin/python -m pip install --upgrade pip
-          /tmp/coffee-roaster-mcp-wheel-smoke/bin/python -m pip install "$wheel"
-          /tmp/coffee-roaster-mcp-wheel-smoke/bin/coffee-roaster-mcp --help
-          /tmp/coffee-roaster-mcp-wheel-smoke/bin/coffee-roaster-mcp --version
-          /tmp/coffee-roaster-mcp-wheel-smoke/bin/python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
+        run: python .github/scripts/smoke_install_built_wheel.py
 
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,24 @@ jobs:
       - name: Build distribution artifacts
         run: python -m build
 
+      - name: Smoke install built wheel
+        run: |
+          python -m venv /tmp/coffee-roaster-mcp-wheel-smoke
+          wheel="$(python - <<'PY'
+          from pathlib import Path
+
+          wheels = sorted(Path("dist").glob("coffee_roaster_mcp-*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"Expected exactly one built wheel, found {len(wheels)}")
+          print(wheels[0])
+          PY
+          )"
+          /tmp/coffee-roaster-mcp-wheel-smoke/bin/python -m pip install --upgrade pip
+          /tmp/coffee-roaster-mcp-wheel-smoke/bin/python -m pip install "$wheel"
+          /tmp/coffee-roaster-mcp-wheel-smoke/bin/coffee-roaster-mcp --help
+          /tmp/coffee-roaster-mcp-wheel-smoke/bin/coffee-roaster-mcp --version
+          /tmp/coffee-roaster-mcp-wheel-smoke/bin/python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"
+
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/docs/session-summaries/2026-05-24-e7-s2-package-install-smoke-flow.md
+++ b/docs/session-summaries/2026-05-24-e7-s2-package-install-smoke-flow.md
@@ -71,6 +71,10 @@ Commands run:
 - `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations.
 - `./.venv/bin/coffee-roaster-mcp --help`: passed.
 - `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- GitHub Actions CI run `26368815098`: passed.
+  - `Checks`: success.
+  - `Build Package`: success, including the new
+    `Smoke install built wheel` step.
 
 ## Risks And Notes
 

--- a/docs/session-summaries/2026-05-24-e7-s2-package-install-smoke-flow.md
+++ b/docs/session-summaries/2026-05-24-e7-s2-package-install-smoke-flow.md
@@ -1,0 +1,101 @@
+# E7-S2 Package Install Smoke Flow
+
+This summary captures the E7-S2 package install smoke validation story,
+implementation scope, validation evidence, and restart context.
+
+## Scope
+
+Story: `E7-S2` / issue `#57`, test the package install smoke flow.
+
+Branch: `feature/57-package-install-smoke-flow`
+
+The work stayed inside package install smoke validation:
+
+- build the package from the repository
+- install the built wheel into a clean environment
+- run installed CLI smoke checks
+- verify installed default config remains mock-safe
+- add focused CI and release workflow smoke coverage for built wheels
+- update durable state and handoff notes
+
+No hardware validation, Warp MCP validation, ChatGPT MCP validation, model
+training/export/sync, real microphone validation, or live release publishing
+was performed.
+
+## Implementation Summary
+
+- Updated `.github/workflows/ci.yml` so the `build-package` job now creates a
+  clean virtual environment after `python -m build`, installs the built wheel,
+  runs installed `coffee-roaster-mcp --help`, runs installed
+  `coffee-roaster-mcp --version`, and verifies installed default config prints
+  `mock disabled int8`.
+- Updated `.github/workflows/release.yml` with the same built-wheel install
+  smoke in the release `build-package` job before artifacts are uploaded.
+- Updated `docs/state/registry.md` and
+  `docs/state/epics/coffee-roaster-mcp-v0.1.md` to mark E7-S2 complete and
+  route the next story to E7-S3 Warp MCP client connection validation.
+
+## Validation
+
+Preflight:
+
+- PR #138 was merged.
+- Issue #56 was closed.
+- `main` was fast-forwarded to
+  `30a1887c07d50f8a968cc155f22718d54d57ef69`.
+- Branch `feature/57-package-install-smoke-flow` was created from updated
+  `main`.
+
+Commands run:
+
+- `./.venv/bin/python -m build`: successfully built
+  `coffee_roaster_mcp-0.1.0.tar.gz` and
+  `coffee_roaster_mcp-0.1.0-py3-none-any.whl`.
+- `python3.11 -m venv /tmp/coffee-roaster-mcp-e7-s2-wheel-smoke`: passed.
+- `/tmp/coffee-roaster-mcp-e7-s2-wheel-smoke/bin/python -m pip install dist/coffee_roaster_mcp-0.1.0-py3-none-any.whl`:
+  initial sandboxed run failed to resolve dependencies because network access
+  was blocked.
+- `/tmp/coffee-roaster-mcp-e7-s2-wheel-smoke/bin/python -m pip install dist/coffee_roaster_mcp-0.1.0-py3-none-any.whl`
+  with approved network access: installed successfully.
+- `/tmp/coffee-roaster-mcp-e7-s2-wheel-smoke/bin/coffee-roaster-mcp --help`:
+  passed.
+- `/tmp/coffee-roaster-mcp-e7-s2-wheel-smoke/bin/coffee-roaster-mcp --version`:
+  `coffee-roaster-mcp 0.1.0`.
+- `/tmp/coffee-roaster-mcp-e7-s2-wheel-smoke/bin/python -c "import os, tempfile; from coffee_roaster_mcp.config import load_config; tmp = tempfile.TemporaryDirectory(); os.chdir(tmp.name); c = load_config(environ={}); print(c.roaster.driver, c.first_crack.mode, c.first_crack.precision); tmp.cleanup()"`:
+  `mock disabled int8`.
+- `./.venv/bin/python -m pytest tests/test_package_metadata.py tests/test_package.py::test_main_prints_help`:
+  3 passed.
+- `./.venv/bin/python -m pytest`: 356 passed.
+- `./.venv/bin/python -m ruff check .`: passed.
+- `./.venv/bin/python -m ruff format --check .`: 30 files already formatted.
+- `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations.
+- `./.venv/bin/coffee-roaster-mcp --help`: passed.
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+
+## Risks And Notes
+
+- The CI and release smoke installs the built wheel and resolves runtime
+  dependencies from PyPI, so package-index or network outages can fail this
+  validation even when the wheel itself is valid.
+- This story proves built local wheel installation and installed CLI/default
+  config smoke checks. It does not run Warp MCP client validation, Hottop
+  hardware validation, real microphone input, or live release publishing.
+- The local smoke validated the wheel path. The sdist was built successfully
+  but was not separately installed in a clean environment because issue #57
+  accepts a built wheel install smoke.
+
+## Usage Snapshot
+
+- Token usage: not provided.
+
+## Restart Prompt
+
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. E7-S2 is complete
+on branch `feature/57-package-install-smoke-flow`: CI and release package-build
+jobs now build distributions, install the built wheel into a clean environment,
+run installed CLI smoke checks, and verify installed default config remains
+`mock disabled int8`. After the E7-S2 PR merges and issue #57 closes, sync
+`main` and route next work to E7-S3 Warp MCP client connection validation unless
+the operator selects a different story. Do not run hardware validation,
+ChatGPT MCP validation, model training/export/sync, real microphone validation,
+or live release publishing unless the selected story explicitly requires it.

--- a/docs/session-summaries/2026-05-24-e7-s2-package-install-smoke-flow.md
+++ b/docs/session-summaries/2026-05-24-e7-s2-package-install-smoke-flow.md
@@ -122,6 +122,7 @@ Commands run:
 ## Usage Snapshot
 
 - Before review fixes: `121K used`.
+- After review fixes: `280K used`.
 
 ## Restart Prompt
 

--- a/docs/session-summaries/2026-05-24-e7-s2-package-install-smoke-flow.md
+++ b/docs/session-summaries/2026-05-24-e7-s2-package-install-smoke-flow.md
@@ -27,13 +27,28 @@ was performed.
 - Updated `.github/workflows/ci.yml` so the `build-package` job now creates a
   clean virtual environment after `python -m build`, installs the built wheel,
   runs installed `coffee-roaster-mcp --help`, runs installed
-  `coffee-roaster-mcp --version`, and verifies installed default config prints
+  `coffee-roaster-mcp --version`, and verifies installed default config matches
   `mock disabled int8`.
-- Updated `.github/workflows/release.yml` with the same built-wheel install
-  smoke in the release `build-package` job before artifacts are uploaded.
+- Updated `.github/workflows/release.yml` with the same built-wheel smoke in
+  the release `build-package` job before artifacts are uploaded.
+- Addressed PR review feedback by extracting the duplicated smoke logic into
+  `.github/scripts/smoke_install_built_wheel.py`, which fails non-zero if the
+  installed default config differs from `mock disabled int8`.
 - Updated `docs/state/registry.md` and
   `docs/state/epics/coffee-roaster-mcp-v0.1.md` to mark E7-S2 complete and
   route the next story to E7-S3 Warp MCP client connection validation.
+
+## Review Comparison
+
+- CodeRabbit and Codex both identified the same substantive issue: the original
+  workflow command printed `mock disabled int8` but did not assert it, so CI
+  would still pass if the installed defaults regressed.
+- CodeRabbit also raised two maintainability points: the config check was too
+  long as a one-liner, and the smoke-install logic was duplicated across CI and
+  release workflows.
+- The fix addresses both reviewers by using one reusable Python smoke script
+  from both workflows and making the installed default-config smoke an explicit
+  assertion.
 
 ## Validation
 
@@ -75,6 +90,22 @@ Commands run:
   - `Checks`: success.
   - `Build Package`: success, including the new
     `Smoke install built wheel` step.
+- PR review fix validation:
+  - Thread-aware PR review fetch confirmed three unresolved actionable threads:
+    two CodeRabbit threads and one Codex thread.
+  - `./.venv/bin/python .github/scripts/smoke_install_built_wheel.py --venv-path /tmp/coffee-roaster-mcp-e7-s2-review-wheel-smoke`:
+    initial sandboxed run failed to resolve dependencies because network access
+    was blocked.
+  - `./.venv/bin/python .github/scripts/smoke_install_built_wheel.py --venv-path /tmp/coffee-roaster-mcp-e7-s2-review-wheel-smoke`
+    with approved network access: passed and printed `mock disabled int8`.
+  - `./.venv/bin/python -m pytest tests/test_package_metadata.py tests/test_package.py::test_main_prints_help`:
+    3 passed.
+  - `./.venv/bin/python -m pytest`: 356 passed.
+  - `./.venv/bin/python -m ruff check .`: passed after removing unused imports
+    from the new helper script.
+  - `./.venv/bin/python -m ruff format --check .`: 31 files already formatted.
+  - `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations.
+  - `git diff --check`: passed.
 
 ## Risks And Notes
 
@@ -90,7 +121,7 @@ Commands run:
 
 ## Usage Snapshot
 
-- Token usage: not provided.
+- Before review fixes: `121K used`.
 
 ## Restart Prompt
 

--- a/docs/session-summaries/2026-05-24-e7-s2-package-install-smoke-flow.md
+++ b/docs/session-summaries/2026-05-24-e7-s2-package-install-smoke-flow.md
@@ -106,6 +106,21 @@ Commands run:
   - `./.venv/bin/python -m ruff format --check .`: 31 files already formatted.
   - `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations.
   - `git diff --check`: passed.
+- Second CodeRabbit review fix validation:
+  - New review `4353238457` identified that installed `--help` and `--version`
+    checks asserted process success but not output content.
+  - Updated `.github/scripts/smoke_install_built_wheel.py` to capture CLI
+    output, assert help output contains expected help text, and assert version
+    output matches `coffee-roaster-mcp X.Y.Z`.
+  - `./.venv/bin/python .github/scripts/smoke_install_built_wheel.py --venv-path /tmp/coffee-roaster-mcp-e7-s2-output-review-wheel-smoke`
+    with approved network access: passed, including asserted help output,
+    version output, and default config output.
+  - `./.venv/bin/python -m pytest tests/test_package_metadata.py tests/test_package.py::test_main_prints_help`:
+    3 passed.
+  - `./.venv/bin/python -m ruff check .`: passed.
+  - `./.venv/bin/python -m ruff format --check .`: 31 files already formatted.
+  - `./.venv/bin/python -m py_compile .github/scripts/smoke_install_built_wheel.py`:
+    passed.
 
 ## Risks And Notes
 

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -1058,6 +1058,9 @@ After completing a story:
   - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
   - Ran `./.venv/bin/coffee-roaster-mcp --version`:
     `coffee-roaster-mcp 0.1.0`.
+  - GitHub Actions CI run `26368815098` completed successfully:
+    `Checks` passed and `Build Package` passed, including the new
+    `Smoke install built wheel` step.
   - Kept hardware validation, Warp MCP validation, ChatGPT MCP validation,
     model training/export/sync, real microphone validation, and live release
     publishing out of scope.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E7-S2`
-- Current target: Package install smoke validation
+- Active story: `E7-S3`
+- Current target: Warp MCP client connection validation
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -35,6 +35,11 @@ The first implementation milestone is a mock vertical slice that requires no roa
   a default-config server uses the mock driver, first-crack mode remains
   disabled, auto-T0 remains disabled, and exported JSONL, CSV, and
   `summary.json` outputs are verified from the completed mock roast.
+- `E7-S2` keeps package install smoke validation on built local distributions:
+  CI and release package-build jobs now build the wheel, install that built
+  wheel into a clean virtual environment, run the installed CLI `--help` and
+  `--version` smoke checks, and confirm installed default config stays on
+  roaster driver `mock`, first-crack mode `disabled`, and INT8 precision.
 - `E2-S1` keeps the initial MCP tool surface bootstrap-safe with `get_server_info` and `get_runtime_config`. Roast-session lifecycle and roast-control tools remain later Epic 2 work.
 - `E2-S2` uses one in-process `RoastSessionStore` with at most one active `RoastSession` at a time. Session state now owns monotonic timing, phase, event timeline storage, telemetry retention, and log-writer references before tool wiring lands.
 - `E2-S3` keeps event writes behind `RoastSessionStore.record_event(...)`. The session timeline now records deterministic append order, authoritative UTC plus monotonic timestamps for core roast events, and idempotent singleton handling for beans added, first crack, bean drop, and cooling transitions.
@@ -785,7 +790,7 @@ Goal: prove the package works from install through mock roast, MCP client calls,
 - [x] `E7-S1` Test full mock roast through MCP tools.
   - Done when a mock roast works from session start to exported logs.
 
-- [ ] `E7-S2` Test package install smoke flow.
+- [x] `E7-S2` Test package install smoke flow.
   - Done when a built wheel can be installed and `coffee-roaster-mcp --help` works.
 
 - [ ] `E7-S3` Test Warp MCP client connection.
@@ -1014,6 +1019,48 @@ After completing a story:
   - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
   - Ran `./.venv/bin/coffee-roaster-mcp --version`:
     `coffee-roaster-mcp 0.1.0`.
+
+- Validation run for E7-S2:
+  - Verified PR #138 was merged and issue #56 was closed before starting.
+  - Synced `main` to merge commit `30a1887c07d50f8a968cc155f22718d54d57ef69`
+    and created branch `feature/57-package-install-smoke-flow`.
+  - Added built-wheel install smoke steps to the CI and release package-build
+    jobs. Each job builds distributions, creates a clean virtual environment,
+    installs the built wheel, runs installed CLI `--help` and `--version`, and
+    verifies installed default config returns `mock disabled int8`.
+  - Built local distributions with `./.venv/bin/python -m build`: successfully
+    built `coffee_roaster_mcp-0.1.0.tar.gz` and
+    `coffee_roaster_mcp-0.1.0-py3-none-any.whl`.
+  - Created clean install environment
+    `/tmp/coffee-roaster-mcp-e7-s2-wheel-smoke`.
+  - Initial sandboxed wheel install could not resolve dependencies because
+    network access was blocked; reran with approved network access.
+  - Installed built wheel
+    `dist/coffee_roaster_mcp-0.1.0-py3-none-any.whl` successfully into the
+    clean environment.
+  - Ran
+    `/tmp/coffee-roaster-mcp-e7-s2-wheel-smoke/bin/coffee-roaster-mcp --help`:
+    passed.
+  - Ran
+    `/tmp/coffee-roaster-mcp-e7-s2-wheel-smoke/bin/coffee-roaster-mcp --version`:
+    `coffee-roaster-mcp 0.1.0`.
+  - Ran the installed default config smoke from an empty temporary directory:
+    returned `mock disabled int8`.
+  - Ran
+    `./.venv/bin/python -m pytest tests/test_package_metadata.py tests/test_package.py::test_main_prints_help`:
+    3 passed.
+  - Ran `./.venv/bin/python -m pytest`: 356 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: 30 files already
+    formatted.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors, 0 warnings,
+    0 informations.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`:
+    `coffee-roaster-mcp 0.1.0`.
+  - Kept hardware validation, Warp MCP validation, ChatGPT MCP validation,
+    model training/export/sync, real microphone validation, and live release
+    publishing out of scope.
 
 - Validation run for E6-S4:
   - Added focused version alignment coverage in `tests/test_server_json.py`.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -1073,6 +1073,12 @@ After completing a story:
     passed with 3 tests; `./.venv/bin/python -m pytest` passed with 356 tests;
     `./.venv/bin/python -m ruff check .`, `./.venv/bin/python -m ruff format --check .`,
     `./.venv/bin/python -m pyright`, and `git diff --check` passed.
+  - Second CodeRabbit review hardening changed the helper script so installed
+    `--help` and `--version` smokes capture and assert output content instead
+    of checking process success only. The updated smoke script passed with
+    approved network access using
+    `/tmp/coffee-roaster-mcp-e7-s2-output-review-wheel-smoke`, and focused
+    pytest, ruff, format check, and helper-script compile checks passed.
   - Kept hardware validation, Warp MCP validation, ChatGPT MCP validation,
     model training/export/sync, real microphone validation, and live release
     publishing out of scope.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -1028,6 +1028,11 @@ After completing a story:
     jobs. Each job builds distributions, creates a clean virtual environment,
     installs the built wheel, runs installed CLI `--help` and `--version`, and
     verifies installed default config returns `mock disabled int8`.
+  - Addressed PR review feedback from CodeRabbit and Codex by extracting the
+    duplicated smoke logic into `.github/scripts/smoke_install_built_wheel.py`
+    and changing the installed default-config smoke from print-only output to
+    an explicit assertion that fails on any value other than
+    `mock disabled int8`.
   - Built local distributions with `./.venv/bin/python -m build`: successfully
     built `coffee_roaster_mcp-0.1.0.tar.gz` and
     `coffee_roaster_mcp-0.1.0-py3-none-any.whl`.
@@ -1061,6 +1066,13 @@ After completing a story:
   - GitHub Actions CI run `26368815098` completed successfully:
     `Checks` passed and `Build Package` passed, including the new
     `Smoke install built wheel` step.
+  - Review-fix validation:
+    `./.venv/bin/python .github/scripts/smoke_install_built_wheel.py --venv-path /tmp/coffee-roaster-mcp-e7-s2-review-wheel-smoke`
+    passed with approved network access and printed `mock disabled int8`;
+    `./.venv/bin/python -m pytest tests/test_package_metadata.py tests/test_package.py::test_main_prints_help`
+    passed with 3 tests; `./.venv/bin/python -m pytest` passed with 356 tests;
+    `./.venv/bin/python -m ruff check .`, `./.venv/bin/python -m ruff format --check .`,
+    `./.venv/bin/python -m pyright`, and `git diff --check` passed.
   - Kept hardware validation, Warp MCP validation, ChatGPT MCP validation,
     model training/export/sync, real microphone validation, and live release
     publishing out of scope.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -349,6 +349,16 @@ beans-added and first-crack override, drop, cooling stop, state read, and
 result without hardware, model download, real microphone input, or live release
 publishing.
 
+E7-S2 completed package install smoke validation from built local
+distributions. The CI and release package-build jobs now create a clean virtual
+environment after `python -m build`, install the built wheel, run installed
+`coffee-roaster-mcp --help` and `coffee-roaster-mcp --version`, and verify the
+installed default config remains `mock disabled int8`. The local validation run
+built both wheel and sdist, installed
+`dist/coffee_roaster_mcp-0.1.0-py3-none-any.whl` into
+`/tmp/coffee-roaster-mcp-e7-s2-wheel-smoke`, and confirmed the installed CLI
+and default config smoke path.
+
 Epic 7 now includes a final end-to-end agent roast validation story that uses a
 real MCP client or agent, configured Hottop hardware, released Hugging Face ONNX
 first-crack artifacts, real microphone/audio input, and the Epic 5 stat/log
@@ -360,9 +370,9 @@ Warp as the local MCP client on the mock-safe path. E7-S4 validates manual
 operator-approved Hottop device control through Warp MCP tool calls, with no
 autonomous hardware-control decisions.
 
-The next story is E7-S2: test the package install smoke flow before Warp MCP
-client connection validation, Warp manual Hottop control validation, or full
-end-to-end agent roast validation.
+The next story is E7-S3: test Warp MCP client connection on the mock-safe path
+before Warp manual Hottop control validation or full end-to-end agent roast
+validation.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -353,7 +353,10 @@ E7-S2 completed package install smoke validation from built local
 distributions. The CI and release package-build jobs now create a clean virtual
 environment after `python -m build`, install the built wheel, run installed
 `coffee-roaster-mcp --help` and `coffee-roaster-mcp --version`, and verify the
-installed default config remains `mock disabled int8`. The local validation run
+installed default config remains `mock disabled int8`. PR review hardening
+moved the duplicated smoke logic into
+`.github/scripts/smoke_install_built_wheel.py` and changed the default-config
+check from print-only output to an explicit assertion. The local validation run
 built both wheel and sdist, installed
 `dist/coffee_roaster_mcp-0.1.0-py3-none-any.whl` into
 `/tmp/coffee-roaster-mcp-e7-s2-wheel-smoke`, and confirmed the installed CLI


### PR DESCRIPTION
## Summary
- add built-wheel install smoke checks to CI and release package-build jobs
- verify the installed CLI `--help` and `--version` paths plus installed default config `mock disabled int8`
- update Epic 7 state, registry routing, and the E7-S2 session summary

## Validation
- `./.venv/bin/python -m build`: built `coffee_roaster_mcp-0.1.0.tar.gz` and `coffee_roaster_mcp-0.1.0-py3-none-any.whl`
- `/tmp/coffee-roaster-mcp-e7-s2-wheel-smoke/bin/python -m pip install dist/coffee_roaster_mcp-0.1.0-py3-none-any.whl`: installed successfully with approved network access after the sandboxed dependency-resolution attempt failed
- `/tmp/coffee-roaster-mcp-e7-s2-wheel-smoke/bin/coffee-roaster-mcp --help`: passed
- `/tmp/coffee-roaster-mcp-e7-s2-wheel-smoke/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`
- installed default config smoke: `mock disabled int8`
- `./.venv/bin/python -m pytest tests/test_package_metadata.py tests/test_package.py::test_main_prints_help`: 3 passed
- `./.venv/bin/python -m pytest`: 356 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: 30 files already formatted
- `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations
- `./.venv/bin/coffee-roaster-mcp --help`: passed
- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`

Closes #57

Out of scope: hardware validation, Warp MCP validation, ChatGPT MCP validation, model training/export/sync, real microphone validation, and live release publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a CI/release smoke step that builds and installs the freshly built package into a clean environment and runs basic CLI/install validation, including an asserted default-config check; introduced a reusable smoke-test script to drive these checks.

* **Documentation**
  * Added session summary and updated epic/registry docs describing the package-install smoke flow, run logs, limitations, validation evidence, and next steps.

* **Chores**
  * Marked the package-install validation milestone complete and advanced the roadmap to the next story.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->