### PR TITLE
Prepare v0.1.2 metadata release with related project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ RoastPilot will provide one local MCP runtime for roaster control, telemetry, fi
 
 The project is currently in bootstrap. See `docs/plans/coffee-roaster-mcp-v0.1-overall-plan.md` and `docs/state/registry.md` for the active plan and state.
 
+## Related Project Artifacts
+
+- Current architecture article: [The Architecture: The Agent-Spec Driven ML Development With Warp](https://dev.to/syamaner/part-1-the-architecture-the-agent-spec-driven-ml-development-with-warpoz-3al6)
+- Original prototype intro: [Training a Neural Network to Detect Coffee First Crack from Audio](https://dev.to/syamaner/part-1-training-a-neural-network-to-detect-coffee-first-crack-from-audio-an-agentic-development-1jei)
+- Original prototype MCP post: [Building MCP Servers to Control a Home Coffee Roaster](https://dev.to/syamaner/part-2-building-mcp-servers-to-control-a-home-coffee-roaster-an-agentic-development-journey-with-58ik)
+- First-crack model: [syamaner/coffee-first-crack-detection](https://huggingface.co/syamaner/coffee-first-crack-detection)
+- First-crack dataset: [syamaner/coffee-first-crack-audio](https://huggingface.co/datasets/syamaner/coffee-first-crack-audio)
+- First-crack demo: [Coffee First-Crack Detection Space](https://huggingface.co/spaces/syamaner/coffee-first-crack-detection)
+
+The current `coffee-roaster-mcp` package is a consolidated rebuild of the
+prototype with the lessons learned folded into one deterministic local MCP
+server, conservative hardware boundaries, and releaseable package metadata.
+
 ## What RoastPilot Is
 
 RoastPilot is the human-facing product name. `coffee-roaster-mcp` is the infrastructure and packaging name used for the repository, Python package, and future distribution.

--- a/docs/release.md
+++ b/docs/release.md
@@ -227,6 +227,40 @@ Confirmed outcomes:
   bypass as `v0.1.0`; keep tag protection and release environment ownership
   under review before the next release.
 
+## v0.1.2 Release Prep
+
+The `v0.1.2` release is a metadata-only package release to expose related
+project resources on PyPI and through the README reached from the MCP Registry
+listing.
+
+Planned change set:
+
+- Bump `coffee_roaster_mcp.__version__`, `server.json.version`, and
+  `server.json.packages[0].version` from `0.1.1` to `0.1.2`.
+- Add package `Project-URL` metadata for the architecture article, original
+  prototype posts, Hugging Face first-crack model, Hugging Face dataset, and
+  Gradio demo Space.
+- Add the same links to the README under Related Project Artifacts.
+- Clarify that the current MCP package is the consolidated deterministic
+  rebuild of the prototype.
+- Keep `server.json.websiteUrl` pointed at the README instead of adding
+  non-schema registry metadata fields.
+
+After the PR merges:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git tag v0.1.2
+git push origin v0.1.2
+```
+
+Then approve the `release` environment deployment and verify:
+
+```bash
+uvx --refresh --from coffee-roaster-mcp==0.1.2 coffee-roaster-mcp --version
+```
+
 ## v0.1.0 Live Publish Outcome
 
 The first live release completed on 2026-05-24 through GitHub Actions run

--- a/docs/session-summaries/2026-05-25-v0.1.2-related-project-links.md
+++ b/docs/session-summaries/2026-05-25-v0.1.2-related-project-links.md
@@ -1,0 +1,58 @@
+# v0.1.2 Related Project Links
+
+Date: 2026-05-25
+
+Branch: `docs/related-project-links`
+
+Goal: add related architecture, model, dataset, and demo links to
+package-facing metadata and prepare a small `0.1.2` release so PyPI can publish
+the updated metadata.
+
+## Scope
+
+- Add package `Project-URL` entries for:
+  - current architecture article
+  - original prototype intro
+  - original prototype MCP post
+  - Hugging Face first-crack model
+  - Hugging Face first-crack dataset
+  - Gradio first-crack demo Space
+- Add the same links to the README under Related Project Artifacts.
+- Clarify that the current `coffee-roaster-mcp` package is a consolidated
+  rebuild of the prototype with lessons learned folded into a deterministic
+  local MCP server.
+- Bump `coffee_roaster_mcp.__version__`, `server.json.version`, and
+  `server.json.packages[0].version` from `0.1.1` to `0.1.2`.
+- Keep `server.json` otherwise unchanged so MCP Registry metadata stays within
+  the validated schema; the registry listing continues to point at the README.
+
+## Validation
+
+- `./.venv/bin/python -m pytest tests/test_package_metadata.py tests/test_readme.py tests/test_server_json.py`: 8 passed
+- `./.venv/bin/python -m pytest tests/test_package_metadata.py tests/test_readme.py tests/test_server_json.py tests/test_package.py::test_version_is_defined`: 9 passed after adding prototype links
+- `./.venv/bin/python -m pytest`: 365 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: 31 files already formatted
+- `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.2`
+- `./.venv/bin/python -m build --outdir /tmp/coffee-roaster-mcp-0.1.2-related-links-dist`: built `coffee_roaster_mcp-0.1.2.tar.gz` and `coffee_roaster_mcp-0.1.2-py3-none-any.whl`
+- `./.venv/bin/python -m build --outdir /tmp/coffee-roaster-mcp-0.1.2-related-links-dist2`: built `coffee_roaster_mcp-0.1.2.tar.gz` and `coffee_roaster_mcp-0.1.2-py3-none-any.whl` after adding prototype links
+- Built-wheel smoke from `/tmp/coffee-roaster-mcp-0.1.2-related-links-dist`: passed with installed CLI `coffee-roaster-mcp 0.1.2` and mock-safe defaults `mock disabled int8`
+- Wheel metadata inspection confirmed the architecture, prototype intro,
+  prototype MCP post, Hugging Face model, Hugging Face dataset, and Gradio demo
+  `Project-URL` entries in `coffee_roaster_mcp-0.1.2-py3-none-any.whl`.
+
+## Publish Notes
+
+PyPI cannot overwrite metadata for an existing version, so the related links
+must publish through a new `0.1.2` release. After the PR merges, tag `v0.1.2`
+from updated `main`, push the tag, approve the GitHub `release` environment
+deployment, and verify:
+
+```bash
+uvx --refresh --from coffee-roaster-mcp==0.1.2 coffee-roaster-mcp --version
+```
+
+The MCP Registry listing should keep its direct metadata focused on the server
+and package while linking to the README through `websiteUrl`.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -19,6 +19,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - Active story: `E7-S4`
 - Current target: retest Warp manual Hottop MCP control validation on the
   published `coffee-roaster-mcp==0.1.1` package path
+- Next package publication target: `v0.1.2` metadata-only release for related
+  project links
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -54,6 +56,12 @@ The first implementation milestone is a mock vertical slice that requires no roa
   published PyPI and then MCP Registry metadata. Published-package smoke with
   `uvx --refresh --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp --version`
   returned `coffee-roaster-mcp 0.1.1`.
+- `v0.1.2` is reserved as a metadata-only release for related project links:
+  package project URLs and README links for the architecture article, original
+  prototype posts, Hugging Face first-crack model, Hugging Face dataset, and
+  Gradio demo Space. README wording frames this package as the consolidated
+  deterministic rebuild of the prototype. The MCP Registry JSON remains
+  schema-focused and continues to point `websiteUrl` at the README.
 - `E7-S5a` is inserted before the final release checklist to close the
   first-crack MCP validation gap without requiring Hottop hardware or live
   microphone input. It uses the mock roaster, released Hugging Face first-crack

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -29,6 +29,13 @@ fixes. PR #144 merged the version bump, tag `v0.1.1` points at
 `uvx --refresh --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp --version`
 smoke returned `coffee-roaster-mcp 0.1.1`.
 
+The next package publication target is `v0.1.2`, a metadata-only release that
+adds related project links to PyPI project URLs and the README while keeping
+MCP Registry metadata schema-safe through the existing README `websiteUrl`.
+The links include the current architecture article, the original prototype
+posts, the Hugging Face model/dataset/demo artifacts, and README wording that
+frames this package as the consolidated deterministic rebuild of the prototype.
+
 Epic 3 is complete. The Hottop driver now has validated lifecycle, command-loop,
 packet, temperature-unit, heat, fan, drop, cooling, cleanup, and emergency-stop
 behavior at the driver boundary. The full connected-Hottop E3-S9 validation run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,12 @@ Homepage = "https://github.com/syamaner/coffee-roaster-mcp"
 Documentation = "https://github.com/syamaner/coffee-roaster-mcp#readme"
 Repository = "https://github.com/syamaner/coffee-roaster-mcp"
 Issues = "https://github.com/syamaner/coffee-roaster-mcp/issues"
+"Architecture Article" = "https://dev.to/syamaner/part-1-the-architecture-the-agent-spec-driven-ml-development-with-warpoz-3al6"
+"Prototype Intro" = "https://dev.to/syamaner/part-1-training-a-neural-network-to-detect-coffee-first-crack-from-audio-an-agentic-development-1jei"
+"Prototype MCP Post" = "https://dev.to/syamaner/part-2-building-mcp-servers-to-control-a-home-coffee-roaster-an-agentic-development-journey-with-58ik"
+"First-Crack Model" = "https://huggingface.co/syamaner/coffee-first-crack-detection"
+"First-Crack Dataset" = "https://huggingface.co/datasets/syamaner/coffee-first-crack-audio"
+"First-Crack Demo" = "https://huggingface.co/spaces/syamaner/coffee-first-crack-detection"
 
 [project.scripts]
 coffee-roaster-mcp = "coffee_roaster_mcp.cli:main"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.syamaner/coffee-roaster-mcp",
   "title": "RoastPilot",
   "description": "RoastPilot controls coffee roasting sessions through local stdio MCP tools and exports logs.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "websiteUrl": "https://github.com/syamaner/coffee-roaster-mcp#readme",
   "repository": {
     "url": "https://github.com/syamaner/coffee-roaster-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "coffee-roaster-mcp",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/coffee_roaster_mcp/__init__.py
+++ b/src/coffee_roaster_mcp/__init__.py
@@ -1,3 +1,3 @@
 """RoastPilot MCP server package."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -89,7 +89,7 @@ _EXPECTED_T0_STATUS_KEYS = {
 
 
 def test_version_is_defined() -> None:
-    assert __version__ == "0.1.1"
+    assert __version__ == "0.1.2"
 
 
 def test_cli_parser_program_name() -> None:

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -49,6 +49,12 @@ def test_installed_distribution_metadata_is_complete() -> None:
         "Documentation, https://github.com/syamaner/coffee-roaster-mcp#readme",
         "Repository, https://github.com/syamaner/coffee-roaster-mcp",
         "Issues, https://github.com/syamaner/coffee-roaster-mcp/issues",
+        "Architecture Article, https://dev.to/syamaner/part-1-the-architecture-the-agent-spec-driven-ml-development-with-warpoz-3al6",
+        "Prototype Intro, https://dev.to/syamaner/part-1-training-a-neural-network-to-detect-coffee-first-crack-from-audio-an-agentic-development-1jei",
+        "Prototype MCP Post, https://dev.to/syamaner/part-2-building-mcp-servers-to-control-a-home-coffee-roaster-an-agentic-development-journey-with-58ik",
+        "First-Crack Model, https://huggingface.co/syamaner/coffee-first-crack-detection",
+        "First-Crack Dataset, https://huggingface.co/datasets/syamaner/coffee-first-crack-audio",
+        "First-Crack Demo, https://huggingface.co/spaces/syamaner/coffee-first-crack-detection",
     } <= project_urls
 
     assert resources.files("coffee_roaster_mcp").joinpath("py.typed").is_file()


### PR DESCRIPTION
## Summary

- bump package and MCP Registry metadata versions from `0.1.1` to `0.1.2`
- add related project links to package `Project-URL` metadata and the README
- include the current architecture article, original prototype intro, original prototype MCP post, Hugging Face model, Hugging Face dataset, and Gradio demo Space
- clarify that `coffee-roaster-mcp` is the consolidated deterministic rebuild of the prototype
- keep `server.json` schema-focused, using the existing README `websiteUrl` for MCP Registry discovery
- update release/state docs and add a session summary for the metadata release

## Validation

Full validation before adding prototype links:

- `./.venv/bin/python -m pytest tests/test_package_metadata.py tests/test_readme.py tests/test_server_json.py`: 8 passed
- `./.venv/bin/python -m pytest`: 365 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: 31 files already formatted
- `./.venv/bin/python -m pyright`: 0 errors, 0 warnings, 0 informations
- `./.venv/bin/coffee-roaster-mcp --help`: passed
- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.2`
- `./.venv/bin/python -m build --outdir /tmp/coffee-roaster-mcp-0.1.2-related-links-dist`: built `coffee_roaster_mcp-0.1.2.tar.gz` and `coffee_roaster_mcp-0.1.2-py3-none-any.whl`
- built-wheel smoke from `/tmp/coffee-roaster-mcp-0.1.2-related-links-dist`: passed with installed CLI `coffee-roaster-mcp 0.1.2` and mock-safe defaults `mock disabled int8`
- wheel metadata inspection confirmed the new `Project-URL` entries

Focused validation after adding prototype links:

- `./.venv/bin/python -m pytest tests/test_package_metadata.py tests/test_readme.py tests/test_server_json.py tests/test_package.py::test_version_is_defined`: 9 passed
- `./.venv/bin/python -m ruff check README.md pyproject.toml tests/test_package_metadata.py`: passed
- `./.venv/bin/python -m ruff format --check tests/test_package_metadata.py`: 1 file already formatted
- `./.venv/bin/python -m build --outdir /tmp/coffee-roaster-mcp-0.1.2-related-links-dist2`: built `coffee_roaster_mcp-0.1.2.tar.gz` and `coffee_roaster_mcp-0.1.2-py3-none-any.whl`
- wheel metadata inspection confirmed the architecture, prototype, Hugging Face, and Gradio `Project-URL` entries

## Publish After Merge

```bash
git checkout main
git pull --ff-only origin main
git tag v0.1.2
git push origin v0.1.2
```

Then approve the GitHub `release` environment deployment and verify:

```bash
uvx --refresh --from coffee-roaster-mcp==0.1.2 coffee-roaster-mcp --version
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Related Project Artifacts” section linking architecture article, prototype posts, Hugging Face model/dataset, and a demo.

* **Documentation**
  * Updated README and release docs to surface related resources and release instructions; documented v0.1.2 as a metadata-only update.

* **Chores**
  * Published v0.1.2: metadata-only version bump and registry/PyPI metadata updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->