### PR TITLE
E7-S3: Record Warp MCP client validation

### DIFF
--- a/docs/session-summaries/2026-05-24-e7-s3-warp-mcp-client-connection.md
+++ b/docs/session-summaries/2026-05-24-e7-s3-warp-mcp-client-connection.md
@@ -204,6 +204,10 @@ Required repo checks:
   microphone/audio input, ChatGPT MCP compatibility, live publishing, or a full
   end-to-end agent roast.
 
+## Usage Snapshot
+
+- `293K used`.
+
 ## Restart Prompt
 
 Resume in the local clone of `syamaner/coffee-roaster-mcp`. E7-S3 is complete

--- a/docs/session-summaries/2026-05-24-e7-s3-warp-mcp-client-connection.md
+++ b/docs/session-summaries/2026-05-24-e7-s3-warp-mcp-client-connection.md
@@ -1,0 +1,220 @@
+# E7-S3 Warp MCP Client Connection
+
+This summary captures the E7-S3 Warp MCP client connection validation story,
+manual Warp evidence, exported artifact verification, and restart context.
+
+## Scope
+
+Story: `E7-S3` / issue `#58`, test Warp MCP client connection.
+
+Branch: `feature/58-warp-mcp-client-connection`
+
+The work stayed inside Warp MCP client validation on the mock-safe
+published-package path:
+
+- configure Warp to launch the published `coffee-roaster-mcp==0.1.0` package
+- use an explicit mock-safe config and working directory
+- confirm Warp starts the stdio MCP server and discovers RoastPilot tools
+- call bootstrap/runtime config tools from Warp
+- complete a full mock roast through Warp public MCP tools
+- verify exported JSONL, CSV, and summary files
+- record commands, outcomes, risks, and next-story routing
+
+No Hottop hardware validation, ChatGPT MCP validation, model
+training/export/sync, real microphone validation, live release publishing, or
+full end-to-end agent roast validation was performed.
+
+## Warp Configuration
+
+Mock-safe working directory:
+
+- `/tmp/roastpilot-warp-mock`
+
+Config file:
+
+- `/tmp/roastpilot-warp-mock/coffee-roaster-mcp.yaml`
+
+Config content:
+
+```yaml
+roaster:
+  driver: mock
+first_crack:
+  mode: disabled
+session:
+  auto_t0_detection_enabled: false
+```
+
+Warp MCP server JSON:
+
+```json
+{
+  "mcpServers": {
+    "roastpilot": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "coffee-roaster-mcp==0.1.0",
+        "coffee-roaster-mcp",
+        "serve"
+      ],
+      "env": {
+        "COFFEE_ROASTER_MCP_CONFIG": "/tmp/roastpilot-warp-mock/coffee-roaster-mcp.yaml"
+      },
+      "working_directory": "/tmp/roastpilot-warp-mock"
+    }
+  }
+}
+```
+
+## Validation Evidence
+
+Preflight:
+
+- PR #139 was merged.
+- Issue #57 was closed.
+- `main` was fast-forwarded to
+  `efc405de392be3ec2245905c10c5ad06f0e0dfda`.
+- Branch `feature/58-warp-mcp-client-connection` was created from updated
+  `main`.
+
+Local setup commands:
+
+- `mkdir -p /tmp/roastpilot-warp-mock`: passed.
+- Created `/tmp/roastpilot-warp-mock/coffee-roaster-mcp.yaml` with mock-safe
+  config.
+- `command -v uvx`: initially failed because `uvx` was not on `PATH`.
+- `brew install uv`: installed `uv`/`uvx`.
+- `uvx --from coffee-roaster-mcp==0.1.0 coffee-roaster-mcp --version` from
+  `/tmp/roastpilot-warp-mock`: `coffee-roaster-mcp 0.1.0`.
+
+Warp issue evidence:
+
+- Issue comment
+  `https://github.com/syamaner/coffee-roaster-mcp/issues/58#issuecomment-4529937694`
+  records the first operator-provided Warp screenshot showing `roastpilot`
+  enabled/running and 13 discovered tools.
+- Issue comment
+  `https://github.com/syamaner/coffee-roaster-mcp/issues/58#issuecomment-4529945202`
+  records the Warp `get_runtime_config` result.
+- Issue comment
+  `https://github.com/syamaner/coffee-roaster-mcp/issues/58#issuecomment-4529947162`
+  records the Warp `get_server_info` result.
+- Issue comment
+  `https://github.com/syamaner/coffee-roaster-mcp/issues/58#issuecomment-4529951383`
+  records a successful Warp `start_roast_session` call.
+- Issue comment
+  `https://github.com/syamaner/coffee-roaster-mcp/issues/58#issuecomment-4529965494`
+  records the full Warp mock roast tool-call flow and attaches exported
+  `roast.csv` and `summary.json` evidence.
+
+Warp-discovered tools:
+
+- `get_server_info`
+- `get_runtime_config`
+- `start_roast_session`
+- `get_roast_state`
+- `set_heat`
+- `set_fan`
+- `mark_beans_added`
+- `mark_first_crack`
+- `drop_beans`
+- `start_cooling`
+- `stop_cooling`
+- `export_roast_log`
+- `emergency_stop`
+
+Warp `get_runtime_config` confirmed:
+
+- `config_source`: `/tmp/roastpilot-warp-mock/coffee-roaster-mcp.yaml`
+- `roaster_driver`: `mock`
+- `first_crack_mode`: `disabled`
+- `model_precision`: `int8`
+- `log_dir`: `logs`
+- `sample_interval_seconds`: `5.0`
+- `auto_t0_detection_enabled`: `false`
+
+Warp `get_server_info` confirmed:
+
+- `product_name`: `RoastPilot`
+- `package_name`: `coffee-roaster-mcp`
+- `version`: `0.1.0`
+- `transport`: `stdio`
+- `bootstrap_safe`: `true`
+- expected public tool list
+
+Full Warp mock roast flow:
+
+- `start_roast_session`
+- `set_heat` with `heat_level_percent: 60`
+- `set_fan` with `fan_level_percent: 35`
+- `mark_beans_added`
+- `mark_first_crack`
+- `drop_beans`
+- `stop_cooling`
+- `get_roast_state`
+- `export_roast_log`
+
+Exported artifact paths:
+
+- `/private/tmp/roastpilot-warp-mock/logs/roasts/b279284880fd4263b2cc0df5366e557f/roast.jsonl`
+- `/private/tmp/roastpilot-warp-mock/logs/roasts/b279284880fd4263b2cc0df5366e557f/roast.csv`
+- `/private/tmp/roastpilot-warp-mock/logs/roasts/b279284880fd4263b2cc0df5366e557f/summary.json`
+
+Local artifact verification:
+
+- `summary.json` recorded session
+  `b279284880fd4263b2cc0df5366e557f`, `phase: complete`, `active: false`,
+  `roaster_driver: mock`, `event_count: 5`, and empty first-crack model
+  metadata for disabled first-crack mode.
+- `roast.jsonl` contained expected event rows:
+  `beans_added`, `first_crack_detected`, `beans_dropped`, `cooling_started`,
+  and `cooling_stopped`.
+- `roast.csv` contained expected event lifecycle phases:
+  `roasting`, `development`, `dropped`, `cooling`, and `complete`.
+- Structured verification command:
+  `./.venv/bin/python -c "..."`
+  validated the summary session id, complete phase, mock driver, empty
+  first-crack model metadata, JSONL event order, and CSV event phases.
+
+Required repo checks:
+
+- `./.venv/bin/python -m pytest`: 356 passed.
+- `./.venv/bin/python -m ruff check .`: passed.
+- `./.venv/bin/python -m ruff format --check .`: 31 files already formatted.
+- `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations.
+- `./.venv/bin/coffee-roaster-mcp --help`: passed.
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+
+## Risks And Notes
+
+- GUI app PATH can differ from terminal PATH. Local validation initially found
+  no `uvx` on `PATH`; installing `uv` with Homebrew resolved it. If Warp cannot
+  locate `uvx` in a future run, use `/opt/homebrew/bin/uvx` as the MCP command
+  or ensure Warp inherits a PATH containing Homebrew binaries.
+- The successful Warp run did not require Warp MCP error-log inspection. Issue
+  #58 records the relevant Warp MCP log locations for future failed startup or
+  discovery cases.
+- The final successful mock roast session was
+  `b279284880fd4263b2cc0df5366e557f`. Earlier exploratory Warp prompts started
+  a separate session while testing `start_roast_session`; the final exported
+  artifacts came from the full-flow session above.
+- This story proves Warp can start, discover, and call the published package on
+  the mock-safe path. It does not prove Hottop hardware behavior, real
+  microphone/audio input, ChatGPT MCP compatibility, live publishing, or a full
+  end-to-end agent roast.
+
+## Restart Prompt
+
+Resume in the local clone of `syamaner/coffee-roaster-mcp`. E7-S3 is complete
+on branch `feature/58-warp-mcp-client-connection`: Warp launched
+`coffee-roaster-mcp==0.1.0` through `uvx`, discovered the expected RoastPilot
+tools, confirmed runtime config `mock`, `disabled`, and auto-T0 disabled,
+completed a full mock roast through public MCP tools, and exported verified
+JSONL, CSV, and summary outputs under
+`/private/tmp/roastpilot-warp-mock/logs/roasts/b279284880fd4263b2cc0df5366e557f/`.
+After the E7-S3 PR merges and issue #58 closes, sync `main` and route next work
+to E7-S4 Warp manual Hottop MCP control validation unless the operator selects
+a different story. Do not run full end-to-end agent roast validation, ChatGPT
+MCP validation, model training/export/sync, real microphone validation, or live
+release publishing unless the selected story explicitly requires it.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E7-S3`
-- Current target: Warp MCP client connection validation
+- Active story: `E7-S4`
+- Current target: Warp manual Hottop MCP control validation
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -40,6 +40,12 @@ The first implementation milestone is a mock vertical slice that requires no roa
   wheel into a clean virtual environment, run the installed CLI `--help` and
   `--version` smoke checks, and confirm installed default config stays on
   roaster driver `mock`, first-crack mode `disabled`, and INT8 precision.
+- `E7-S3` keeps Warp MCP client connection validation on the mock-safe
+  published-package path: Warp launches `coffee-roaster-mcp==0.1.0` through
+  `uvx`, uses an explicit mock-safe config and working directory, discovers the
+  public RoastPilot MCP tools, confirms runtime config `mock`, `disabled`, and
+  auto-T0 disabled, completes a full mock roast through public MCP tools, and
+  verifies exported JSONL, CSV, and summary outputs.
 - `E2-S1` keeps the initial MCP tool surface bootstrap-safe with `get_server_info` and `get_runtime_config`. Roast-session lifecycle and roast-control tools remain later Epic 2 work.
 - `E2-S2` uses one in-process `RoastSessionStore` with at most one active `RoastSession` at a time. Session state now owns monotonic timing, phase, event timeline storage, telemetry retention, and log-writer references before tool wiring lands.
 - `E2-S3` keeps event writes behind `RoastSessionStore.record_event(...)`. The session timeline now records deterministic append order, authoritative UTC plus monotonic timestamps for core roast events, and idempotent singleton handling for beans added, first crack, bean drop, and cooling transitions.
@@ -793,7 +799,7 @@ Goal: prove the package works from install through mock roast, MCP client calls,
 - [x] `E7-S2` Test package install smoke flow.
   - Done when a built wheel can be installed and `coffee-roaster-mcp --help` works.
 
-- [ ] `E7-S3` Test Warp MCP client connection.
+- [x] `E7-S3` Test Warp MCP client connection.
   - Done when Warp can configure, start, discover, and call the local stdio
     MCP server on the mock-safe path, confirm `mock` / `disabled` defaults,
     complete a full mock roast through public MCP tools, and verify exported
@@ -1082,6 +1088,70 @@ After completing a story:
   - Kept hardware validation, Warp MCP validation, ChatGPT MCP validation,
     model training/export/sync, real microphone validation, and live release
     publishing out of scope.
+
+- Validation run for E7-S3:
+  - Verified PR #139 was merged and issue #57 was closed before starting.
+  - Synced `main` to merge commit `efc405de392be3ec2245905c10c5ad06f0e0dfda`
+    and created branch `feature/58-warp-mcp-client-connection`.
+  - Created mock-safe Warp working directory
+    `/tmp/roastpilot-warp-mock` with `coffee-roaster-mcp.yaml` pinning
+    roaster driver `mock`, first-crack mode `disabled`, and
+    `session.auto_t0_detection_enabled: false`.
+  - Installed `uv`/`uvx` with Homebrew because `uvx` was not initially on
+    `PATH`, then verified the published package command from the Warp working
+    directory:
+    `uvx --from coffee-roaster-mcp==0.1.0 coffee-roaster-mcp --version`
+    returned `coffee-roaster-mcp 0.1.0`.
+  - Operator-provided Warp evidence in issue #58 confirmed the `roastpilot`
+    MCP server was enabled/running and discovered 13 RoastPilot tools:
+    `get_server_info`, `get_runtime_config`, `start_roast_session`,
+    `get_roast_state`, `set_heat`, `set_fan`, `mark_beans_added`,
+    `mark_first_crack`, `drop_beans`, `start_cooling`, `stop_cooling`,
+    `export_roast_log`, and `emergency_stop`.
+  - Warp `get_runtime_config` returned config source
+    `/tmp/roastpilot-warp-mock/coffee-roaster-mcp.yaml`, roaster driver
+    `mock`, first-crack mode `disabled`, model precision `int8`,
+    `log_dir: logs`, sample interval `5.0`, and
+    `auto_t0_detection_enabled: false`.
+  - Warp `get_server_info` returned product `RoastPilot`, package
+    `coffee-roaster-mcp`, version `0.1.0`, transport `stdio`,
+    `bootstrap_safe: true`, and the expected public tool list.
+  - Warp started a mock roast session successfully and then completed a full
+    mock roast through public MCP tools: `start_roast_session`, `set_heat` at
+    `60`, `set_fan` at `35`, `mark_beans_added`, `mark_first_crack`,
+    `drop_beans`, `stop_cooling`, `get_roast_state`, and `export_roast_log`.
+  - Verified exported files under
+    `/private/tmp/roastpilot-warp-mock/logs/roasts/b279284880fd4263b2cc0df5366e557f/`:
+    `roast.jsonl`, `roast.csv`, and `summary.json`.
+  - `summary.json` recorded `session_id:
+    b279284880fd4263b2cc0df5366e557f`, `phase: complete`, `active: false`,
+    `roaster_driver: mock`, `event_count: 5`, and empty first-crack model
+    metadata for disabled mode.
+  - `roast.jsonl` contained the expected event rows:
+    `beans_added`, `first_crack_detected`, `beans_dropped`,
+    `cooling_started`, and `cooling_stopped`.
+  - `roast.csv` contained the expected event lifecycle phases:
+    `roasting`, `development`, `dropped`, `cooling`, and `complete`.
+  - Ran structured artifact verification:
+    `./.venv/bin/python -c "..."`
+    validated the summary session id, complete phase, mock driver, empty
+    first-crack model metadata, JSONL event order, and CSV event phases.
+  - Ran `./.venv/bin/python -m pytest`: 356 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: 31 files already
+    formatted.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors, 0 warnings,
+    0 informations.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`:
+    `coffee-roaster-mcp 0.1.0`.
+  - No Warp MCP error logs were needed because server startup, tool discovery,
+    runtime config calls, mock roast tool calls, and export completed
+    successfully. If a future Warp validation fails, issue #58 records the
+    Warp MCP log locations to inspect.
+  - Kept Hottop hardware validation, ChatGPT MCP validation, model
+    training/export/sync, real microphone validation, live release publishing,
+    and full end-to-end agent roast validation out of scope.
 
 - Validation run for E6-S4:
   - Added focused version alignment coverage in `tests/test_server_json.py`.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -373,9 +373,20 @@ Warp as the local MCP client on the mock-safe path. E7-S4 validates manual
 operator-approved Hottop device control through Warp MCP tool calls, with no
 autonomous hardware-control decisions.
 
-The next story is E7-S3: test Warp MCP client connection on the mock-safe path
-before Warp manual Hottop control validation or full end-to-end agent roast
-validation.
+E7-S3 completed Warp MCP client connection validation on the mock-safe
+published-package path. Warp launched the `roastpilot` stdio MCP server through
+`uvx --from coffee-roaster-mcp==0.1.0 coffee-roaster-mcp serve`, discovered the
+expected public RoastPilot tools, confirmed runtime config `mock`, `disabled`,
+and `auto_t0_detection_enabled: false`, completed a full mock roast through
+Warp public MCP tool calls, and exported verified `roast.jsonl`, `roast.csv`,
+and `summary.json` files under
+`/private/tmp/roastpilot-warp-mock/logs/roasts/b279284880fd4263b2cc0df5366e557f/`.
+
+The next story is E7-S4: run Warp manual Hottop MCP control validation with
+operator approval for each hardware-affecting tool call. Do not run full
+end-to-end agent roast validation, ChatGPT MCP validation, model
+training/export/sync, or real microphone validation unless a later story
+explicitly requires it.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 


### PR DESCRIPTION
## Summary
- record Warp MCP client validation on the mock-safe published-package path
- document Warp setup, runtime/tool evidence, full mock roast transcript notes, and exported artifact verification
- mark E7-S3 complete and route next work to E7-S4 Warp manual Hottop control validation

## Validation
- Warp launched `coffee-roaster-mcp==0.1.0` through `uvx --from coffee-roaster-mcp==0.1.0 coffee-roaster-mcp serve`
- Warp discovered 13 RoastPilot tools and returned `get_server_info` with `RoastPilot`, `coffee-roaster-mcp`, `0.1.0`, `stdio`, and `bootstrap_safe: true`
- Warp `get_runtime_config` confirmed `roaster_driver: mock`, `first_crack_mode: disabled`, and `auto_t0_detection_enabled: false`
- Warp completed a full mock roast through public MCP tools and exported logs for session `b279284880fd4263b2cc0df5366e557f`
- Verified `/private/tmp/roastpilot-warp-mock/logs/roasts/b279284880fd4263b2cc0df5366e557f/roast.jsonl`, `roast.csv`, and `summary.json`
- structured artifact verification command validated summary session id, complete phase, mock driver, empty first-crack model metadata, JSONL event order, and CSV event phases
- `./.venv/bin/python -m pytest`: 356 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: 31 files already formatted
- `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations
- `./.venv/bin/coffee-roaster-mcp --help`: passed
- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`

Closes #58

Out of scope: Hottop hardware validation, ChatGPT MCP validation, model training/export/sync, real microphone validation, live release publishing, and full end-to-end agent roast validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive validation documentation for the Warp MCP client connection story, capturing configuration, validation evidence, and verification steps.
  * Updated Epic 7 state tracking to mark prior work as complete and define the next validation phase.
  * Updated registry documentation with current validation status and upcoming work scope.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->