### PR TITLE
Prepare v0.1.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 RoastPilot is a spec-driven MCP server for autonomous coffee roasting.
 
-The package name is `coffee-roaster-mcp`. Version `0.1.0` is published on
-production PyPI and listed in the MCP Registry as
+The package name is `coffee-roaster-mcp`. It is published on production PyPI
+and listed in the MCP Registry as
 `io.github.syamaner/coffee-roaster-mcp`.
 
 RoastPilot will provide one local MCP runtime for roaster control, telemetry, first-crack detection integration, roast metrics, and log export.

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,7 +6,7 @@ This runbook documents the operator prerequisites and CI release path for
 The release workflow is `.github/workflows/release.yml`. It supports two paths:
 
 - Manual dry run through `workflow_dispatch` with `dry_run: true`.
-- Live release through a pushed version tag such as `v0.1.0`.
+- Live release through a pushed version tag such as `v0.1.1`.
 
 ## Operator Prerequisites
 
@@ -30,7 +30,7 @@ Before enabling a live release, the release owner must confirm:
   the release owner before deployment jobs can run.
 - Protected tag rules block unapproved creation or update of `v*` tags.
 - The release tag matches the package version exactly, for example package
-  version `0.1.0` must use tag `v0.1.0`.
+  version `0.1.1` must use tag `v0.1.1`.
 - No model weights, audio files, roast logs, serial captures, `.env` files, or
   local IDE folders are included in the release artifact.
 
@@ -78,8 +78,8 @@ After all prerequisites are confirmed:
 2. Push the matching version tag:
 
    ```bash
-   git tag v0.1.0
-   git push origin v0.1.0
+   git tag v0.1.1
+   git push origin v0.1.1
    ```
 
 3. Approve the `release` environment deployment in GitHub Actions.
@@ -111,7 +111,7 @@ official registry docs and schema, then repeat the non-destructive checks below:
    `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`.
 2. Confirm `server.json.name` is `io.github.syamaner/coffee-roaster-mcp`.
 3. Confirm the PyPI package entry uses `registryType: pypi`, identifier
-   `coffee-roaster-mcp`, package version `0.1.0`, runtime hint `uvx`, and
+   `coffee-roaster-mcp`, package version `0.1.1`, runtime hint `uvx`, and
    stdio transport.
 4. Confirm README contains exactly one PyPI ownership verification marker:
    `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`.
@@ -155,6 +155,38 @@ listing data can change or reset before general availability. A failed publish
 after PyPI succeeds leaves PyPI live without Registry discoverability and should
 be retried only after checking Registry status and confirming no partial
 version entry was created.
+
+## v0.1.1 Release Prep
+
+The `v0.1.1` release is the fix-forward package release for the E7-S4 Warp
+manual Hottop validation recovery fixes. It should be tagged only after the
+version PR is merged to `main`.
+
+Pre-tag checklist:
+
+1. Confirm `server.json.version`, `server.json.packages[0].version`, and
+   `coffee_roaster_mcp.__version__` are all `0.1.1`.
+2. Confirm the local gates pass:
+   `pytest`, `ruff check .`, `ruff format --check .`, `pyright`,
+   `coffee-roaster-mcp --help`, and `coffee-roaster-mcp --version`.
+3. Build the wheel and source distribution with `python -m build`.
+4. Smoke install the built wheel from `dist/` before tagging.
+5. Merge the version PR, then tag from updated `main`:
+
+   ```bash
+   git checkout main
+   git pull --ff-only origin main
+   git tag v0.1.1
+   git push origin v0.1.1
+   ```
+
+6. Approve the GitHub `release` environment deployment.
+7. Verify production PyPI and the MCP Registry show package version `0.1.1`.
+8. Run the published-package smoke only after PyPI exposes `0.1.1`:
+
+   ```bash
+   uvx --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp --version
+   ```
 
 ## v0.1.0 Live Publish Outcome
 

--- a/docs/session-summaries/2026-05-25-v0.1.1-release-prep.md
+++ b/docs/session-summaries/2026-05-25-v0.1.1-release-prep.md
@@ -1,0 +1,98 @@
+# v0.1.1 Release Prep
+
+This summary captures the small release/version PR that prepares
+`coffee-roaster-mcp` `0.1.1` after the E7-S4 Warp Hottop recovery fixes merged.
+
+## Scope
+
+Branch: `release/0.1.1`
+
+Goal: prepare a version-only release PR for `0.1.1`.
+
+In scope:
+
+- bump `coffee_roaster_mcp.__version__` from `0.1.0` to `0.1.1`
+- bump `server.json.version` from `0.1.0` to `0.1.1`
+- bump `server.json.packages[0].version` from `0.1.0` to `0.1.1`
+- update release and state documentation for the `v0.1.1` release path
+- run local gates, package build, and built-wheel smoke before opening the PR
+
+Out of scope:
+
+- do not tag `v0.1.1` before the version PR merges to `main`
+- do not publish to PyPI or the MCP Registry from the release-prep branch
+- do not use `uvx --from coffee-roaster-mcp==0.1.1` until `0.1.1` is actually
+  published on PyPI
+- do not claim hardware-ready release status from the E7-S4 partial Warp
+  validation evidence
+
+## Preflight
+
+- Confirmed PR #143 was merged.
+- Checked out `main`.
+- Ran `git pull --ff-only origin main`, fast-forwarding from `c480afc` to
+  merge commit `566e5e042ef039b7edd1e11138917b2c98298113`.
+- Created branch `release/0.1.1`.
+
+## Changes
+
+- Updated `src/coffee_roaster_mcp/__init__.py` to `__version__ = "0.1.1"`.
+- Updated `server.json` top-level and PyPI package-entry versions to `0.1.1`.
+- Updated version-alignment tests to expect the new package version and use
+  `__version__` for the package entry assertion.
+- Updated README wording so the package publication statement does not become
+  stale in the published long description.
+- Updated `docs/release.md` with `v0.1.1` release-prep instructions while
+  preserving the historical `v0.1.0` live-publish outcome.
+- Updated state docs so the active target is the `v0.1.1` version PR.
+
+## Validation
+
+Local validation:
+
+- Focused version tests:
+  `./.venv/bin/python -m pytest tests/test_package.py::test_version_is_defined tests/test_server_json.py`:
+  5 passed.
+- `./.venv/bin/python -m pytest`: 365 passed.
+- `./.venv/bin/python -m ruff check .`: passed.
+- `./.venv/bin/python -m ruff format --check .`: 31 files already formatted.
+- `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations.
+- `./.venv/bin/coffee-roaster-mcp --help`: passed.
+- `./.venv/bin/coffee-roaster-mcp --version`:
+  `coffee-roaster-mcp 0.1.1`.
+- `./.venv/bin/python -m build`: built
+  `coffee_roaster_mcp-0.1.1.tar.gz` and
+  `coffee_roaster_mcp-0.1.1-py3-none-any.whl`.
+- Built-wheel smoke installed
+  `dist/coffee_roaster_mcp-0.1.1-py3-none-any.whl` into
+  `/tmp/coffee-roaster-mcp-0.1.1-wheel-smoke`.
+- Built-wheel CLI smoke returned `coffee-roaster-mcp 0.1.1`.
+- Built-wheel mock-safe default config smoke returned `mock disabled int8`.
+
+The first built-wheel install attempt failed because sandboxed pip could not
+resolve dependency downloads. The same install command passed after approving
+network access for the smoke venv.
+
+## Release Handoff
+
+After this PR merges:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git tag v0.1.1
+git push origin v0.1.1
+```
+
+Then approve the GitHub `release` environment deployment. The workflow should
+run checks, build the package, publish PyPI, then publish MCP Registry metadata.
+
+Post-publish verification:
+
+```bash
+uvx --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp --version
+```
+
+For immediate Warp retesting before public release, point Warp at the local
+branch `.venv/bin/coffee-roaster-mcp serve` instead of using the unpublished
+`uvx --from coffee-roaster-mcp==0.1.1` path.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,8 +16,9 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E7-S4`
-- Current target: Warp manual Hottop MCP control validation
+- Active story: `v0.1.1 release prep`
+- Current target: package and MCP Registry metadata version bump for the
+  post-E7-S4 recovery fixes
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -46,6 +47,10 @@ The first implementation milestone is a mock vertical slice that requires no roa
   public RoastPilot MCP tools, confirms runtime config `mock`, `disabled`, and
   auto-T0 disabled, completes a full mock roast through public MCP tools, and
   verifies exported JSONL, CSV, and summary outputs.
+- `v0.1.1` is the fix-forward release prep after E7-S4 merged. The version PR
+  aligns `coffee_roaster_mcp.__version__`, `server.json.version`, and
+  `server.json.packages[0].version` at `0.1.1`, then the release should be
+  tagged from updated `main` as `v0.1.1` only after the PR merges.
 - `E7-S5a` is inserted before the final release checklist to close the
   first-crack MCP validation gap without requiring Hottop hardware or live
   microphone input. It uses the mock roaster, released Hugging Face first-crack

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,6 +22,11 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
+The active release-prep branch is `release/0.1.1`, which bumps the package and
+MCP Registry metadata version to `0.1.1` for the post-E7-S4 recovery fixes.
+After the version PR merges, tag updated `main` as `v0.1.1` and let the
+release workflow publish PyPI before MCP Registry metadata.
+
 Epic 3 is complete. The Hottop driver now has validated lifecycle, command-loop,
 packet, temperature-unit, heat, fan, drop, cooling, cleanup, and emergency-stop
 behavior at the driver boundary. The full connected-Hottop E3-S9 validation run

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.syamaner/coffee-roaster-mcp",
   "title": "RoastPilot",
   "description": "RoastPilot controls coffee roasting sessions through local stdio MCP tools and exports logs.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "websiteUrl": "https://github.com/syamaner/coffee-roaster-mcp#readme",
   "repository": {
     "url": "https://github.com/syamaner/coffee-roaster-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "coffee-roaster-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/coffee_roaster_mcp/__init__.py
+++ b/src/coffee_roaster_mcp/__init__.py
@@ -1,3 +1,3 @@
 """RoastPilot MCP server package."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -89,7 +89,7 @@ _EXPECTED_T0_STATUS_KEYS = {
 
 
 def test_version_is_defined() -> None:
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.1.1"
 
 
 def test_cli_parser_program_name() -> None:

--- a/tests/test_server_json.py
+++ b/tests/test_server_json.py
@@ -96,7 +96,7 @@ def test_server_json_declares_roastpilot_pypi_stdio_package() -> None:
         {
             "registryType": "pypi",
             "identifier": "coffee-roaster-mcp",
-            "version": "0.1.0",
+            "version": __version__,
             "runtimeHint": "uvx",
             "transport": {"type": "stdio"},
         }


### PR DESCRIPTION
## Summary

- Bumps `coffee_roaster_mcp.__version__` to `0.1.1`.
- Bumps `server.json.version` and `server.json.packages[0].version` to `0.1.1`.
- Updates release/state/session docs for the `v0.1.1` fix-forward release path after E7-S4.

## Validation

- `./.venv/bin/python -m pytest tests/test_package.py::test_version_is_defined tests/test_server_json.py` - 5 passed
- `./.venv/bin/python -m pytest` - 365 passed
- `./.venv/bin/python -m ruff check .` - passed
- `./.venv/bin/python -m ruff format --check .` - 31 files already formatted
- `./.venv/bin/python -m pyright` - 0 errors, 0 warnings, 0 informations
- `./.venv/bin/coffee-roaster-mcp --help` - passed
- `./.venv/bin/coffee-roaster-mcp --version` - `coffee-roaster-mcp 0.1.1`
- `./.venv/bin/python -m build` - built `coffee_roaster_mcp-0.1.1.tar.gz` and `coffee_roaster_mcp-0.1.1-py3-none-any.whl`
- Built-wheel smoke installed `dist/coffee_roaster_mcp-0.1.1-py3-none-any.whl` into `/tmp/coffee-roaster-mcp-0.1.1-wheel-smoke`
- Built-wheel `coffee-roaster-mcp --version` - `coffee-roaster-mcp 0.1.1`
- Built-wheel default config smoke - `mock disabled int8`

## Release Handoff

After this PR merges, tag from updated `main`:

```bash
git checkout main
git pull --ff-only origin main
git tag v0.1.1
git push origin v0.1.1
```

Then approve the GitHub `release` environment deployment. Use `uvx --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp --version` only after PyPI actually exposes `0.1.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version from 0.1.0 to 0.1.1 across all components including manifests and module definitions.

* **Tests**
  * Updated version alignment tests to verify consistency across package metadata and configuration.

* **Documentation**
  * Updated README with current registry listing and expanded release runbook with v0.1.1 release procedures and validation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->