### PR TITLE
Docs: Add first-crack replay validation story

### DIFF
--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -46,6 +46,17 @@ The first implementation milestone is a mock vertical slice that requires no roa
   public RoastPilot MCP tools, confirms runtime config `mock`, `disabled`, and
   auto-T0 disabled, completes a full mock roast through public MCP tools, and
   verifies exported JSONL, CSV, and summary outputs.
+- `E7-S5a` is inserted before the final release checklist to close the
+  first-crack MCP validation gap without requiring Hottop hardware or live
+  microphone input. It uses the mock roaster, released Hugging Face first-crack
+  artifacts pinned to revision
+  `b349a919c34b6130472da97c01817be404e4f629`, and a committed small derived
+  labelled WAV fixture generated from the
+  `coffee-first-crack-detection` checkout. The fixture is a narrow exception to
+  the normal no-audio-in-git rule, must include retimestamped labels and a
+  manifest, and the real-model MCP replay remains opt-in or local/manual rather
+  than default CI. Lightweight fixture metadata and label consistency checks may
+  run in CI.
 - `E2-S1` keeps the initial MCP tool surface bootstrap-safe with `get_server_info` and `get_runtime_config`. Roast-session lifecycle and roast-control tools remain later Epic 2 work.
 - `E2-S2` uses one in-process `RoastSessionStore` with at most one active `RoastSession` at a time. Session state now owns monotonic timing, phase, event timeline storage, telemetry retention, and log-writer references before tool wiring lands.
 - `E2-S3` keeps event writes behind `RoastSessionStore.record_event(...)`. The session timeline now records deterministic append order, authoritative UTC plus monotonic timestamps for core roast events, and idempotent singleton handling for beans added, first crack, bean drop, and cooling transitions.
@@ -812,6 +823,16 @@ Goal: prove the package works from install through mock roast, MCP client calls,
     and exported-log review. No autonomous hardware-control decisions are in
     scope.
 
+- [ ] `E7-S5a` Test MCP first-crack detection with labelled WAV replay.
+  - Done when a small derived WAV fixture, retimestamped label file, and
+    manifest are committed under test fixtures; the MCP server can run with the
+    mock roaster, `first_crack.mode: audio`, pinned released Hugging Face INT8
+    artifacts, and detector-paced WAV replay; public MCP tools can start and
+    monitor a roast until first crack is reported; the reported first-crack time
+    is validated against the fixture labels; and exported logs plus replay
+    metrics are recorded. The real-model replay test is excluded from default
+    CI unless explicitly enabled as an opt-in or slow validation path.
+
 - [ ] `E7-S5` Produce v0.1 release checklist.
   - Done when release steps cover tests, package build, version alignment, HF revision pin, PyPI publish, registry publish, GitHub release, and hardware-ready labeling.
 
@@ -830,6 +851,9 @@ Goal: prove the package works from install through mock roast, MCP client calls,
 - Warp can discover and call tools through the local stdio MCP server.
 - Warp manual Hottop hardware-control results are recorded with explicit
   operator approvals.
+- MCP first-crack detection can be validated on the mock roaster with a
+  committed labelled WAV replay fixture and pinned released Hugging Face
+  artifacts before full hardware/audio end-to-end validation.
 - A real MCP client or agent can complete an end-to-end roast validation using
   configured hardware, real audio, and released Hugging Face ONNX first-crack
   artifacts, with correct state, stats, and exported logs recorded as evidence.

--- a/docs/state/github-issues.md
+++ b/docs/state/github-issues.md
@@ -101,6 +101,7 @@ Milestone: `v0.1`
 - #57 E7-S2: Test package install smoke flow
 - #58 E7-S3: Test Warp MCP client connection
 - #59 E7-S4: Run Warp manual Hottop MCP control validation
+- #141 E7-S5a: Test MCP first-crack detection with labelled WAV replay
 - #60 E7-S5: Produce v0.1 release checklist
 - #112 E7-S6: Run end-to-end agent roast validation with HF ONNX audio path
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -373,6 +373,16 @@ Warp as the local MCP client on the mock-safe path. E7-S4 validates manual
 operator-approved Hottop device control through Warp MCP tool calls, with no
 autonomous hardware-control decisions.
 
+Epic 7 now also includes E7-S5a to close the MCP first-crack detection replay
+gap before the final release checklist and full end-to-end agent roast. E7-S5a
+uses the mock roaster plus a committed small derived labelled WAV fixture from
+the `coffee-first-crack-detection` checkout, retimestamped labels, a manifest,
+detector-paced replay, and pinned released Hugging Face INT8 artifacts at
+revision `b349a919c34b6130472da97c01817be404e4f629`. The fixture is a narrow
+documented exception to the normal no-audio-in-git rule. Real-model MCP replay
+remains opt-in or local/manual rather than default CI, while lightweight fixture
+metadata and label consistency checks may run in CI.
+
 E7-S3 completed Warp MCP client connection validation on the mock-safe
 published-package path. Warp launched the `roastpilot` stdio MCP server through
 `uvx --from coffee-roaster-mcp==0.1.0 coffee-roaster-mcp serve`, discovered the


### PR DESCRIPTION
## Summary

- Add E7-S5a to local epic state for MCP first-crack detection with labelled WAV replay.
- Record the narrow committed-fixture exception, pinned HF artifact revision, detector-paced replay requirement, and default-CI exclusion for real-model replay.
- Add issue #141 to the repo-local GitHub issue index.

Refs #141

## Validation

- `git diff --check`
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m pyright`
- `./.venv/bin/coffee-roaster-mcp --help`
- `./.venv/bin/coffee-roaster-mcp --version`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added validation workflow for first-crack detection using mock roaster and labeled WAV replay fixture.
  * Documented integration with released ML artifacts and lightweight consistency checks.
  * Updated end-to-end validation checklist with new test scenario.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->