### PR TITLE
Record v0.1.2 release outcome

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -261,6 +261,52 @@ Then approve the `release` environment deployment and verify:
 uvx --refresh --from coffee-roaster-mcp==0.1.2 coffee-roaster-mcp --version
 ```
 
+## v0.1.2 Live Publish Outcome
+
+The metadata-only release completed on 2026-05-25 through GitHub Actions run
+`26403620501`:
+
+- Tag: `v0.1.2`
+- Commit: `3c19d6a677cf40c769dc8394d2e2ac53308446b6`
+- Workflow: `https://github.com/syamaner/coffee-roaster-mcp/actions/runs/26403620501`
+- PyPI release: `https://pypi.org/project/coffee-roaster-mcp/0.1.2/`
+- MCP Registry search:
+  `https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.syamaner/coffee-roaster-mcp`
+
+Release job outcomes:
+
+- `Validate Release Metadata`: success
+- `Checks`: success
+- `Build Package`: success
+- `Publish PyPI`: success after `release` environment approval
+- `Publish MCP Registry`: success after PyPI publish
+- `Release Dry Run`: skipped, as expected for a tag push
+
+Confirmed outcomes:
+
+- Production PyPI exposes `coffee-roaster-mcp` version `0.1.2`.
+- PyPI project URLs include the architecture article, original prototype intro,
+  original prototype MCP post, Hugging Face first-crack model, Hugging Face
+  dataset, and Gradio demo Space.
+- PyPI artifacts:
+  - `coffee_roaster_mcp-0.1.2-py3-none-any.whl`, SHA-256
+    `c548967fc239cd93786cc23287c4c55cd67dac398a61b82021bc0022bd4926db`
+  - `coffee_roaster_mcp-0.1.2.tar.gz`, SHA-256
+    `25d554bef5f7477256fac63a1c277c224de116d7251f9cd34ff11fdb42a9ef77`
+- Registry search returns `io.github.syamaner/coffee-roaster-mcp` with PyPI
+  package `coffee-roaster-mcp`, version `0.1.2`, runtime hint `uvx`, stdio
+  transport, and `isLatest: true`.
+- Published-package smoke passed after refreshing the local `uvx` package
+  cache:
+  `uvx --refresh-package coffee-roaster-mcp --from coffee-roaster-mcp==0.1.2 coffee-roaster-mcp --version`
+  returned `coffee-roaster-mcp 0.1.2`.
+- The initial `uvx --refresh --from coffee-roaster-mcp==0.1.2 ...` smoke saw
+  package-index lag and reported no available `0.1.2` version; the
+  package-specific refresh succeeded immediately after.
+- The `v0.1.2` tag creation reported the same protected-tag creation rule
+  bypass as prior releases; keep tag protection and release environment
+  ownership under review.
+
 ## v0.1.0 Live Publish Outcome
 
 The first live release completed on 2026-05-24 through GitHub Actions run

--- a/docs/session-summaries/2026-05-25-v0.1.2-related-project-links.md
+++ b/docs/session-summaries/2026-05-25-v0.1.2-related-project-links.md
@@ -56,3 +56,47 @@ uvx --refresh --from coffee-roaster-mcp==0.1.2 coffee-roaster-mcp --version
 
 The MCP Registry listing should keep its direct metadata focused on the server
 and package while linking to the README through `websiteUrl`.
+
+## Publish Outcome
+
+PR #146 merged to `main` with squash commit
+`3c19d6a677cf40c769dc8394d2e2ac53308446b6`. Tag `v0.1.2` was pushed at that
+commit. GitHub again reported the protected-tag creation rule bypass:
+`Cannot create ref due to creations being restricted.`
+
+Release workflow run `26403620501` completed successfully:
+
+- `Validate Release Metadata`: success
+- `Checks`: success
+- `Build Package`: success
+- `Publish PyPI`: success
+- `Publish MCP Registry`: success
+- `Release Dry Run`: skipped as expected
+
+Published verification:
+
+- PyPI release: `https://pypi.org/project/coffee-roaster-mcp/0.1.2/`
+- PyPI exposes version `0.1.2`.
+- PyPI project URLs expose the architecture article, original prototype intro,
+  original prototype MCP post, Hugging Face model, Hugging Face dataset, and
+  Gradio demo Space.
+- PyPI wheel SHA-256:
+  `c548967fc239cd93786cc23287c4c55cd67dac398a61b82021bc0022bd4926db`
+- PyPI sdist SHA-256:
+  `25d554bef5f7477256fac63a1c277c224de116d7251f9cd34ff11fdb42a9ef77`
+- MCP Registry search returns `0.1.2` with `isLatest: true`.
+- Published-package smoke passed:
+
+```bash
+uvx --refresh-package coffee-roaster-mcp --from coffee-roaster-mcp==0.1.2 coffee-roaster-mcp --version
+```
+
+Output:
+
+```text
+coffee-roaster-mcp 0.1.2
+```
+
+The first `uvx --refresh --from coffee-roaster-mcp==0.1.2 ...` attempt saw
+package-index lag and reported no available `0.1.2` version. The
+package-specific refresh succeeded immediately after.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -19,8 +19,8 @@ The first implementation milestone is a mock vertical slice that requires no roa
 - Active story: `E7-S4`
 - Current target: retest Warp manual Hottop MCP control validation on the
   published `coffee-roaster-mcp==0.1.1` package path
-- Next package publication target: `v0.1.2` metadata-only release for related
-  project links
+- Latest package release: `v0.1.2` metadata-only release for related project
+  links
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -56,12 +56,17 @@ The first implementation milestone is a mock vertical slice that requires no roa
   published PyPI and then MCP Registry metadata. Published-package smoke with
   `uvx --refresh --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp --version`
   returned `coffee-roaster-mcp 0.1.1`.
-- `v0.1.2` is reserved as a metadata-only release for related project links:
-  package project URLs and README links for the architecture article, original
-  prototype posts, Hugging Face first-crack model, Hugging Face dataset, and
-  Gradio demo Space. README wording frames this package as the consolidated
-  deterministic rebuild of the prototype. The MCP Registry JSON remains
-  schema-focused and continues to point `websiteUrl` at the README.
+- `v0.1.2` is published as a metadata-only release for related project links.
+  PR #146 added package project URLs and README links for the architecture
+  article, original prototype posts, Hugging Face first-crack model, Hugging
+  Face dataset, and Gradio demo Space. README wording frames this package as
+  the consolidated deterministic rebuild of the prototype. The MCP Registry
+  JSON remains schema-focused and continues to point `websiteUrl` at the
+  README. Tag `v0.1.2` points at
+  `3c19d6a677cf40c769dc8394d2e2ac53308446b6`, release run `26403620501`
+  published PyPI and MCP Registry metadata, and published-package smoke with
+  `uvx --refresh-package coffee-roaster-mcp --from coffee-roaster-mcp==0.1.2 coffee-roaster-mcp --version`
+  returned `coffee-roaster-mcp 0.1.2`.
 - `E7-S5a` is inserted before the final release checklist to close the
   first-crack MCP validation gap without requiring Hottop hardware or live
   microphone input. It uses the mock roaster, released Hugging Face first-crack

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -29,12 +29,15 @@ fixes. PR #144 merged the version bump, tag `v0.1.1` points at
 `uvx --refresh --from coffee-roaster-mcp==0.1.1 coffee-roaster-mcp --version`
 smoke returned `coffee-roaster-mcp 0.1.1`.
 
-The next package publication target is `v0.1.2`, a metadata-only release that
-adds related project links to PyPI project URLs and the README while keeping
-MCP Registry metadata schema-safe through the existing README `websiteUrl`.
-The links include the current architecture article, the original prototype
-posts, the Hugging Face model/dataset/demo artifacts, and README wording that
-frames this package as the consolidated deterministic rebuild of the prototype.
+The `v0.1.2` metadata-only release is published. PR #146 merged the related
+project links and version bump, tag `v0.1.2` points at
+`3c19d6a677cf40c769dc8394d2e2ac53308446b6`, GitHub Actions release run
+`26403620501` published PyPI and then MCP Registry metadata, and the published
+`uvx --refresh-package coffee-roaster-mcp --from coffee-roaster-mcp==0.1.2 coffee-roaster-mcp --version`
+smoke returned `coffee-roaster-mcp 0.1.2`. The release adds current
+architecture, original prototype, Hugging Face model/dataset/demo links, and
+README wording that frames this package as the consolidated deterministic
+rebuild of the prototype.
 
 Epic 3 is complete. The Hottop driver now has validated lifecycle, command-loop,
 packet, temperature-unit, heat, fan, drop, cooling, cleanup, and emergency-stop


### PR DESCRIPTION
## Summary

- record the completed v0.1.2 release workflow, PyPI publication, MCP Registry publication, and published-package smoke
- capture PyPI artifact hashes and project URL verification
- update state docs from release-prep wording to published-outcome wording

## Validation

- `./.venv/bin/python -m pytest tests/test_readme.py tests/test_release_workflow.py tests/test_server_json.py`: 13 passed
- `./.venv/bin/python -m ruff check .`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes to document v0.1.2 completion, including verification details and published package links.
  * Updated project state registry to reflect v0.1.2 release status and published artifact confirmation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->