### PR TITLE
Record v0.1.1 release outcome

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -188,6 +188,45 @@ Pre-tag checklist:
    uvx --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp --version
    ```
 
+## v0.1.1 Live Publish Outcome
+
+The fix-forward release completed on 2026-05-25 through GitHub Actions run
+`26402310473`:
+
+- Tag: `v0.1.1`
+- Commit: `810318519899e662204b78671657bd9bc7222a73`
+- Workflow: `https://github.com/syamaner/coffee-roaster-mcp/actions/runs/26402310473`
+- PyPI release: `https://pypi.org/project/coffee-roaster-mcp/0.1.1/`
+- MCP Registry search:
+  `https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.syamaner/coffee-roaster-mcp`
+
+Release job outcomes:
+
+- `Validate Release Metadata`: success
+- `Checks`: success
+- `Build Package`: success
+- `Publish PyPI`: success
+- `Publish MCP Registry`: success after PyPI publish
+- `Release Dry Run`: skipped, as expected for a tag push
+
+Confirmed outcomes:
+
+- Production PyPI exposes `coffee-roaster-mcp` version `0.1.1`.
+- PyPI artifacts:
+  - `coffee_roaster_mcp-0.1.1-py3-none-any.whl`, SHA-256
+    `a6c68ec7dbea3c428922fce525fbf0d6dc451d549dff36a56bcb731aaf5ad395`
+  - `coffee_roaster_mcp-0.1.1.tar.gz`, SHA-256
+    `744bfaa34584173158c98bfebf80b574e25b7f793ac390d61ee1688862ca73df`
+- Registry search returns `io.github.syamaner/coffee-roaster-mcp` with PyPI
+  package `coffee-roaster-mcp`, version `0.1.1`, runtime hint `uvx`, stdio
+  transport, and `isLatest: true`.
+- Published-package smoke passed after refreshing the local `uvx` cache:
+  `uvx --refresh --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp --version`
+  returned `coffee-roaster-mcp 0.1.1`.
+- The `v0.1.1` tag creation reported the same protected-tag creation rule
+  bypass as `v0.1.0`; keep tag protection and release environment ownership
+  under review before the next release.
+
 ## v0.1.0 Live Publish Outcome
 
 The first live release completed on 2026-05-24 through GitHub Actions run

--- a/docs/session-summaries/2026-05-25-v0.1.1-release-prep.md
+++ b/docs/session-summaries/2026-05-25-v0.1.1-release-prep.md
@@ -75,7 +75,8 @@ network access for the smoke venv.
 
 ## Release Handoff
 
-After this PR merges:
+The version PR merged as PR #144. The release tag was created from updated
+`main`:
 
 ```bash
 git checkout main
@@ -84,15 +85,50 @@ git tag v0.1.1
 git push origin v0.1.1
 ```
 
-Then approve the GitHub `release` environment deployment. The workflow should
-run checks, build the package, publish PyPI, then publish MCP Registry metadata.
+The `v0.1.1` tag points at commit
+`810318519899e662204b78671657bd9bc7222a73`. GitHub reported the same
+protected-tag creation rule bypass seen on `v0.1.0`.
+
+GitHub Actions release run:
+
+- `https://github.com/syamaner/coffee-roaster-mcp/actions/runs/26402310473`
+
+Release job outcomes:
+
+- `Checks`: success.
+- `Validate Release Metadata`: success.
+- `Build Package`: success.
+- `Publish PyPI`: success.
+- `Publish MCP Registry`: success after PyPI publish.
+- `Release Dry Run`: skipped, as expected for a tag push.
 
 Post-publish verification:
 
+- PyPI release: `https://pypi.org/project/coffee-roaster-mcp/0.1.1/`
+- PyPI exposes version `0.1.1`.
+- PyPI wheel:
+  `coffee_roaster_mcp-0.1.1-py3-none-any.whl`, SHA-256
+  `a6c68ec7dbea3c428922fce525fbf0d6dc451d549dff36a56bcb731aaf5ad395`.
+- PyPI source distribution:
+  `coffee_roaster_mcp-0.1.1.tar.gz`, SHA-256
+  `744bfaa34584173158c98bfebf80b574e25b7f793ac390d61ee1688862ca73df`.
+- MCP Registry search returns a `0.1.1` listing with PyPI package
+  `coffee-roaster-mcp`, runtime hint `uvx`, stdio transport, and
+  `isLatest: true`.
+- Published-package smoke passed after refreshing the local `uvx` cache:
+
 ```bash
-uvx --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp --version
+uvx --refresh --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp --version
 ```
 
-For immediate Warp retesting before public release, point Warp at the local
-branch `.venv/bin/coffee-roaster-mcp serve` instead of using the unpublished
-`uvx --from coffee-roaster-mcp==0.1.1` path.
+Output:
+
+```text
+coffee-roaster-mcp 0.1.1
+```
+
+Warp retesting can now use the published-package path:
+
+```bash
+uvx --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp serve
+```

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,9 +16,9 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `v0.1.1 release prep`
-- Current target: package and MCP Registry metadata version bump for the
-  post-E7-S4 recovery fixes
+- Active story: `E7-S4`
+- Current target: retest Warp manual Hottop MCP control validation on the
+  published `coffee-roaster-mcp==0.1.1` package path
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -47,10 +47,13 @@ The first implementation milestone is a mock vertical slice that requires no roa
   public RoastPilot MCP tools, confirms runtime config `mock`, `disabled`, and
   auto-T0 disabled, completes a full mock roast through public MCP tools, and
   verifies exported JSONL, CSV, and summary outputs.
-- `v0.1.1` is the fix-forward release prep after E7-S4 merged. The version PR
-  aligns `coffee_roaster_mcp.__version__`, `server.json.version`, and
-  `server.json.packages[0].version` at `0.1.1`, then the release should be
-  tagged from updated `main` as `v0.1.1` only after the PR merges.
+- `v0.1.1` is the fix-forward release after E7-S4 merged. PR #144 aligned
+  `coffee_roaster_mcp.__version__`, `server.json.version`, and
+  `server.json.packages[0].version` at `0.1.1`; tag `v0.1.1` points at
+  `810318519899e662204b78671657bd9bc7222a73`; release run `26402310473`
+  published PyPI and then MCP Registry metadata. Published-package smoke with
+  `uvx --refresh --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp --version`
+  returned `coffee-roaster-mcp 0.1.1`.
 - `E7-S5a` is inserted before the final release checklist to close the
   first-crack MCP validation gap without requiring Hottop hardware or live
   microphone input. It uses the mock roaster, released Hugging Face first-crack

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -22,10 +22,12 @@
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
-The active release-prep branch is `release/0.1.1`, which bumps the package and
-MCP Registry metadata version to `0.1.1` for the post-E7-S4 recovery fixes.
-After the version PR merges, tag updated `main` as `v0.1.1` and let the
-release workflow publish PyPI before MCP Registry metadata.
+The `v0.1.1` fix-forward release is published for the post-E7-S4 recovery
+fixes. PR #144 merged the version bump, tag `v0.1.1` points at
+`810318519899e662204b78671657bd9bc7222a73`, GitHub Actions release run
+`26402310473` published PyPI and then MCP Registry metadata, and the published
+`uvx --refresh --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp --version`
+smoke returned `coffee-roaster-mcp 0.1.1`.
 
 Epic 3 is complete. The Hottop driver now has validated lifecycle, command-loop,
 packet, temperature-unit, heat, fan, drop, cooling, cleanup, and emergency-stop


### PR DESCRIPTION
## Summary

- Records the completed `v0.1.1` PyPI and MCP Registry release outcome.
- Updates the E7/v0.1 state docs to route retesting to the published `coffee-roaster-mcp==0.1.1` package path.
- Adds PyPI artifact hashes, workflow run, registry status, and `uvx` smoke result to release/session docs.

## Validation

- `./.venv/bin/python -m pytest tests/test_readme.py tests/test_release_workflow.py tests/test_server_json.py` - 13 passed
- `git diff --check` - passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release runbook with v0.1.1 publication outcomes, including GitHub Actions run details, PyPI and MCP Registry publication records, and post-publish verification results.
  * Added release handoff documentation with verification commands and checksums.
  * Updated registry and epic state documentation to reflect v0.1.1 release completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->