### PR TITLE
E7-S5: Produce v0.1 release checklist

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -6,7 +6,7 @@ This runbook documents the operator prerequisites and CI release path for
 The release workflow is `.github/workflows/release.yml`. It supports two paths:
 
 - Manual dry run through `workflow_dispatch` with `dry_run: true`.
-- Live release through a pushed version tag such as `v0.1.1`.
+- Live release through a pushed version tag such as `v0.1.2`.
 
 ## Operator Prerequisites
 
@@ -30,7 +30,7 @@ Before enabling a live release, the release owner must confirm:
   the release owner before deployment jobs can run.
 - Protected tag rules block unapproved creation or update of `v*` tags.
 - The release tag matches the package version exactly, for example package
-  version `0.1.1` must use tag `v0.1.1`.
+  version `0.1.2` must use tag `v0.1.2`.
 - No model weights, audio files, roast logs, serial captures, `.env` files, or
   local IDE folders are included in the release artifact.
 
@@ -69,6 +69,178 @@ The dry run:
 - Confirms both distribution artifacts exist.
 - Does not publish to PyPI or the MCP Registry.
 
+## v0.1 Release Checklist
+
+Use this checklist for the next v0.1 release candidate from updated `main`.
+The current published package and registry metadata are `0.1.2`; the latest
+E7-S5a first-crack replay evidence uses released Hugging Face INT8 artifacts
+from `syamaner/coffee-first-crack-detection` pinned to revision
+`b349a919c34b6130472da97c01817be404e4f629`.
+
+### Required Tests And Checks
+
+Run the normal local gate before tagging:
+
+```bash
+python -m pytest
+python -m ruff check .
+python -m ruff format --check .
+python -m pyright
+coffee-roaster-mcp --help
+coffee-roaster-mcp --version
+```
+
+Confirm CI passes on the release-candidate PR:
+
+- PR `Checks` job: tests with coverage, lint, format check, typecheck, and CLI
+  smoke checks.
+- PR `Build Package` job: distribution build, built-wheel install smoke, and
+  artifact upload.
+
+Run release dry-run validation before pushing a live tag when the candidate
+contains release metadata or workflow changes:
+
+```bash
+gh workflow run release.yml -f dry_run=true
+```
+
+### Package Build Validation
+
+Build and smoke-test the local distributions before tagging:
+
+```bash
+python -m build
+python .github/scripts/smoke_install_built_wheel.py
+```
+
+The smoke install must use a clean virtual environment, install the built
+wheel from `dist/`, run installed `coffee-roaster-mcp --help`, run installed
+`coffee-roaster-mcp --version`, and assert the installed default config is
+`mock disabled int8`.
+
+### Version Alignment
+
+Before tagging, confirm these values all match the release version:
+
+- `src/coffee_roaster_mcp/__init__.py` `__version__`
+- `server.json.version`
+- `server.json.packages[0].version`
+- the pushed tag name, using `v{version}`
+- installed CLI output from `coffee-roaster-mcp --version`
+
+For the current published state, all package and registry metadata are aligned
+at `0.1.2`. A later release candidate must update all three checked-in version
+fields in the same PR before tagging.
+
+### Hugging Face First-Crack Artifact Pin
+
+For the v0.1 release candidate, record the first-crack artifact pin in the
+release notes or release PR:
+
+- repo: `syamaner/coffee-first-crack-detection`
+- revision: `b349a919c34b6130472da97c01817be404e4f629`
+- precision: `int8`
+- required artifacts:
+  - `onnx/int8/model_quantized.onnx`
+  - `onnx/int8/preprocessor_config.json`
+
+Do not select a newer model revision during release unless the change is
+deliberate, documented in the release PR, and revalidated with the E7-S5a
+labelled WAV replay path. Model training, ONNX export, Hugging Face sync,
+model cards, and dataset cards remain in `coffee-first-crack-detection`.
+
+### PyPI Publish Steps
+
+1. Merge the release-candidate PR to `main`.
+2. Update and verify local `main`:
+
+   ```bash
+   git checkout main
+   git pull --ff-only origin main
+   ```
+
+3. Confirm the tag does not already exist locally or remotely.
+4. Create and push the matching protected version tag:
+
+   ```bash
+   git tag v0.1.2
+   git push origin v0.1.2
+   ```
+
+5. Approve the GitHub `release` environment deployment for `Publish PyPI`.
+6. Confirm production PyPI exposes the expected `coffee-roaster-mcp` version,
+   wheel, sdist, README, and project URLs.
+7. Run a published-package smoke after the package index exposes the version:
+
+   ```bash
+   uvx --refresh-package coffee-roaster-mcp --from coffee-roaster-mcp==0.1.2 coffee-roaster-mcp --version
+   ```
+
+Use the actual candidate version in tag and smoke commands. The `0.1.2`
+commands above document the current published state.
+
+### MCP Registry Publish Steps
+
+The release workflow publishes the MCP Registry entry only after PyPI publish
+succeeds.
+
+1. Confirm `server.json` contains the expected schema URI, Registry name
+   `io.github.syamaner/coffee-roaster-mcp`, PyPI identifier
+   `coffee-roaster-mcp`, package version, runtime hint `uvx`, and stdio
+   transport.
+2. Confirm README contains exactly one verification marker:
+   `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`.
+3. Confirm the workflow validates `server.json` with the pinned
+   `mcp-publisher` before authenticating.
+4. Approve the GitHub `release` environment deployment for
+   `Publish MCP Registry`.
+5. Confirm the Registry search endpoint returns
+   `io.github.syamaner/coffee-roaster-mcp` with the expected package version,
+   `runtimeHint: uvx`, `transport.type: stdio`, and `isLatest: true`.
+
+Do not run a manual live Registry publish from a laptop. The intended live path
+uses GitHub Actions OIDC from the release workflow.
+
+### GitHub Release Steps
+
+After PyPI and MCP Registry publishing pass:
+
+1. Create or update the GitHub Release for the tag.
+2. Summarize the user-visible release contents, validation status, and known
+   boundaries.
+3. Include links to the PyPI release, MCP Registry search result, release
+   workflow run, and relevant validation/session summary.
+4. Mention the pinned Hugging Face revision used for first-crack artifacts.
+5. State whether the release is mock-safe only, hardware-validated, or
+   hardware-ready according to the policy below.
+
+### Hardware-Ready Labeling Policy
+
+Do not apply a hardware-ready release label from release checklist completion
+alone.
+
+A release may be described as mock-safe when default install, package smoke,
+MCP client, and mock roast validation pass without hardware or model download.
+The current `v0.1.2` state is mock-safe by default and includes E7-S5a
+labelled WAV replay evidence for the released first-crack artifact pin.
+
+A release may be described as hardware-validated only when the release
+candidate has current evidence for:
+
+- Warp or another real MCP client connected to the Hottop-configured server.
+- Operator-approved heat, fan, drop, cooling, stop-cooling, emergency-stop,
+  telemetry, and exported-log review.
+- Explicit config, device path, model/audio settings, workflow run or local
+  command evidence, and exported log paths.
+
+A hardware-ready label additionally requires all hardware-validated evidence
+plus current real microphone or audio-path first-crack validation, full
+end-to-end agent roast validation evidence, and release-owner approval that the
+documented Hottop command-loop, drop/cooling, emergency-stop, audio, and log
+export behavior is acceptable for the target release. E7-S6 owns the full
+end-to-end agent roast validation; this checklist story does not run it and
+does not apply the label.
+
 ## Live Release
 
 After all prerequisites are confirmed:
@@ -78,8 +250,8 @@ After all prerequisites are confirmed:
 2. Push the matching version tag:
 
    ```bash
-   git tag v0.1.1
-   git push origin v0.1.1
+   git tag v0.1.2
+   git push origin v0.1.2
    ```
 
 3. Approve the `release` environment deployment in GitHub Actions.
@@ -111,8 +283,8 @@ official registry docs and schema, then repeat the non-destructive checks below:
    `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`.
 2. Confirm `server.json.name` is `io.github.syamaner/coffee-roaster-mcp`.
 3. Confirm the PyPI package entry uses `registryType: pypi`, identifier
-   `coffee-roaster-mcp`, package version `0.1.1`, runtime hint `uvx`, and
-   stdio transport.
+   `coffee-roaster-mcp`, the release-candidate package version, runtime hint
+   `uvx`, and stdio transport.
 4. Confirm README contains exactly one PyPI ownership verification marker:
    `<!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->`.
 5. Download the pinned `mcp-publisher` release asset and verify its SHA-256

--- a/docs/session-summaries/2026-05-25-e7-s5-v0.1-release-checklist.md
+++ b/docs/session-summaries/2026-05-25-e7-s5-v0.1-release-checklist.md
@@ -1,0 +1,79 @@
+# E7-S5 v0.1 Release Checklist
+
+Date: 2026-05-25
+
+Branch: `feature/60-v0.1-release-checklist`
+
+Issue: #60
+
+## Scope
+
+Produced the v0.1 release checklist only.
+
+Included:
+
+- required local, CI, and release dry-run checks
+- package build validation and built-wheel smoke validation
+- version alignment across package and MCP Registry metadata
+- Hugging Face first-crack artifact revision pin
+- PyPI publish steps
+- MCP Registry publish steps
+- GitHub Release steps
+- hardware-ready labeling policy and prerequisites
+
+Excluded:
+
+- live Hottop validation
+- real microphone validation
+- full end-to-end agent roast validation
+- model training, ONNX export, Hugging Face sync, model cards, or dataset cards
+- live PyPI or MCP Registry publishing
+- hardware-ready release labeling
+
+## Prerequisite Verification
+
+- PR #148 is merged.
+- E7-S5a / issue #141 is closed as completed.
+- Local `main` was clean, checked out, and fast-forwarded from
+  `56b9b7cd3c18fef3e51b32ab6cbc7008a2c42163` to
+  `696f6501d158c3b70458bf8a3727988dd14362d4` before branching.
+- GitHub issue #60 is open and requires the release checklist only.
+
+## Checklist Content
+
+Updated `docs/release.md` with a dedicated `v0.1 Release Checklist` section.
+
+The checklist records the current release state:
+
+- current published package and registry metadata: `0.1.2`
+- package version fields to keep aligned:
+  - `src/coffee_roaster_mcp/__init__.py` `__version__`
+  - `server.json.version`
+  - `server.json.packages[0].version`
+- E7-S5a first-crack artifact pin:
+  - repo: `syamaner/coffee-first-crack-detection`
+  - revision: `b349a919c34b6130472da97c01817be404e4f629`
+  - precision: `int8`
+  - artifacts:
+    - `onnx/int8/model_quantized.onnx`
+    - `onnx/int8/preprocessor_config.json`
+
+The hardware-ready policy says checklist completion alone cannot apply a
+hardware-ready label. Hardware-ready requires current hardware-validated
+evidence, current real microphone or audio-path first-crack validation, full
+end-to-end agent roast validation evidence, and release-owner approval.
+
+## Validation
+
+- `./.venv/bin/python -m pytest tests/test_server_json.py tests/test_release_workflow.py tests/test_readme.py tests/test_package.py::test_version_is_defined tests/test_package.py::test_main_prints_version`: 15 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+
+## Next Routing
+
+After the E7-S5 PR for issue #60 merges, continue to E7-S6 / issue #112: run
+end-to-end agent roast validation with the HF ONNX audio path.
+
+Keep model training, ONNX export, Hugging Face sync, live PyPI/MCP Registry
+publishing, and hardware-ready release labeling out of scope unless issue #112
+explicitly requires them.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,9 +16,9 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E7-S5a`
-- Current target: open the labelled WAV replay validation PR and route next to
-  `E7-S5` release checklist work
+- Active story: `E7-S5`
+- Current target: produce the v0.1 release checklist and route next to `E7-S6`
+  end-to-end agent roast validation
 - Latest package release: `v0.1.2` metadata-only release for related project
   links
 - Product/display name: `RoastPilot`
@@ -90,6 +90,15 @@ The first implementation milestone is a mock vertical slice that requires no roa
   `b349a919c34b6130472da97c01817be404e4f629`, detector-paced WAV replay, and
   public MCP tools to start, mark T0, poll until first crack, validate the
   reported time against labels, and export logs.
+- `E7-S5` documents the v0.1 release checklist in `docs/release.md`, grounded
+  in the current `v0.1.2` package/registry metadata state and the E7-S5a pinned
+  Hugging Face first-crack revision
+  `b349a919c34b6130472da97c01817be404e4f629`. The checklist covers required
+  local/CI checks, package build and built-wheel smoke validation, version
+  alignment, PyPI publish, MCP Registry publish, GitHub release notes, and the
+  hardware-ready labeling policy. It does not execute live Hottop validation,
+  real microphone validation, full end-to-end agent roast validation, model
+  training/export/sync, live publishing, or hardware-ready labeling.
 - `E2-S1` keeps the initial MCP tool surface bootstrap-safe with `get_server_info` and `get_runtime_config`. Roast-session lifecycle and roast-control tools remain later Epic 2 work.
 - `E2-S2` uses one in-process `RoastSessionStore` with at most one active `RoastSession` at a time. Session state now owns monotonic timing, phase, event timeline storage, telemetry retention, and log-writer references before tool wiring lands.
 - `E2-S3` keeps event writes behind `RoastSessionStore.record_event(...)`. The session timeline now records deterministic append order, authoritative UTC plus monotonic timestamps for core roast events, and idempotent singleton handling for beans added, first crack, bean drop, and cooling transitions.
@@ -878,8 +887,16 @@ Goal: prove the package works from install through mock roast, MCP client calls,
     `emitted_window_count: 2`, `processed_window_count: 2`, and
     `dropped_window_count: 0`.
 
-- [ ] `E7-S5` Produce v0.1 release checklist.
+- [x] `E7-S5` Produce v0.1 release checklist.
   - Done when release steps cover tests, package build, version alignment, HF revision pin, PyPI publish, registry publish, GitHub release, and hardware-ready labeling.
+  - Implemented in `docs/release.md` with the current `v0.1.2` metadata state,
+    the E7-S5a pinned Hugging Face first-crack revision
+    `b349a919c34b6130472da97c01817be404e4f629`, release dry-run guidance,
+    package build and built-wheel smoke checks, PyPI/MCP Registry publish
+    sequencing, GitHub Release follow-up, and explicit hardware-ready labeling
+    prerequisites. Live Hottop validation, real microphone validation, full
+    end-to-end agent roast validation, live publishing, and hardware-ready
+    labeling remain out of scope for this story.
 
 - [ ] `E7-S6` Run end-to-end agent roast validation with HF ONNX audio path.
   - Done when a real MCP client or agent can install/connect to the package and
@@ -2203,3 +2220,18 @@ After completing a story:
   - Ran `./.venv/bin/python -m pyright`: 0 errors.
   - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
   - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.0`.
+- Validation run for E7-S5:
+  - Added the v0.1 release checklist to `docs/release.md`.
+  - Confirmed the checklist covers required local/CI checks, release dry run,
+    `python -m build`, built-wheel install smoke validation, package/server
+    metadata version alignment, the pinned E7-S5a Hugging Face first-crack
+    revision `b349a919c34b6130472da97c01817be404e4f629`, PyPI publishing,
+    MCP Registry publishing, GitHub Release follow-up, and hardware-ready
+    labeling prerequisites.
+  - Kept live Hottop validation, real microphone validation, full end-to-end
+    agent roast validation, model training/export/sync, live PyPI/MCP Registry
+    publishing, and hardware-ready release labeling out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_server_json.py tests/test_release_workflow.py tests/test_readme.py tests/test_package.py::test_version_is_defined tests/test_package.py::test_main_prints_version`:
+    15 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -411,13 +411,18 @@ Warp public MCP tool calls, and exported verified `roast.jsonl`, `roast.csv`,
 and `summary.json` files under
 `/private/tmp/roastpilot-warp-mock/logs/roasts/b279284880fd4263b2cc0df5366e557f/`.
 
-E7-S4 is complete: PR #143 merged and issue #59 is closed. E7-S5a is complete
-on branch `feature/141-test-mcp-first-crack-detection-labelled-wav-replay` and
-should open a PR for issue #141. The next story after that PR merges is E7-S5:
-produce the v0.1 release checklist. Do not run live Hottop validation, real
-microphone validation, full end-to-end agent roast validation, model
-training/export/sync, live PyPI/MCP Registry publishing, or hardware-ready
-release labeling unless a later story explicitly requires it.
+E7-S4 is complete: PR #143 merged and issue #59 is closed. E7-S5a is complete:
+PR #148 merged and issue #141 is closed. E7-S5 is complete on branch
+`feature/60-v0.1-release-checklist`: `docs/release.md` now contains the v0.1
+release checklist covering required checks, package build validation, version
+alignment, the pinned E7-S5a Hugging Face first-crack artifact revision
+`b349a919c34b6130472da97c01817be404e4f629`, PyPI publishing, MCP Registry
+publishing, GitHub Release follow-up, and hardware-ready labeling
+prerequisites. The next story after the E7-S5 PR merges is E7-S6: run
+end-to-end agent roast validation with the HF ONNX audio path. Do not run live
+Hottop validation, real microphone validation, full end-to-end agent roast
+validation, model training/export/sync, live PyPI/MCP Registry publishing, or
+hardware-ready release labeling unless issue #112 explicitly requires it.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 


### PR DESCRIPTION
## Summary

Closes #60.

- Add the v0.1 release checklist to `docs/release.md`, grounded in current `v0.1.2` package and registry metadata.
- Document required local/CI checks, release dry run, package build validation, built-wheel smoke validation, package/server metadata version alignment, PyPI publish, MCP Registry publish, and GitHub Release follow-up.
- Record the E7-S5a pinned Hugging Face first-crack artifact revision `b349a919c34b6130472da97c01817be404e4f629` and hardware-ready labeling prerequisites.
- Update active epic state, registry routing, and add the E7-S5 session summary routing next to E7-S6.

## Validation

- `./.venv/bin/python -m pytest tests/test_server_json.py tests/test_release_workflow.py tests/test_readme.py tests/test_package.py::test_version_is_defined tests/test_package.py::test_main_prints_version`: 15 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: passed
- `git diff --check`: passed

## Scope Notes

Kept out of scope: live Hottop validation, real microphone validation, full end-to-end agent roast validation, model training/export/sync, live PyPI/MCP Registry publishing, and hardware-ready release labeling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated internal release workflow documentation and project planning records to reflect v0.1.2 release status and completion of release validation checklist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->