### PR TITLE
Route Epic 7 through E7-S6a detector alignment

### DIFF
--- a/docs/session-summaries/2026-05-25-e7-s5-v0.1-release-checklist.md
+++ b/docs/session-summaries/2026-05-25-e7-s5-v0.1-release-checklist.md
@@ -71,9 +71,18 @@ end-to-end agent roast validation evidence, and release-owner approval.
 
 ## Next Routing
 
-After the E7-S5 PR for issue #60 merges, continue to E7-S6 / issue #112: run
-end-to-end agent roast validation with the HF ONNX audio path.
+After the E7-S5 PR for issue #60 merges, continue to E7-S6a / issue #150:
+align the MCP first-crack detector with sliding-window validation before the
+full real microphone/Hottop Warp roast.
+
+E7-S6a was inserted because the current MCP first-crack runtime uses
+non-overlapping detector windows and records first crack at the inferred window
+end. The story must validate the corrected sliding-window behavior with the
+committed E7-S5a labelled WAV fixture and pinned released INT8 Hugging Face
+revision `b349a919c34b6130472da97c01817be404e4f629`.
 
 Keep model training, ONNX export, Hugging Face sync, live PyPI/MCP Registry
-publishing, and hardware-ready release labeling out of scope unless issue #112
-explicitly requires them.
+publishing, real microphone validation, live Hottop validation, full
+end-to-end Warp manual roast validation, and hardware-ready release labeling
+out of scope until E7-S6a is complete and issue #112 explicitly requires the
+manual roast validation.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -99,6 +99,14 @@ The first implementation milestone is a mock vertical slice that requires no roa
   hardware-ready labeling policy. It does not execute live Hottop validation,
   real microphone validation, full end-to-end agent roast validation, model
   training/export/sync, live publishing, or hardware-ready labeling.
+- `E7-S6a` is inserted before the full E7-S6 manual Warp roast to align the
+  MCP first-crack runtime with the model repo's sliding-window validation
+  behavior. E7-S5a proved the released INT8 ONNX model can fire through public
+  MCP tools, but the current MCP path uses non-overlapping detector windows and
+  records first crack at the inferred window end. E7-S6a must add the needed
+  sliding-window configuration and confirmation behavior, then validate the
+  corrected timing against the committed labelled WAV fixture and pinned
+  Hugging Face revision before any real microphone/Hottop roast validation.
 - `E2-S1` keeps the initial MCP tool surface bootstrap-safe with `get_server_info` and `get_runtime_config`. Roast-session lifecycle and roast-control tools remain later Epic 2 work.
 - `E2-S2` uses one in-process `RoastSessionStore` with at most one active `RoastSession` at a time. Session state now owns monotonic timing, phase, event timeline storage, telemetry retention, and log-writer references before tool wiring lands.
 - `E2-S3` keeps event writes behind `RoastSessionStore.record_event(...)`. The session timeline now records deterministic append order, authoritative UTC plus monotonic timestamps for core roast events, and idempotent singleton handling for beans added, first crack, bean drop, and cooling transitions.
@@ -898,6 +906,24 @@ Goal: prove the package works from install through mock roast, MCP client calls,
     end-to-end agent roast validation, live publishing, and hardware-ready
     labeling remain out of scope for this story.
 
+- [ ] `E7-S6a` Align MCP first-crack detector with sliding-window validation.
+  - Issue: #150.
+  - Done when the MCP first-crack runtime supports the sliding-window detector
+    parameters required for release validation, emits overlapping windows when
+    configured, confirms first crack from recent positive windows before
+    recording exactly one event, and validates corrected timing with the
+    committed E7-S5a WAV fixture plus pinned released INT8 Hugging Face
+    artifacts.
+  - Required WAV validation uses
+    `tests/fixtures/audio/roastpilot-fc-replay-001.wav`, retimestamped labels,
+    and manifest with revision
+    `b349a919c34b6130472da97c01817be404e4f629`; the validation should fail if
+    the corrected sliding-window profile only reproduces the old
+    non-overlapping detection around `20.017` seconds after T0.
+  - Live Hottop validation, real microphone validation, full end-to-end Warp
+    manual roast validation, model training/export/sync, live publishing, and
+    hardware-ready labeling remain out of scope.
+
 - [ ] `E7-S6` Run end-to-end agent roast validation with HF ONNX audio path.
   - Done when a real MCP client or agent can install/connect to the package and
     run a full roast flow using public MCP tools, configured Hottop hardware,
@@ -919,6 +945,8 @@ Goal: prove the package works from install through mock roast, MCP client calls,
 - A real MCP client or agent can complete an end-to-end roast validation using
   configured hardware, real audio, and released Hugging Face ONNX first-crack
   artifacts, with correct state, stats, and exported logs recorded as evidence.
+- MCP first-crack detector timing is aligned with the model repo's
+  sliding-window validation behavior before the full real microphone roast.
 - Release is tagged only after package, registry, and smoke tests pass.
 
 ## Spikes

--- a/docs/state/github-issues.md
+++ b/docs/state/github-issues.md
@@ -103,6 +103,7 @@ Milestone: `v0.1`
 - #59 E7-S4: Run Warp manual Hottop MCP control validation
 - #141 E7-S5a: Test MCP first-crack detection with labelled WAV replay
 - #60 E7-S5: Produce v0.1 release checklist
+- #150 E7-S6a: Align MCP first-crack detector with sliding-window validation
 - #112 E7-S6: Run end-to-end agent roast validation with HF ONNX audio path
 
 ## Standalone Spikes

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -418,11 +418,16 @@ release checklist covering required checks, package build validation, version
 alignment, the pinned E7-S5a Hugging Face first-crack artifact revision
 `b349a919c34b6130472da97c01817be404e4f629`, PyPI publishing, MCP Registry
 publishing, GitHub Release follow-up, and hardware-ready labeling
-prerequisites. The next story after the E7-S5 PR merges is E7-S6: run
-end-to-end agent roast validation with the HF ONNX audio path. Do not run live
-Hottop validation, real microphone validation, full end-to-end agent roast
-validation, model training/export/sync, live PyPI/MCP Registry publishing, or
-hardware-ready release labeling unless issue #112 explicitly requires it.
+prerequisites. E7-S6a / issue #150 is inserted before the full E7-S6 manual
+Warp roast because the current MCP first-crack runtime uses non-overlapping
+detector windows and records detection at the inferred window end; E7-S6a must
+align the runtime with sliding-window confirmation behavior and validate the
+fix using the committed labelled WAV fixture with pinned released INT8 Hugging
+Face artifacts. The next story after the E7-S5 PR merges is E7-S6a / issue
+#150. Do not run live Hottop validation, real microphone validation, full
+end-to-end agent roast validation, model training/export/sync, live PyPI/MCP
+Registry publishing, or hardware-ready release labeling until E7-S6a is
+complete and issue #112 explicitly requires the real-roast validation.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 


### PR DESCRIPTION
## Summary

References #150 and #112.

- Add E7-S6a / issue #150 to the Epic 7 issue index and active epic story list.
- Route the post-E7-S5 handoff to E7-S6a before the full E7-S6 manual Warp roast.
- Record that S6a must validate sliding-window first-crack timing with the committed E7-S5a WAV fixture and pinned released INT8 Hugging Face artifacts.

## Validation

- `git diff --check HEAD~1..HEAD`: passed
- `./.venv/bin/python -m pytest tests/test_server_json.py tests/test_release_workflow.py tests/test_readme.py tests/test_package.py::test_version_is_defined tests/test_package.py::test_main_prints_version`: 15 passed

## Scope Notes

Docs/state routing only. Live Hottop validation, real microphone validation, full end-to-end Warp roast validation, model training/export/sync, live publishing, and hardware-ready labeling remain out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development planning documentation to reflect revised roadmap priorities and validation strategy for upcoming work phases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/syamaner/coffee-roaster-mcp/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->