### PR TITLE
E7-S4: Record Warp Hottop validation preflight blocker

### DIFF
--- a/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
+++ b/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
@@ -139,7 +139,10 @@ Required repo checks:
 - Export recovery phase follow-up:
   `./.venv/bin/python -m pytest tests/test_exports.py::test_snapshot_export_csv_keeps_fault_phase_for_recovery_cooling_stop tests/test_mcp_server.py::test_stop_cooling_recovers_after_emergency_stop_leaves_cooling_on tests/test_mcp_server.py::test_stop_cooling_recovery_keeps_fault_when_driver_reports_cooling_on`:
   3 passed.
-- `./.venv/bin/python -m pytest`: 360 passed.
+- Second review follow-up targeted recovery tests:
+  `./.venv/bin/python -m pytest tests/test_session.py::test_stop_cooling_recovery_records_new_event_after_completed_session_fault tests/test_mcp_server.py::test_stop_cooling_recovers_after_emergency_stop_leaves_cooling_on tests/test_mcp_server.py::test_stop_cooling_recovery_keeps_fault_when_driver_reports_cooling_on tests/test_mcp_server.py::test_stop_cooling_recovery_rejects_driver_heat_after_fault tests/test_mcp_server.py::test_stale_stop_cooling_recovery_fails_closed tests/test_exports.py::test_snapshot_export_csv_keeps_fault_phase_for_recovery_cooling_stop`:
+  6 passed.
+- `./.venv/bin/python -m pytest`: 363 passed.
 - `./.venv/bin/python -m ruff check .`: passed.
 - `./.venv/bin/python -m ruff format --check .`: 31 files already formatted.
 - `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations.
@@ -218,6 +221,22 @@ Code review follow-up:
   exports a `fault -> cooling_stopped(recovery_after_fault: true)` timeline and
   asserts both rows remain `phase: fault` while the recovery row reports
   `cooling_on: False`.
+- Codex review
+  `https://github.com/syamaner/coffee-roaster-mcp/pull/143#pullrequestreview-4356538487`
+  found three remaining post-fault recovery gaps:
+  `cooling_stopped` recovery events could be deduplicated against an older
+  normal `cooling_stopped` event, stale recovery completion did not use the same
+  fail-closed guard as the normal reserved command paths, and recovery
+  completion could accept a driver state with nonzero heat after a fault.
+- The follow-up fix keeps normal singleton event behavior but allows a fresh
+  `cooling_stopped` event when `recovery_after_fault: true`; rejects post-fault
+  recovery completion unless heat is off; and routes recovery completion
+  `SessionLifecycleError` failures through
+  `_fail_closed_after_stale_driver_command`.
+- Regression coverage now includes a completed-session-then-faulted recovery
+  timeline with two `cooling_stopped` events, a heat-on recovery rejection that
+  preserves fault state, and a stale recovery completion that triggers the
+  fail-closed emergency-stop driver safety path.
 
 Actions deliberately not taken:
 

--- a/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
+++ b/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
@@ -180,6 +180,45 @@ Fix:
 - Completed inactive sessions still reject `stop_cooling`, so the fix does not
   reopen normal controls after completion.
 
+Code review follow-up:
+
+- CodeRabbit review
+  `https://github.com/syamaner/coffee-roaster-mcp/pull/143#pullrequestreview-4356405938`
+  asked for explicit failure-branch coverage for the new recovery path. The
+  risk was that the happy path only proved recovery when the driver reported
+  cooling off; it did not prove safe behavior when the driver still reported
+  cooling active after `stop_cooling`.
+- Commit `32b440a` added
+  `test_stop_cooling_recovery_keeps_fault_when_driver_reports_cooling_on`.
+  That test configures the recording driver with `stop_cooling_stays_on=True`,
+  asserts `stop_cooling` raises, confirms the session remains
+  `phase: fault`, `active: false`, and `cooling_on: true`, and confirms no
+  `cooling_stopped` event is appended. The test deliberately expects the
+  driver action log to include `stop_cooling`, because the failure is only
+  knowable after the driver command returns `cooling_on: true`.
+- The same follow-up expanded the public
+  `RoastSessionStore.reserve_driver_stop_cooling_recovery` and
+  `RoastSessionStore.complete_reserved_driver_stop_cooling_recovery_snapshot`
+  docstrings with Google-style `Args`, `Returns`, `Raises`, and notes covering
+  the fault-only reservation lifecycle.
+- Codex review
+  `https://github.com/syamaner/coffee-roaster-mcp/pull/143#pullrequestreview-4356449763`
+  found an export consistency bug in the first recovery fix. The runtime state
+  stayed faulted, but CSV export phase derivation could classify the later
+  `cooling_stopped` recovery row as `complete`, because normal
+  `cooling_stopped` rows imply completion.
+- Commit `aff9fdb` updated export phase derivation so
+  `cooling_stopped` rows with `recovery_after_fault: true` remain classified as
+  `fault` when a fault is already visible. It also adjusted same-timestamp
+  event ordering so post-fault recovery `cooling_stopped` rows sort after the
+  `fault` event; this matters because stopped sessions reuse the stop monotonic
+  time for later recovery events.
+- Commit `aff9fdb` also added
+  `test_snapshot_export_csv_keeps_fault_phase_for_recovery_cooling_stop`, which
+  exports a `fault -> cooling_stopped(recovery_after_fault: true)` timeline and
+  asserts both rows remain `phase: fault` while the recovery row reports
+  `cooling_on: False`.
+
 Actions deliberately not taken:
 
 - did not mark E7-S4 complete from partial/faulted Warp evidence
@@ -188,6 +227,10 @@ Actions deliberately not taken:
 Hardware-ready release-label decision: still blocked. The emergency-stop
 recovery bug must be validated through Warp before hardware-ready status can be
 considered.
+
+## Usage Snapshot
+
+- `792K used`.
 
 ## Resume Checklist
 

--- a/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
+++ b/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
@@ -1,0 +1,190 @@
+# E7-S4 Warp Manual Hottop MCP Control Validation
+
+This summary captures the E7-S4 start, safety boundary, preflight evidence,
+current blocker, and restart context.
+
+## Scope
+
+Story: `E7-S4` / issue `#59`, run Warp manual Hottop MCP control validation.
+
+Branch: `feature/59-warp-manual-hottop-control-validation`
+
+The work is limited to Warp manual Hottop MCP control validation:
+
+- use Warp as the MCP client surface
+- configure the published `coffee-roaster-mcp==0.1.0` package for Hottop
+- keep `first_crack.mode: disabled`
+- keep `session.auto_t0_detection_enabled: false`
+- require explicit operator approval before every hardware-affecting tool call
+- record device state before and after each hardware-affecting command
+- export and review `roast.jsonl`, `roast.csv`, and `summary.json` only after
+  a supervised validation run
+
+No autonomous roasting, ChatGPT MCP validation, model training/export/sync, real
+microphone or ONNX audio-path validation, live PyPI/MCP Registry publishing, or
+full end-to-end agent roast validation is in scope.
+
+## Required Warp Configuration
+
+Hottop working directory:
+
+- `/tmp/roastpilot-warp-hottop`
+
+Config file:
+
+- `/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml`
+
+Required config values:
+
+```yaml
+transport:
+  type: stdio
+
+roaster:
+  driver: hottop_kn8828b_2k_plus
+  port: /dev/cu.usbserial-XXXX
+  baudrate: 115200
+  temperature_unit: auto
+  command_interval_seconds: 0.3
+
+first_crack:
+  mode: disabled
+
+session:
+  auto_t0_detection_enabled: false
+```
+
+The `roaster.port` value must be replaced with the actual Hottop serial device
+visible on the validation host. Do not use a placeholder or stale port value for
+live hardware validation.
+
+Warp MCP server JSON:
+
+```json
+{
+  "mcpServers": {
+    "roastpilot-hottop": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "coffee-roaster-mcp==0.1.0",
+        "coffee-roaster-mcp",
+        "serve"
+      ],
+      "env": {
+        "COFFEE_ROASTER_MCP_CONFIG": "/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml"
+      },
+      "working_directory": "/tmp/roastpilot-warp-hottop"
+    }
+  }
+}
+```
+
+If Warp cannot find `uvx`, use:
+
+```json
+"command": "/opt/homebrew/bin/uvx"
+```
+
+## Preflight Evidence
+
+GitHub and branch gate:
+
+- PR #140 was merged.
+- Issue #58 was closed.
+- `git checkout main`: passed.
+- `git pull --ff-only origin main`: fast-forwarded `main` from
+  `de18572edf3ea69f15a9e60a04f049a20f96ae34` to `c480afc`.
+- Created branch `feature/59-warp-manual-hottop-control-validation`.
+
+State and issue context read before starting:
+
+- `docs/state/registry.md`
+- `docs/state/epics/coffee-roaster-mcp-v0.1.md`
+- `docs/session-summaries/2026-05-24-e7-s3-warp-mcp-client-connection.md`
+- GitHub issue #59 and configuration guidance comment
+  `https://github.com/syamaner/coffee-roaster-mcp/issues/59#issuecomment-4529994261`
+
+Local command preflight:
+
+- `command -v uvx`: `/opt/homebrew/bin/uvx`
+- `/opt/homebrew/bin/uvx --version`: `uvx 0.11.16`
+- `ls /dev/cu.*`:
+  - `/dev/cu.Bluetooth-Incoming-Port`
+  - `/dev/cu.debug-console`
+
+No `/dev/cu.usbserial-*` Hottop adapter was visible during this preflight.
+
+Required repo checks:
+
+- `./.venv/bin/python -m pytest`: 356 passed.
+- `./.venv/bin/python -m ruff check .`: passed.
+- `./.venv/bin/python -m ruff format --check .`: 31 files already formatted.
+- `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations.
+- `./.venv/bin/coffee-roaster-mcp --help`: passed.
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+
+## Current Status
+
+Status: blocked before live Warp hardware validation.
+
+Reason: no actual Hottop USB serial adapter was visible, so the required
+`roaster.port` could not be set to a verified device path.
+
+Actions deliberately not taken:
+
+- did not create `/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml` with a
+  fake or stale serial port
+- did not launch the Hottop-configured server through Warp
+- did not call `start_roast_session`, `set_heat`, `set_fan`, `drop_beans`,
+  `start_cooling`, `stop_cooling`, or `emergency_stop` against hardware
+- did not export or claim hardware validation artifacts
+
+Hardware-ready release-label decision: blocked. Partial preflight evidence does
+not support a hardware-ready release label.
+
+## Resume Checklist
+
+Before resuming hardware validation:
+
+- connect the Hottop USB serial adapter
+- confirm the actual port appears with `ls /dev/cu.*`
+- keep the physical stop plan ready
+- create `/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml` with the actual
+  `roaster.port`
+- configure Warp with the `roastpilot-hottop` MCP JSON
+- confirm Warp discovers the expected tools
+- call `get_runtime_config` and confirm:
+  - `roaster_driver`: `hottop_kn8828b_2k_plus`
+  - `first_crack_mode`: `disabled`
+  - `auto_t0_detection_enabled`: `false`
+- call `get_roast_state` and record initial device state before controls
+- require explicit operator approval before every hardware-affecting MCP call
+- record device state before and after connect, heat, fan, drop, cooling,
+  stop-cooling, and emergency-stop validation
+- stop immediately on unexpected telemetry, command-loop errors, unsafe roaster
+  behavior, or uncertainty
+
+## Restart Prompt
+
+Resume in `/Users/sertanyamaner/git/coffee-roaster-mcp` on branch
+`feature/59-warp-manual-hottop-control-validation`. E7-S4 is started but blocked
+before live Warp Hottop validation because no actual Hottop USB serial adapter
+was visible: `ls /dev/cu.*` showed only `/dev/cu.Bluetooth-Incoming-Port` and
+`/dev/cu.debug-console`. PR #140 is merged, issue #58 is closed, `main` was
+fast-forwarded to `c480afc`, and `uvx` is available at `/opt/homebrew/bin/uvx`
+with version `0.11.16`. Read `docs/state/registry.md`,
+`docs/state/epics/coffee-roaster-mcp-v0.1.md`,
+`docs/session-summaries/2026-05-24-e7-s3-warp-mcp-client-connection.md`, this
+summary, and issue #59 including
+`https://github.com/syamaner/coffee-roaster-mcp/issues/59#issuecomment-4529994261`.
+After the Hottop adapter is connected, create
+`/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml` with actual
+`roaster.port`, keep `first_crack.mode: disabled` and
+`session.auto_t0_detection_enabled: false`, launch through Warp using
+`uvx --from coffee-roaster-mcp==0.1.0 coffee-roaster-mcp serve` or
+`/opt/homebrew/bin/uvx`, and require explicit operator approval plus before/after
+device-state evidence for every hardware-affecting tool call. Do not run
+autonomous roasting, ChatGPT MCP validation, model training/export/sync, real
+microphone or ONNX audio-path validation, live PyPI/MCP Registry publishing, or
+full end-to-end agent roast validation unless separately selected.

--- a/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
+++ b/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
@@ -142,7 +142,10 @@ Required repo checks:
 - Second review follow-up targeted recovery tests:
   `./.venv/bin/python -m pytest tests/test_session.py::test_stop_cooling_recovery_records_new_event_after_completed_session_fault tests/test_mcp_server.py::test_stop_cooling_recovers_after_emergency_stop_leaves_cooling_on tests/test_mcp_server.py::test_stop_cooling_recovery_keeps_fault_when_driver_reports_cooling_on tests/test_mcp_server.py::test_stop_cooling_recovery_rejects_driver_heat_after_fault tests/test_mcp_server.py::test_stale_stop_cooling_recovery_fails_closed tests/test_exports.py::test_snapshot_export_csv_keeps_fault_phase_for_recovery_cooling_stop`:
   6 passed.
-- `./.venv/bin/python -m pytest`: 363 passed.
+- CodeRabbit post-fault ownership follow-up:
+  `./.venv/bin/python -m pytest tests/test_session.py::test_start_session_rejects_pending_post_fault_cooling_recovery tests/test_session.py::test_reserve_session_start_rejects_pending_post_fault_cooling_recovery tests/test_session.py::test_start_session_allows_new_session_after_previous_stop tests/test_mcp_server.py::test_stop_cooling_recovers_after_emergency_stop_leaves_cooling_on`:
+  4 passed.
+- `./.venv/bin/python -m pytest`: 365 passed.
 - `./.venv/bin/python -m ruff check .`: passed.
 - `./.venv/bin/python -m ruff format --check .`: 31 files already formatted.
 - `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations.
@@ -237,6 +240,16 @@ Code review follow-up:
   timeline with two `cooling_stopped` events, a heat-on recovery rejection that
   preserves fault state, and a stale recovery completion that triggers the
   fail-closed emergency-stop driver safety path.
+- CodeRabbit review
+  `https://github.com/syamaner/coffee-roaster-mcp/pull/143#pullrequestreview-4356608858`
+  found that a new session could be started after emergency stop while the
+  previous faulted session still had cooling active. Because post-fault
+  `stop_cooling` recovery is latest-session-only, that could orphan the cooling
+  recovery path.
+- The follow-up fix blocks both direct `start_session` and reserved
+  `start_roast_session` startup while the latest session is inactive, faulted,
+  and `cooling_on: true`. Regression tests cover both start paths and preserve
+  normal rollover after a completed, non-faulted session.
 
 Actions deliberately not taken:
 

--- a/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
+++ b/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
@@ -136,7 +136,10 @@ Required repo checks:
 - Review follow-up targeted recovery tests:
   `./.venv/bin/python -m pytest tests/test_mcp_server.py::test_stop_cooling_recovers_after_emergency_stop_leaves_cooling_on tests/test_mcp_server.py::test_stop_cooling_recovery_keeps_fault_when_driver_reports_cooling_on tests/test_mcp_server.py::test_stop_cooling_still_rejects_completed_inactive_session tests/test_mcp_server.py::test_stop_cooling_uses_driver_cooling_state_before_completing`:
   4 passed.
-- `./.venv/bin/python -m pytest`: 359 passed.
+- Export recovery phase follow-up:
+  `./.venv/bin/python -m pytest tests/test_exports.py::test_snapshot_export_csv_keeps_fault_phase_for_recovery_cooling_stop tests/test_mcp_server.py::test_stop_cooling_recovers_after_emergency_stop_leaves_cooling_on tests/test_mcp_server.py::test_stop_cooling_recovery_keeps_fault_when_driver_reports_cooling_on`:
+  3 passed.
+- `./.venv/bin/python -m pytest`: 360 passed.
 - `./.venv/bin/python -m ruff check .`: passed.
 - `./.venv/bin/python -m ruff format --check .`: 31 files already formatted.
 - `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations.

--- a/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
+++ b/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
@@ -133,7 +133,10 @@ Required repo checks:
 - Targeted recovery tests after Warp emergency-stop finding:
   `./.venv/bin/python -m pytest tests/test_mcp_server.py::test_stop_cooling_recovers_after_emergency_stop_leaves_cooling_on tests/test_mcp_server.py::test_stop_cooling_still_rejects_completed_inactive_session tests/test_mcp_server.py::test_stop_cooling_uses_driver_cooling_state_before_completing`:
   3 passed.
-- `./.venv/bin/python -m pytest`: 358 passed.
+- Review follow-up targeted recovery tests:
+  `./.venv/bin/python -m pytest tests/test_mcp_server.py::test_stop_cooling_recovers_after_emergency_stop_leaves_cooling_on tests/test_mcp_server.py::test_stop_cooling_recovery_keeps_fault_when_driver_reports_cooling_on tests/test_mcp_server.py::test_stop_cooling_still_rejects_completed_inactive_session tests/test_mcp_server.py::test_stop_cooling_uses_driver_cooling_state_before_completing`:
+  4 passed.
+- `./.venv/bin/python -m pytest`: 359 passed.
 - `./.venv/bin/python -m ruff check .`: passed.
 - `./.venv/bin/python -m ruff format --check .`: 31 files already formatted.
 - `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations.

--- a/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
+++ b/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
@@ -1,7 +1,7 @@
 # E7-S4 Warp Manual Hottop MCP Control Validation
 
 This summary captures the E7-S4 start, safety boundary, preflight evidence,
-current blocker, and restart context.
+current manual-validation status, and restart context.
 
 ## Scope
 
@@ -42,7 +42,7 @@ transport:
 
 roaster:
   driver: hottop_kn8828b_2k_plus
-  port: /dev/cu.usbserial-XXXX
+  port: /dev/cu.usbserial-DN016OJ3
   baudrate: 115200
   temperature_unit: auto
   command_interval_seconds: 0.3
@@ -54,9 +54,10 @@ session:
   auto_t0_detection_enabled: false
 ```
 
-The `roaster.port` value must be replaced with the actual Hottop serial device
-visible on the validation host. Do not use a placeholder or stale port value for
-live hardware validation.
+The `roaster.port` value was set to the actual Hottop serial device visible on
+the validation host during preflight:
+
+- `/dev/cu.usbserial-DN016OJ3`
 
 Warp MCP server JSON:
 
@@ -113,7 +114,19 @@ Local command preflight:
   - `/dev/cu.Bluetooth-Incoming-Port`
   - `/dev/cu.debug-console`
 
-No `/dev/cu.usbserial-*` Hottop adapter was visible during this preflight.
+Initial preflight did not show a Hottop adapter. After the operator reconnected
+the device, `/dev/cu.usbserial-DN016OJ3` appeared.
+
+Config creation and local non-hardware verification:
+
+- Created `/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml` with
+  `roaster.driver: hottop_kn8828b_2k_plus`,
+  `roaster.port: /dev/cu.usbserial-DN016OJ3`,
+  `first_crack.mode: disabled`, and
+  `session.auto_t0_detection_enabled: false`.
+- Ran local config-load verification without connecting to hardware:
+  `./.venv/bin/python -c "..."` returned
+  `hottop_kn8828b_2k_plus /dev/cu.usbserial-DN016OJ3 disabled False`.
 
 Required repo checks:
 
@@ -126,32 +139,29 @@ Required repo checks:
 
 ## Current Status
 
-Status: blocked before live Warp hardware validation.
+Status: ready for supervised Warp tool discovery and read-only config/state
+checks, but hardware-affecting validation is not yet run.
 
-Reason: no actual Hottop USB serial adapter was visible, so the required
-`roaster.port` could not be set to a verified device path.
+Reason: the Hottop serial adapter is now visible and the config file exists, but
+the required Warp evidence and explicit operator approvals for hardware-affecting
+MCP tool calls have not been captured yet.
 
 Actions deliberately not taken:
 
-- did not create `/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml` with a
-  fake or stale serial port
 - did not launch the Hottop-configured server through Warp
 - did not call `start_roast_session`, `set_heat`, `set_fan`, `drop_beans`,
   `start_cooling`, `stop_cooling`, or `emergency_stop` against hardware
 - did not export or claim hardware validation artifacts
 
-Hardware-ready release-label decision: blocked. Partial preflight evidence does
-not support a hardware-ready release label.
+Hardware-ready release-label decision: still blocked. Adapter/config preflight
+alone does not support a hardware-ready release label.
 
 ## Resume Checklist
 
 Before resuming hardware validation:
 
-- connect the Hottop USB serial adapter
-- confirm the actual port appears with `ls /dev/cu.*`
+- confirm the Hottop USB serial adapter still appears with `ls /dev/cu.*`
 - keep the physical stop plan ready
-- create `/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml` with the actual
-  `roaster.port`
 - configure Warp with the `roastpilot-hottop` MCP JSON
 - confirm Warp discovers the expected tools
 - call `get_runtime_config` and confirm:
@@ -168,20 +178,21 @@ Before resuming hardware validation:
 ## Restart Prompt
 
 Resume in `/Users/sertanyamaner/git/coffee-roaster-mcp` on branch
-`feature/59-warp-manual-hottop-control-validation`. E7-S4 is started but blocked
-before live Warp Hottop validation because no actual Hottop USB serial adapter
-was visible: `ls /dev/cu.*` showed only `/dev/cu.Bluetooth-Incoming-Port` and
-`/dev/cu.debug-console`. PR #140 is merged, issue #58 is closed, `main` was
-fast-forwarded to `c480afc`, and `uvx` is available at `/opt/homebrew/bin/uvx`
-with version `0.11.16`. Read `docs/state/registry.md`,
+`feature/59-warp-manual-hottop-control-validation`. E7-S4 is started and the
+Hottop adapter is now visible at `/dev/cu.usbserial-DN016OJ3`. The config file
+`/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml` was created with driver
+`hottop_kn8828b_2k_plus`, port `/dev/cu.usbserial-DN016OJ3`,
+`first_crack.mode: disabled`, and
+`session.auto_t0_detection_enabled: false`; local config-load verification
+returned `hottop_kn8828b_2k_plus /dev/cu.usbserial-DN016OJ3 disabled False`.
+PR #140 is merged, issue #58 is closed, `main` was fast-forwarded to `c480afc`,
+and `uvx` is available at `/opt/homebrew/bin/uvx` with version `0.11.16`. Read
+`docs/state/registry.md`,
 `docs/state/epics/coffee-roaster-mcp-v0.1.md`,
 `docs/session-summaries/2026-05-24-e7-s3-warp-mcp-client-connection.md`, this
 summary, and issue #59 including
 `https://github.com/syamaner/coffee-roaster-mcp/issues/59#issuecomment-4529994261`.
-After the Hottop adapter is connected, create
-`/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml` with actual
-`roaster.port`, keep `first_crack.mode: disabled` and
-`session.auto_t0_detection_enabled: false`, launch through Warp using
+Next, launch through Warp using
 `uvx --from coffee-roaster-mcp==0.1.0 coffee-roaster-mcp serve` or
 `/opt/homebrew/bin/uvx`, and require explicit operator approval plus before/after
 device-state evidence for every hardware-affecting tool call. Do not run

--- a/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
+++ b/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
@@ -130,7 +130,10 @@ Config creation and local non-hardware verification:
 
 Required repo checks:
 
-- `./.venv/bin/python -m pytest`: 356 passed.
+- Targeted recovery tests after Warp emergency-stop finding:
+  `./.venv/bin/python -m pytest tests/test_mcp_server.py::test_stop_cooling_recovers_after_emergency_stop_leaves_cooling_on tests/test_mcp_server.py::test_stop_cooling_still_rejects_completed_inactive_session tests/test_mcp_server.py::test_stop_cooling_uses_driver_cooling_state_before_completing`:
+  3 passed.
+- `./.venv/bin/python -m pytest`: 358 passed.
 - `./.venv/bin/python -m ruff check .`: passed.
 - `./.venv/bin/python -m ruff format --check .`: 31 files already formatted.
 - `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations.
@@ -139,22 +142,46 @@ Required repo checks:
 
 ## Current Status
 
-Status: ready for supervised Warp tool discovery and read-only config/state
-checks, but hardware-affecting validation is not yet run.
+Status: live Warp Hottop validation surfaced a recovery bug after emergency
+stop; a code fix is now on the branch.
 
-Reason: the Hottop serial adapter is now visible and the config file exists, but
-the required Warp evidence and explicit operator approvals for hardware-affecting
-MCP tool calls have not been captured yet.
+Observed Warp behavior:
+
+- `drop_beans` from `pre_roast` was rejected before the driver boundary:
+  `beans_dropped cannot be recorded while phase is pre_roast; allowed phases:
+  roasting, development`. This is expected lifecycle-guard behavior, not a bug.
+- After emergency stop, Warp reported `get_roast_state` with `phase: fault`,
+  `active: false`, `cooling_on: true`, `fan_level_percent: 100`, and
+  `cooling_motor_on: true`.
+- A subsequent `stop_cooling` attempt failed with
+  `No active roast session exists.`
+
+Bug conclusion:
+
+- Emergency stop intentionally leaves cooling on as the fail-closed hardware
+  state.
+- The MCP `stop_cooling` tool incorrectly required an active session, so the
+  operator could not stop cooling through MCP after emergency stop faulted and
+  stopped the session.
+
+Fix:
+
+- `stop_cooling` now has a narrow recovery path for the latest stopped
+  `fault` session when cooling is still on.
+- The recovery path sends only the configured driver `stop_cooling` command,
+  records a `cooling_stopped` event with `recovery_after_fault: true`, sets
+  cooling off in session state, and preserves `phase: fault` / `active: false`.
+- Completed inactive sessions still reject `stop_cooling`, so the fix does not
+  reopen normal controls after completion.
 
 Actions deliberately not taken:
 
-- did not launch the Hottop-configured server through Warp
-- did not call `start_roast_session`, `set_heat`, `set_fan`, `drop_beans`,
-  `start_cooling`, `stop_cooling`, or `emergency_stop` against hardware
+- did not mark E7-S4 complete from partial/faulted Warp evidence
 - did not export or claim hardware validation artifacts
 
-Hardware-ready release-label decision: still blocked. Adapter/config preflight
-alone does not support a hardware-ready release label.
+Hardware-ready release-label decision: still blocked. The emergency-stop
+recovery bug must be validated through Warp before hardware-ready status can be
+considered.
 
 ## Resume Checklist
 
@@ -172,6 +199,8 @@ Before resuming hardware validation:
 - require explicit operator approval before every hardware-affecting MCP call
 - record device state before and after connect, heat, fan, drop, cooling,
   stop-cooling, and emergency-stop validation
+- specifically rerun post-emergency `stop_cooling` recovery through Warp and
+  confirm cooling turns off while the session remains faulted and inactive
 - stop immediately on unexpected telemetry, command-loop errors, unsafe roaster
   behavior, or uncertainty
 
@@ -192,10 +221,16 @@ and `uvx` is available at `/opt/homebrew/bin/uvx` with version `0.11.16`. Read
 `docs/session-summaries/2026-05-24-e7-s3-warp-mcp-client-connection.md`, this
 summary, and issue #59 including
 `https://github.com/syamaner/coffee-roaster-mcp/issues/59#issuecomment-4529994261`.
-Next, launch through Warp using
-`uvx --from coffee-roaster-mcp==0.1.0 coffee-roaster-mcp serve` or
-`/opt/homebrew/bin/uvx`, and require explicit operator approval plus before/after
-device-state evidence for every hardware-affecting tool call. Do not run
-autonomous roasting, ChatGPT MCP validation, model training/export/sync, real
-microphone or ONNX audio-path validation, live PyPI/MCP Registry publishing, or
-full end-to-end agent roast validation unless separately selected.
+Warp hardware validation surfaced a recovery bug: after emergency stop,
+`get_roast_state` showed `phase: fault`, `active: false`, `cooling_on: true`,
+`fan_level_percent: 100`, and `cooling_motor_on: true`, but `stop_cooling`
+failed with `No active roast session exists.` The branch now includes a narrow
+post-emergency recovery fix allowing `stop_cooling` only for the latest stopped
+fault session with cooling still on, while preserving `phase: fault` and
+`active: false`. Next, run the updated branch locally or publish/install an
+updated package build before retesting in Warp, then specifically validate
+post-emergency `stop_cooling` recovery with explicit operator approval and
+before/after `get_roast_state`. Do not run autonomous roasting, ChatGPT MCP
+validation, model training/export/sync, real microphone or ONNX audio-path
+validation, live PyPI/MCP Registry publishing, or full end-to-end agent roast
+validation unless separately selected.

--- a/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
+++ b/docs/session-summaries/2026-05-25-e7-s4-warp-manual-hottop-control-validation.md
@@ -263,6 +263,7 @@ considered.
 ## Usage Snapshot
 
 - `792K used`.
+- `1.86M used`.
 
 ## Resume Checklist
 

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -816,12 +816,16 @@ Goal: prove the package works from install through mock roast, MCP client calls,
     complete a full mock roast through public MCP tools, and verify exported
     JSONL, CSV, and summary outputs.
 
-- [ ] `E7-S4` Run Warp manual Hottop MCP control validation.
+- [!] `E7-S4` Run Warp manual Hottop MCP control validation.
   - Done when Warp can connect to the Hottop-configured RoastPilot MCP server
     and the operator manually approves each hardware-affecting tool call for
     connect, telemetry, heat, fan, drop, cooling, stop-cooling, emergency stop,
     and exported-log review. No autonomous hardware-control decisions are in
     scope.
+  - Started from updated `main` on
+    `feature/59-warp-manual-hottop-control-validation`, but live validation is
+    blocked until the actual Hottop USB serial adapter is visible and the
+    operator explicitly approves each Warp hardware-affecting tool call.
 
 - [ ] `E7-S5a` Test MCP first-crack detection with labelled WAV replay.
   - Done when a small derived WAV fixture, retimestamped label file, and
@@ -1176,6 +1180,33 @@ After completing a story:
   - Kept Hottop hardware validation, ChatGPT MCP validation, model
     training/export/sync, real microphone validation, live release publishing,
     and full end-to-end agent roast validation out of scope.
+
+- Validation preflight for E7-S4:
+  - Verified PR #140 was merged and issue #58 was closed before starting.
+  - Synced `main` from merge commit
+    `de18572edf3ea69f15a9e60a04f049a20f96ae34` to
+    `c480afc` with `git pull --ff-only origin main`.
+  - Created branch
+    `feature/59-warp-manual-hottop-control-validation`.
+  - Read issue #59 and its configuration guidance comment. The intended Warp
+    hardware configuration remains `/tmp/roastpilot-warp-hottop`, roaster
+    driver `hottop_kn8828b_2k_plus`, first-crack mode `disabled`, and
+    `session.auto_t0_detection_enabled: false`, launched through
+    `uvx --from coffee-roaster-mcp==0.1.0 coffee-roaster-mcp serve` or
+    `/opt/homebrew/bin/uvx` if Warp cannot find `uvx`.
+  - Confirmed local `uvx` resolves to `/opt/homebrew/bin/uvx` and reports
+    `uvx 0.11.16`.
+  - Checked visible macOS serial devices with `ls /dev/cu.*`; only
+    `/dev/cu.Bluetooth-Incoming-Port` and `/dev/cu.debug-console` were present.
+    No actual `/dev/cu.usbserial-*` Hottop adapter was visible, so
+    `/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml` was not created with
+    a fake port and Warp hardware validation was not launched.
+  - No hardware-affecting MCP calls were run. This preserves the E7-S4 safety
+    boundary requiring physical stop readiness, runtime config and device-state
+    confirmation before controls, and explicit operator approval before each
+    connect, heat, fan, drop, cooling, stop-cooling, and emergency-stop call.
+  - Hardware-ready release labeling remains blocked. Partial preflight evidence
+    does not prove Warp Hottop control behavior.
 
 - Validation run for E6-S4:
   - Added focused version alignment coverage in `tests/test_server_json.py`.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -823,9 +823,12 @@ Goal: prove the package works from install through mock roast, MCP client calls,
     and exported-log review. No autonomous hardware-control decisions are in
     scope.
   - Started from updated `main` on
-    `feature/59-warp-manual-hottop-control-validation`, but live validation is
-    blocked until the actual Hottop USB serial adapter is visible and the
-    operator explicitly approves each Warp hardware-affecting tool call.
+    `feature/59-warp-manual-hottop-control-validation`. The Hottop adapter is
+    now visible at `/dev/cu.usbserial-DN016OJ3`, and
+    `/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml` has been created with
+    the Hottop driver, disabled first-crack mode, and auto-T0 disabled. Live
+    validation still requires Warp evidence and explicit operator approval for
+    each hardware-affecting tool call.
 
 - [ ] `E7-S5a` Test MCP first-crack detection with labelled WAV replay.
   - Done when a small derived WAV fixture, retimestamped label file, and
@@ -1196,17 +1199,26 @@ After completing a story:
     `/opt/homebrew/bin/uvx` if Warp cannot find `uvx`.
   - Confirmed local `uvx` resolves to `/opt/homebrew/bin/uvx` and reports
     `uvx 0.11.16`.
-  - Checked visible macOS serial devices with `ls /dev/cu.*`; only
+  - Initially checked visible macOS serial devices with `ls /dev/cu.*`; only
     `/dev/cu.Bluetooth-Incoming-Port` and `/dev/cu.debug-console` were present.
-    No actual `/dev/cu.usbserial-*` Hottop adapter was visible, so
-    `/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml` was not created with
-    a fake port and Warp hardware validation was not launched.
+    No actual `/dev/cu.usbserial-*` Hottop adapter was visible, so no fake-port
+    config was created and Warp hardware validation was not launched.
+  - After the operator reconnected the Hottop adapter, `ls /dev/cu.*` showed
+    `/dev/cu.usbserial-DN016OJ3`.
+  - Created `/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml` with
+    `roaster.driver: hottop_kn8828b_2k_plus`,
+    `roaster.port: /dev/cu.usbserial-DN016OJ3`,
+    `first_crack.mode: disabled`, and
+    `session.auto_t0_detection_enabled: false`.
+  - Ran local config-load verification without connecting to hardware:
+    `./.venv/bin/python -c "..."` returned
+    `hottop_kn8828b_2k_plus /dev/cu.usbserial-DN016OJ3 disabled False`.
   - No hardware-affecting MCP calls were run. This preserves the E7-S4 safety
     boundary requiring physical stop readiness, runtime config and device-state
     confirmation before controls, and explicit operator approval before each
     connect, heat, fan, drop, cooling, stop-cooling, and emergency-stop call.
-  - Hardware-ready release labeling remains blocked. Partial preflight evidence
-    does not prove Warp Hottop control behavior.
+  - Hardware-ready release labeling remains blocked. Adapter/config preflight
+    evidence does not prove Warp Hottop control behavior.
 
 - Validation run for E6-S4:
   - Added focused version alignment coverage in `tests/test_server_json.py`.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -1217,8 +1217,23 @@ After completing a story:
     boundary requiring physical stop readiness, runtime config and device-state
     confirmation before controls, and explicit operator approval before each
     connect, heat, fan, drop, cooling, stop-cooling, and emergency-stop call.
-  - Hardware-ready release labeling remains blocked. Adapter/config preflight
-    evidence does not prove Warp Hottop control behavior.
+  - Live Warp validation later surfaced a post-emergency recovery bug:
+    emergency stop correctly faulted and stopped the session while leaving
+    cooling on, but the MCP `stop_cooling` tool then failed with
+    `No active roast session exists.` This blocked operator recovery through
+    Warp while `get_roast_state` still showed `cooling_on: true`,
+    `fan_level_percent: 100`, and `cooling_motor_on: true`.
+  - Added a narrow MCP recovery path so `stop_cooling` is allowed only for the
+    latest stopped `fault` session while cooling remains on. The recovery path
+    sends the driver `stop_cooling` command, records a `cooling_stopped` event
+    with `recovery_after_fault: true`, turns cooling off in session state, and
+    preserves `phase: fault` / `active: false`. Completed inactive sessions
+    still reject `stop_cooling`.
+  - Targeted recovery validation passed:
+    `./.venv/bin/python -m pytest tests/test_mcp_server.py::test_stop_cooling_recovers_after_emergency_stop_leaves_cooling_on tests/test_mcp_server.py::test_stop_cooling_still_rejects_completed_inactive_session tests/test_mcp_server.py::test_stop_cooling_uses_driver_cooling_state_before_completing`:
+    3 passed.
+  - Hardware-ready release labeling remains blocked until the recovery fix and
+    the remaining hardware-control checklist are validated through Warp.
 
 - Validation run for E6-S4:
   - Added focused version alignment coverage in `tests/test_server_json.py`.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -410,6 +410,16 @@ explicit operator approval for each hardware-affecting MCP call. Do not launch
 Warp hardware controls, export hardware logs, or apply a hardware-ready release
 label from adapter/config preflight alone.
 
+Live E7-S4 Warp validation surfaced a post-emergency recovery bug: emergency
+stop correctly faulted and stopped the session while leaving cooling on, but
+MCP `stop_cooling` then failed with `No active roast session exists.` The
+branch now includes a narrow recovery path that allows `stop_cooling` only for
+the latest stopped `fault` session while cooling remains on, records
+`cooling_stopped` with `recovery_after_fault: true`, and preserves
+`phase: fault` / `active: false`. Hardware-ready release labeling remains
+blocked until that recovery path and the rest of E7-S4 are validated through
+Warp.
+
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 
 Epic 2 and Epic 3 are complete. Coverage output is visible in GitHub Actions through a concise Markdown job summary and an `html-coverage-report` artifact.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -399,14 +399,16 @@ training/export/sync, or real microphone validation unless a later story
 explicitly requires it.
 
 E7-S4 is started on branch
-`feature/59-warp-manual-hottop-control-validation`, but live Warp Hottop
-validation is blocked until the actual Hottop USB serial adapter is visible and
-the operator explicitly approves each hardware-affecting MCP call. The local
-preflight confirmed `uvx` at `/opt/homebrew/bin/uvx`, but `ls /dev/cu.*` showed
-only `/dev/cu.Bluetooth-Incoming-Port` and `/dev/cu.debug-console`; no
-`/dev/cu.usbserial-*` Hottop device was available. Do not create a fake
-hardware config, launch Warp hardware controls, export hardware logs, or apply
-a hardware-ready release label from this partial evidence.
+`feature/59-warp-manual-hottop-control-validation`. The local preflight
+confirmed `uvx` at `/opt/homebrew/bin/uvx`; after the operator reconnected the
+Hottop adapter, `ls /dev/cu.*` showed `/dev/cu.usbserial-DN016OJ3`. The
+dedicated config now exists at
+`/tmp/roastpilot-warp-hottop/coffee-roaster-mcp.yaml` with the Hottop driver,
+that serial port, first-crack mode disabled, and auto-T0 disabled. Live Warp
+Hottop validation still requires Warp tool-discovery/config/state evidence and
+explicit operator approval for each hardware-affecting MCP call. Do not launch
+Warp hardware controls, export hardware logs, or apply a hardware-ready release
+label from adapter/config preflight alone.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -398,6 +398,16 @@ end-to-end agent roast validation, ChatGPT MCP validation, model
 training/export/sync, or real microphone validation unless a later story
 explicitly requires it.
 
+E7-S4 is started on branch
+`feature/59-warp-manual-hottop-control-validation`, but live Warp Hottop
+validation is blocked until the actual Hottop USB serial adapter is visible and
+the operator explicitly approves each hardware-affecting MCP call. The local
+preflight confirmed `uvx` at `/opt/homebrew/bin/uvx`, but `ls /dev/cu.*` showed
+only `/dev/cu.Bluetooth-Incoming-Port` and `/dev/cu.debug-console`; no
+`/dev/cu.usbserial-*` Hottop device was available. Do not create a fake
+hardware config, launch Warp hardware controls, export hardware logs, or apply
+a hardware-ready release label from this partial evidence.
+
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 
 Epic 2 and Epic 3 are complete. Coverage output is visible in GitHub Actions through a concise Markdown job summary and an `html-coverage-report` artifact.

--- a/src/coffee_roaster_mcp/exports.py
+++ b/src/coffee_roaster_mcp/exports.py
@@ -469,6 +469,12 @@ def _phase_from(events: list[RoastEvent]) -> RoastPhase:
             phase = "dropped"
         elif event.kind == "cooling_started":
             phase = "cooling"
+        elif (
+            event.kind == "cooling_stopped"
+            and phase == "fault"
+            and event.payload.get("recovery_after_fault") is True
+        ):
+            phase = "fault"
         elif event.kind == "cooling_stopped":
             phase = "complete"
         elif event.kind == "fault":
@@ -580,6 +586,8 @@ def _event_cooling_value(event: RoastEvent, *, telemetry: TelemetrySample | None
 
 def _event_sort_key(event: RoastEvent) -> tuple[float, int]:
     """Return deterministic event ordering key for CSV export."""
+    if event.kind == "cooling_stopped" and event.payload.get("recovery_after_fault") is True:
+        return (event.monotonic_seconds, _event_order("fault") + 1)
     return (event.monotonic_seconds, _event_order(event.kind))
 
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -698,8 +698,15 @@ def create_mcp_server(
     ) -> EventCommandResult:
         """Stop cooling through the configured driver boundary."""
         server_context = ctx.request_context.lifespan_context
-        session = _require_active_session(server_context)
-        event, snapshot = _run_reserved_driver_stop_cooling(server_context, session)
+        session = server_context.session_store.get_active_session()
+        if session is None:
+            session = _require_faulted_cooling_session(server_context)
+            event, snapshot = _run_reserved_driver_stop_cooling_recovery(
+                server_context,
+                session,
+            )
+        else:
+            event, snapshot = _run_reserved_driver_stop_cooling(server_context, session)
         server_context.first_crack_runtime.stop_for_session(
             snapshot.id,
             reason="cooling stopped",
@@ -792,6 +799,20 @@ def _require_active_session(server_context: ServerContext) -> RoastSession:
     """Return the active session or fail clearly when none exists."""
     session = server_context.session_store.get_active_session()
     if session is None:
+        raise ValueError("No active roast session exists.")
+    return session
+
+
+def _require_faulted_cooling_session(server_context: ServerContext) -> RoastSession:
+    """Return the latest stopped fault session when cooling recovery is possible."""
+    session = server_context.session_store.get_latest_session()
+    if (
+        session is None
+        or session.active
+        or session.phase != "fault"
+        or session.faulted_at_utc is None
+        or not session.cooling_on
+    ):
         raise ValueError("No active roast session exists.")
     return session
 
@@ -973,6 +994,26 @@ def _run_reserved_driver_stop_cooling(
         except SessionLifecycleError:
             _fail_closed_after_stale_driver_command(server_context, reservation=reservation)
             raise
+    except Exception:
+        server_context.session_store.clear_driver_command_reservation(session, reservation)
+        raise
+
+
+def _run_reserved_driver_stop_cooling_recovery(
+    server_context: ServerContext,
+    session: RoastSession,
+) -> tuple[RoastEvent, RoastSession]:
+    """Run a reserved cooling-stop command for a faulted stopped session."""
+    reservation = server_context.session_store.reserve_driver_stop_cooling_recovery(session)
+    try:
+        driver_state = server_context.roaster_driver.stop_cooling()
+        return server_context.session_store.complete_reserved_driver_stop_cooling_recovery_snapshot(
+            session,
+            reservation=reservation,
+            heat_level_percent=driver_state.heat_level_percent,
+            fan_level_percent=driver_state.fan_level_percent,
+            cooling_on=driver_state.cooling_on,
+        )
     except Exception:
         server_context.session_store.clear_driver_command_reservation(session, reservation)
         raise

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -1007,13 +1007,20 @@ def _run_reserved_driver_stop_cooling_recovery(
     reservation = server_context.session_store.reserve_driver_stop_cooling_recovery(session)
     try:
         driver_state = server_context.roaster_driver.stop_cooling()
-        return server_context.session_store.complete_reserved_driver_stop_cooling_recovery_snapshot(
-            session,
-            reservation=reservation,
-            heat_level_percent=driver_state.heat_level_percent,
-            fan_level_percent=driver_state.fan_level_percent,
-            cooling_on=driver_state.cooling_on,
-        )
+        try:
+            complete_recovery = (
+                server_context.session_store.complete_reserved_driver_stop_cooling_recovery_snapshot
+            )
+            return complete_recovery(
+                session,
+                reservation=reservation,
+                heat_level_percent=driver_state.heat_level_percent,
+                fan_level_percent=driver_state.fan_level_percent,
+                cooling_on=driver_state.cooling_on,
+            )
+        except SessionLifecycleError:
+            _fail_closed_after_stale_driver_command(server_context, reservation=reservation)
+            raise
     except Exception:
         server_context.session_store.clear_driver_command_reservation(session, reservation)
         raise

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -1112,6 +1112,23 @@ class RoastSessionStore:
                 raise SessionLifecycleError("Cooling must be started before it can be stopped.")
             return self._reserve_driver_command_locked(session, kind="stop_cooling")
 
+    def reserve_driver_stop_cooling_recovery(
+        self,
+        session: RoastSession,
+    ) -> DriverCommandReservation:
+        """Reserve cooling-stop recovery for the latest faulted session."""
+        with self._lock:
+            self._assert_latest_session(session)
+            if session.active:
+                raise SessionLifecycleError("Recovery cooling stop requires a stopped session.")
+            if session.faulted_at_utc is None or session.phase != "fault":
+                raise SessionLifecycleError(
+                    "Recovery cooling stop is only allowed after an emergency stop."
+                )
+            if not session.cooling_on:
+                raise SessionLifecycleError("Cooling must be active before it can be stopped.")
+            return self._reserve_driver_command_locked(session, kind="stop_cooling")
+
     def complete_reserved_driver_control_snapshot(
         self,
         session: RoastSession,
@@ -1278,6 +1295,59 @@ class RoastSessionStore:
                     monotonic_now=self._monotonic_now,
                     phase="complete",
                 )
+            finally:
+                self._clear_driver_command_reservation_locked(session, reservation)
+            return event, _copy_session_for_read(session)
+
+    def complete_reserved_driver_stop_cooling_recovery_snapshot(
+        self,
+        session: RoastSession,
+        *,
+        reservation: DriverCommandReservation,
+        heat_level_percent: int,
+        fan_level_percent: int,
+        cooling_on: bool,
+    ) -> tuple[RoastEvent, RoastSession]:
+        """Complete cooling-stop recovery after an emergency stop."""
+        with self._lock:
+            self._assert_latest_session(session)
+            if (
+                reservation.session_id != session.id
+                or session.pending_driver_command_token != reservation.token
+                or session.pending_driver_command_kind != reservation.kind
+            ):
+                raise SessionLifecycleError("Driver command reservation is no longer active.")
+            if session.active or session.faulted_at_utc is None or session.phase != "fault":
+                raise SessionLifecycleError(
+                    "Recovery cooling stop is only allowed after an emergency stop."
+                )
+            if cooling_on:
+                raise SessionLifecycleError(
+                    "Driver still reports cooling active after stop_cooling."
+                )
+            validated_heat = validate_control_percent(
+                heat_level_percent,
+                label="heat_level_percent",
+            )
+            validated_fan = validate_control_percent(
+                fan_level_percent,
+                label="fan_level_percent",
+            )
+            try:
+                event = self._record_stopped_session_event_locked(
+                    session,
+                    "cooling_stopped",
+                    payload={
+                        "heat_level_percent": validated_heat,
+                        "fan_level_percent": validated_fan,
+                        "cooling_on": False,
+                        "recovery_after_fault": True,
+                    },
+                )
+                session.heat_level_percent = validated_heat
+                session.fan_level_percent = validated_fan
+                session.cooling_on = False
+                session.phase = "fault"
             finally:
                 self._clear_driver_command_reservation_locked(session, reservation)
             return event, _copy_session_for_read(session)
@@ -1619,6 +1689,28 @@ class RoastSessionStore:
         """Validate that one session is the latest known session."""
         if self._latest_session is not session:
             raise SessionLifecycleError("Only the latest session can be mutated.")
+
+    def _record_stopped_session_event_locked(
+        self,
+        session: RoastSession,
+        kind: RoastEventKind,
+        *,
+        payload: dict[str, EventPayloadValue],
+    ) -> RoastEvent:
+        """Record a narrowly allowed event for a stopped latest session."""
+        existing_event = self._get_existing_singleton_event(session, kind)
+        if existing_event is not None:
+            return existing_event
+        event = RoastEvent(
+            kind=kind,
+            recorded_at_utc=self._utc_now(),
+            monotonic_seconds=session.elapsed_monotonic_seconds(self._monotonic_now),
+            payload=dict(payload),
+        )
+        _append_event_log_row(session, event)
+        session.event_timeline.append(event)
+        _apply_event_timestamp(session, event)
+        return event
 
     def _start_session_locked(self) -> RoastSession:
         """Start one new active session while the store lock is already held."""

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -778,7 +778,8 @@ class RoastSessionStore:
             The created active roast session.
 
         Raises:
-            SessionLifecycleError: If an active session already exists.
+            SessionLifecycleError: If an active session already exists or a
+                faulted stopped session still has cooling active.
         """
         with self._lock:
             if self._pending_session_start_token is not None:
@@ -794,6 +795,7 @@ class RoastSessionStore:
     def reserve_session_start(self) -> SessionStartReservation:
         """Reserve session startup before preparing the configured driver."""
         with self._lock:
+            self._assert_no_pending_fault_cooling_recovery_locked()
             if self._latest_session is not None and self._latest_session.active:
                 raise SessionLifecycleError("An active roast session already exists.")
             if self._pending_session_start_token is not None:
@@ -1766,6 +1768,7 @@ class RoastSessionStore:
 
     def _start_session_locked(self) -> RoastSession:
         """Start one new active session while the store lock is already held."""
+        self._assert_no_pending_fault_cooling_recovery_locked()
         if self._latest_session is not None and self._latest_session.active:
             raise SessionLifecycleError("An active roast session already exists.")
 
@@ -1784,6 +1787,20 @@ class RoastSessionStore:
         self._session_id_order.append(session_id)
         self._prune_session_history_locked()
         return session
+
+    def _assert_no_pending_fault_cooling_recovery_locked(self) -> None:
+        """Reject new sessions while stopped fault cooling still needs recovery."""
+        session = self._latest_session
+        if (
+            session is not None
+            and not session.active
+            and session.faulted_at_utc is not None
+            and session.phase == "fault"
+            and session.cooling_on
+        ):
+            raise SessionLifecycleError(
+                "Cannot start a new roast session while post-fault cooling recovery is pending."
+            )
 
     def _assert_session_start_reservation(
         self,

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -1116,7 +1116,27 @@ class RoastSessionStore:
         self,
         session: RoastSession,
     ) -> DriverCommandReservation:
-        """Reserve cooling-stop recovery for the latest faulted session."""
+        """Reserve cooling-stop recovery for the latest faulted session.
+
+        Args:
+            session: Latest session to recover after emergency stop.
+
+        Returns:
+            Driver command reservation that must be completed with
+            `complete_reserved_driver_stop_cooling_recovery_snapshot` or cleared
+            if the driver command fails.
+
+        Raises:
+            SessionLifecycleError: If the session is not the latest session, is
+                still active, is not faulted, is not in `fault` phase, has no
+                active cooling state, or another driver command is in progress.
+
+        Notes:
+            This recovery path is intentionally narrower than normal
+            `stop_cooling`: it exists only after emergency stop has already
+            stopped the session while leaving cooling active as the fail-closed
+            hardware state.
+        """
         with self._lock:
             self._assert_latest_session(session)
             if session.active:
@@ -1308,7 +1328,34 @@ class RoastSessionStore:
         fan_level_percent: int,
         cooling_on: bool,
     ) -> tuple[RoastEvent, RoastSession]:
-        """Complete cooling-stop recovery after an emergency stop."""
+        """Complete cooling-stop recovery after an emergency stop.
+
+        Args:
+            session: Latest faulted, stopped session being recovered.
+            reservation: Active recovery stop-cooling reservation returned by
+                `reserve_driver_stop_cooling_recovery`.
+            heat_level_percent: Driver-reported heat level after the recovery
+                stop-cooling command.
+            fan_level_percent: Driver-reported fan level after the recovery
+                stop-cooling command.
+            cooling_on: Driver-reported cooling state after the recovery
+                stop-cooling command.
+
+        Returns:
+            The recorded `cooling_stopped` recovery event plus an atomic session
+            snapshot.
+
+        Raises:
+            SessionLifecycleError: If the reservation is stale or belongs to a
+                different session, the session is active, the session is not a
+                stopped fault session, the driver still reports cooling active,
+                or returned heat/fan controls are invalid.
+
+        Notes:
+            Successful completion records `cooling_stopped` with
+            `recovery_after_fault: true`, updates the session controls, and
+            preserves `phase: fault` / `active: false`.
+        """
         with self._lock:
             self._assert_latest_session(session)
             if (

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -1380,6 +1380,8 @@ class RoastSessionStore:
                 fan_level_percent,
                 label="fan_level_percent",
             )
+            if validated_heat != 0:
+                raise SessionLifecycleError("Heat must be off after post-fault cooling recovery.")
             try:
                 event = self._record_stopped_session_event_locked(
                     session,
@@ -1746,7 +1748,10 @@ class RoastSessionStore:
     ) -> RoastEvent:
         """Record a narrowly allowed event for a stopped latest session."""
         existing_event = self._get_existing_singleton_event(session, kind)
-        if existing_event is not None:
+        is_post_fault_recovery = (
+            kind == "cooling_stopped" and payload.get("recovery_after_fault") is True
+        )
+        if existing_event is not None and not is_post_fault_recovery:
             return existing_event
         event = RoastEvent(
             kind=kind,

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -519,6 +519,50 @@ def test_snapshot_export_csv_event_rows_use_transition_control_state(
     assert cooling_stopped_row["cooling_on"] == "False"
 
 
+def test_snapshot_export_csv_keeps_fault_phase_for_recovery_cooling_stop(
+    tmp_path: Path,
+) -> None:
+    """Keep post-emergency recovery rows classified as faulted."""
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    clock.monotonic_value = 105.0
+    store.emergency_stop(
+        session,
+        reason="unit-test",
+        safety_payload={
+            "driver": "mock",
+            "driver_safety_method": "emergency_stop",
+            "heat_level_percent": 0,
+            "fan_level_percent": 100,
+            "cooling_on": True,
+        },
+    )
+    clock.monotonic_value = 110.0
+    reservation = store.reserve_driver_stop_cooling_recovery(session)
+    store.complete_reserved_driver_stop_cooling_recovery_snapshot(
+        session,
+        reservation=reservation,
+        heat_level_percent=0,
+        fan_level_percent=100,
+        cooling_on=False,
+    )
+
+    export = export_roast_snapshot(session)
+
+    with export.csv_path.open(encoding="utf-8", newline="") as csv_file:
+        rows = list(csv.DictReader(csv_file))
+    fault_row = next(row for row in rows if row["event"] == "fault")
+    recovery_row = next(row for row in rows if row["event"] == "cooling_stopped")
+    assert fault_row["phase"] == "fault"
+    assert recovery_row["phase"] == "fault"
+    assert recovery_row["cooling_on"] == "False"
+
+
 def test_snapshot_export_csv_uses_driver_transition_payload_state(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1005,6 +1005,64 @@ def test_stop_cooling_uses_driver_cooling_state_before_completing(tmp_path: Path
     ]
 
 
+def test_stop_cooling_recovers_after_emergency_stop_leaves_cooling_on(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver()
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    emergency = _call_tool(server, "emergency_stop", ctx, reason="unit-test")
+    assert emergency.phase == "fault"
+    emergency_state = _call_tool(
+        server,
+        "get_roast_state",
+        ctx,
+        session_id=start_result.session.session_id,
+    )
+    assert emergency_state.active is False
+    assert emergency_state.cooling_on is True
+
+    recovered = _call_tool(server, "stop_cooling", ctx)
+
+    assert recovered.session_id == start_result.session.session_id
+    assert recovered.event.kind == "cooling_stopped"
+    assert recovered.event.payload["recovery_after_fault"] is True
+    assert recovered.phase == "fault"
+    state = _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+    assert state.phase == "fault"
+    assert state.cooling_on is False
+    assert [event.kind for event in state.events] == ["fault", "cooling_stopped"]
+    assert driver.actions == [
+        "connect",
+        "emergency_stop:unit-test",
+        "stop_cooling",
+    ]
+
+
+def test_stop_cooling_still_rejects_completed_inactive_session(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver()
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "mark_beans_added", ctx)
+    _call_tool(server, "drop_beans", ctx)
+    _call_tool(server, "stop_cooling", ctx)
+
+    with pytest.raises(ValueError, match="No active roast session exists"):
+        _call_tool(server, "stop_cooling", ctx)
+
+
 class RecordingRoasterDriver:
     """Driver double that records MCP boundary calls."""
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -891,7 +891,7 @@ def test_stale_heat_command_fails_closed_after_emergency_stop(tmp_path: Path) ->
     ]
 
 
-def test_stale_command_does_not_emergency_stop_newer_active_session(tmp_path: Path) -> None:
+def test_pending_post_fault_cooling_blocks_newer_active_session(tmp_path: Path) -> None:
     config_path = tmp_path / "coffee-roaster-mcp.yaml"
     config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
     command_started = Event()
@@ -913,26 +913,27 @@ def test_stale_command_does_not_emergency_stop_newer_active_session(tmp_path: Pa
     assert command_started.wait(timeout=1.0)
 
     _call_tool(server, "emergency_stop", ctx, reason="unit-test")
-    second_start = _call_tool(server, "start_roast_session", ctx)
+    with pytest.raises(SessionLifecycleError, match="post-fault cooling recovery"):
+        _call_tool(server, "start_roast_session", ctx)
     release_command.set()
     heat_thread.join(timeout=1.0)
 
     assert not heat_thread.is_alive()
     assert isinstance(errors[0], SessionLifecycleError)
-    assert second_start.session.session_id != first_start.session.session_id
-    second_state = _call_tool(
+    state = _call_tool(
         server,
         "get_roast_state",
         ctx,
-        session_id=second_start.session.session_id,
+        session_id=first_start.session.session_id,
     )
-    assert second_state.active is True
-    assert second_state.phase == "pre_roast"
+    assert state.active is False
+    assert state.phase == "fault"
+    assert state.cooling_on is True
     assert driver.actions == [
         "connect",
         "set_heat:65",
         "emergency_stop:unit-test",
-        "connect",
+        "emergency_stop:stale driver command after session state changed",
     ]
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1071,6 +1071,76 @@ def test_stop_cooling_recovery_keeps_fault_when_driver_reports_cooling_on(
         "connect",
         "emergency_stop:unit-test",
         "stop_cooling",
+        "emergency_stop:stale driver command after session state changed",
+    ]
+
+
+def test_stop_cooling_recovery_rejects_driver_heat_after_fault(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(stop_cooling_heat_level_percent=20)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "emergency_stop", ctx, reason="unit-test")
+
+    with pytest.raises(SessionLifecycleError, match="Heat must be off"):
+        _call_tool(server, "stop_cooling", ctx)
+
+    state = _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+    assert state.phase == "fault"
+    assert state.active is False
+    assert state.heat_level_percent == 0
+    assert state.cooling_on is True
+    assert [event.kind for event in state.events] == ["fault"]
+    assert driver.actions == [
+        "connect",
+        "emergency_stop:unit-test",
+        "stop_cooling",
+        "emergency_stop:stale driver command after session state changed",
+    ]
+
+
+def test_stale_stop_cooling_recovery_fails_closed(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    command_started = Event()
+    release_command = Event()
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(block_stop_cooling=(command_started, release_command))
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+    errors: list[BaseException] = []
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "emergency_stop", ctx, reason="unit-test")
+    stop_thread = Thread(
+        target=_record_tool_error,
+        args=(errors, server, "stop_cooling", ctx),
+    )
+    stop_thread.start()
+    assert command_started.wait(timeout=1.0)
+
+    latest_session = server_context.session_store.get_latest_session()
+    assert latest_session is not None
+    server_context.session_store.cancel_pending_driver_command(latest_session)
+    release_command.set()
+    stop_thread.join(timeout=1.0)
+
+    assert not stop_thread.is_alive()
+    assert isinstance(errors[0], SessionLifecycleError)
+    state = _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+    assert state.phase == "fault"
+    assert state.cooling_on is True
+    assert driver.actions == [
+        "connect",
+        "emergency_stop:unit-test",
+        "stop_cooling",
+        "emergency_stop:stale driver command after session state changed",
     ]
 
 
@@ -1106,7 +1176,9 @@ class RecordingRoasterDriver:
         block_connect: tuple[Event, Event] | None = None,
         block_heat: tuple[Event, Event] | None = None,
         block_drop: tuple[Event, Event] | None = None,
+        block_stop_cooling: tuple[Event, Event] | None = None,
         stop_cooling_stays_on: bool = False,
+        stop_cooling_heat_level_percent: int = 0,
         bean_temp_c: float | None = None,
         env_temp_c: float | None = None,
         raw_vendor_data: dict[str, str | int | float | bool | None] | None = None,
@@ -1119,7 +1191,9 @@ class RecordingRoasterDriver:
         self.block_connect = block_connect
         self.block_heat = block_heat
         self.block_drop = block_drop
+        self.block_stop_cooling = block_stop_cooling
         self.stop_cooling_stays_on = stop_cooling_stays_on
+        self.stop_cooling_heat_level_percent = stop_cooling_heat_level_percent
         self.connected = False
         self.heat_level_percent = 0
         self.fan_level_percent = 0
@@ -1194,7 +1268,12 @@ class RecordingRoasterDriver:
     def stop_cooling(self) -> RoasterState:
         """Record cooling-stop commands."""
         self.actions.append("stop_cooling")
+        if self.block_stop_cooling is not None:
+            started, release = self.block_stop_cooling
+            started.set()
+            assert release.wait(timeout=1.0)
         self.cooling_on = self.stop_cooling_stays_on
+        self.heat_level_percent = self.stop_cooling_heat_level_percent
         return self._state()
 
     def emergency_stop(self, *, reason: str) -> EmergencyStopResult:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1045,6 +1045,35 @@ def test_stop_cooling_recovers_after_emergency_stop_leaves_cooling_on(
     ]
 
 
+def test_stop_cooling_recovery_keeps_fault_when_driver_reports_cooling_on(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    driver = RecordingRoasterDriver(stop_cooling_stays_on=True)
+    object.__setattr__(server_context, "roaster_driver", driver)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "emergency_stop", ctx, reason="unit-test")
+
+    with pytest.raises(SessionLifecycleError, match="still reports cooling active"):
+        _call_tool(server, "stop_cooling", ctx)
+
+    state = _call_tool(server, "get_roast_state", ctx, session_id=start_result.session.session_id)
+    assert state.phase == "fault"
+    assert state.active is False
+    assert state.cooling_on is True
+    assert [event.kind for event in state.events] == ["fault"]
+    assert driver.actions == [
+        "connect",
+        "emergency_stop:unit-test",
+        "stop_cooling",
+    ]
+
+
 def test_stop_cooling_still_rejects_completed_inactive_session(tmp_path: Path) -> None:
     config_path = tmp_path / "coffee-roaster-mcp.yaml"
     config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -516,6 +516,25 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         assert faulted_payload["driver"] == "mock"
         assert faulted_payload["driver_safety_method_called"] is True
 
+        recovery_stop_result = cast(
+            Any,
+            await _call_with_timeout(session.call_tool("stop_cooling", {})),
+        )
+        assert recovery_stop_result.structuredContent["session_id"] == second_session_id
+        assert recovery_stop_result.structuredContent["event"]["kind"] == "cooling_stopped"
+        assert recovery_stop_result.structuredContent["phase"] == "fault"
+        assert (
+            recovery_stop_result.structuredContent["event"]["payload"]["recovery_after_fault"]
+            is True
+        )
+        recovered_state_result = cast(
+            Any,
+            await _call_with_timeout(
+                session.call_tool("get_roast_state", {"session_id": second_session_id})
+            ),
+        )
+        assert recovered_state_result.structuredContent["cooling_on"] is False
+
         third_start_result = cast(
             Any,
             await _call_with_timeout(session.call_tool("start_roast_session", {})),

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -603,6 +603,39 @@ def test_start_session_allows_new_session_after_previous_stop() -> None:
     assert store.get_latest_session() is second_session
 
 
+def test_start_session_rejects_pending_post_fault_cooling_recovery() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+    store.emergency_stop(session, reason="unit-test")
+
+    with pytest.raises(SessionLifecycleError, match="post-fault cooling recovery"):
+        store.start_session()
+
+    assert store.get_latest_session() is session
+    assert session.phase == "fault"
+    assert session.cooling_on is True
+
+
+def test_reserve_session_start_rejects_pending_post_fault_cooling_recovery() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+    store.emergency_stop(session, reason="unit-test")
+
+    with pytest.raises(SessionLifecycleError, match="post-fault cooling recovery"):
+        store.reserve_session_start()
+
+    assert store.get_latest_session() is session
+    assert store.get_active_session() is None
+
+
 def test_get_session_snapshot_supports_completed_session_after_rollover() -> None:
     clock = ClockHarness()
     issued_ids = iter(["session-001", "session-002"])

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1033,6 +1033,62 @@ def test_emergency_stop_can_fault_latest_session_stopped_after_driver_call() -> 
     assert snapshot.event_timeline[-1].kind == "fault"
 
 
+def test_stop_cooling_recovery_records_new_event_after_completed_session_fault() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    store.record_event(session, "beans_dropped")
+    store.record_event(session, "cooling_started")
+    store.stop_cooling(session)
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 2, tzinfo=UTC)
+    clock.monotonic_value = 115.0
+    store.emergency_stop(
+        session,
+        reason="post-complete-fault",
+        safety_payload={
+            "driver": "test-driver",
+            "driver_safety_method": "emergency_stop",
+            "heat_level_percent": 0,
+            "fan_level_percent": 100,
+            "cooling_on": True,
+        },
+        allow_stopped_latest=True,
+    )
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 3, tzinfo=UTC)
+    clock.monotonic_value = 125.0
+    reservation = store.reserve_driver_stop_cooling_recovery(session)
+    event, snapshot = store.complete_reserved_driver_stop_cooling_recovery_snapshot(
+        session,
+        reservation=reservation,
+        heat_level_percent=0,
+        fan_level_percent=100,
+        cooling_on=False,
+    )
+
+    cooling_events = [
+        timeline_event
+        for timeline_event in snapshot.event_timeline
+        if timeline_event.kind == "cooling_stopped"
+    ]
+    assert event.kind == cooling_events[-1].kind
+    assert event.payload == cooling_events[-1].payload
+    assert len(cooling_events) == 2
+    assert cooling_events[0].payload == {}
+    assert cooling_events[1].payload["recovery_after_fault"] is True
+    assert cooling_events[1].recorded_at_utc == datetime(2026, 5, 4, 12, 3, tzinfo=UTC)
+    assert snapshot.phase == "fault"
+    assert snapshot.cooling_on is False
+
+
 def test_emergency_stop_faults_active_complete_session() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(


### PR DESCRIPTION
## Summary

- Records the E7-S4 start from updated `main` and the required Warp Hottop validation safety boundary.
- Adds a session summary with issue #59 configuration guidance, `uvx` preflight, serial-port discovery results, and required resume checklist.
- Marks E7-S4 blocked rather than complete because no actual Hottop USB serial adapter was visible, so no hardware-affecting Warp MCP calls were run.

## Validation

- `./.venv/bin/python -m pytest` - 356 passed
- `./.venv/bin/python -m ruff check .` - passed
- `./.venv/bin/python -m ruff format --check .` - 31 files already formatted
- `./.venv/bin/python -m pyright` - 0 errors, 0 warnings, 0 informations
- `./.venv/bin/coffee-roaster-mcp --help` - passed
- `./.venv/bin/coffee-roaster-mcp --version` - `coffee-roaster-mcp 0.1.0`

## Hardware Status

Blocked before live Warp hardware validation. `ls /dev/cu.*` showed only `/dev/cu.Bluetooth-Incoming-Port` and `/dev/cu.debug-console`; no `/dev/cu.usbserial-*` Hottop adapter was available. No fake hardware config was created, no Warp hardware server was launched, no hardware-affecting MCP calls were run, and no hardware-ready release label is supported by this partial evidence.

Refs #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed Warp manual Hottop validation guide, preflight evidence, resume checklist, and updated epic/registry status (blocked/in progress).
* **New Features**
  * Added a recovery flow allowing stop-cooling for the latest stopped, faulted session while preserving the fault phase.
* **Bug Fixes**
  * Corrected post-emergency-stop behavior where stop-cooling failed or incorrectly cleared the fault phase.
* **Tests**
  * Added tests covering recovery stop-cooling, failure/concurrency scenarios, session-start blocking, and export CSV phase preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->