### PR TITLE
Align MCP first-crack sliding-window validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ first_crack:
   precision: int8
   local_model_dir: null
   onnx_threads: 2
+  confidence_threshold: 0.9
+  min_positive_windows: 1
+  confirmation_window_seconds: 20.0
   allow_manual_override: true
 
 audio:
@@ -302,6 +305,8 @@ audio:
   wav_path: null
   replay_mode: realtime
   window_seconds: 1.0
+  overlap: 0.0
+  hop_seconds: null
 
 logging:
   log_dir: ./logs
@@ -330,12 +335,17 @@ Supported environment overrides:
 - `COFFEE_FIRST_CRACK_PRECISION`
 - `COFFEE_FIRST_CRACK_LOCAL_MODEL_DIR`
 - `COFFEE_FIRST_CRACK_ONNX_THREADS`
+- `COFFEE_FIRST_CRACK_CONFIDENCE_THRESHOLD`
+- `COFFEE_FIRST_CRACK_MIN_POSITIVE_WINDOWS`
+- `COFFEE_FIRST_CRACK_CONFIRMATION_WINDOW_SECONDS`
 - `COFFEE_AUDIO_SOURCE`
 - `COFFEE_AUDIO_INPUT_DEVICE`
 - `COFFEE_AUDIO_SAMPLE_RATE`
 - `COFFEE_AUDIO_WAV_PATH`
 - `COFFEE_AUDIO_REPLAY_MODE`
 - `COFFEE_AUDIO_WINDOW_SECONDS`
+- `COFFEE_AUDIO_OVERLAP`
+- `COFFEE_AUDIO_HOP_SECONDS`
 - `COFFEE_ROAST_LOG_DIR`
 - `COFFEE_AUTO_T0_DROP_THRESHOLD_C`
 - `HF_HOME`
@@ -348,9 +358,9 @@ contract as microphone capture, and requires the file sample rate to match
 `audio.sample_rate`. WAV replay defaults to the background `realtime` capture
 pipeline. For local labelled-fixture validation, set
 `audio.replay_mode: detector_paced` and the detector-compatible
-`audio.window_seconds` so each complete WAV window is processed as soon as the
-detector/runtime is ready, without wall-clock sleeps and without normal queue
-drops.
+`audio.window_seconds` plus either `audio.overlap` or `audio.hop_seconds` so
+each complete WAV window is processed as soon as the detector/runtime is ready,
+without wall-clock sleeps and without normal queue drops.
 
 The repository normally does not commit audio. The only current exception is
 the small derived E7-S5a labelled replay fixture under `tests/fixtures/audio/`,

--- a/docs/install-and-hardware-setup.md
+++ b/docs/install-and-hardware-setup.md
@@ -79,6 +79,9 @@ first_crack:
   precision: int8
   local_model_dir: null
   onnx_threads: 2
+  confidence_threshold: 0.9
+  min_positive_windows: 1
+  confirmation_window_seconds: 20.0
   allow_manual_override: true
 
 audio:
@@ -86,6 +89,10 @@ audio:
   input_device: null
   sample_rate: 16000
   wav_path: null
+  replay_mode: realtime
+  window_seconds: 1.0
+  overlap: 0.0
+  hop_seconds: null
 
 logging:
   log_dir: ./logs
@@ -114,12 +121,17 @@ Supported environment overrides:
 - `COFFEE_FIRST_CRACK_PRECISION`
 - `COFFEE_FIRST_CRACK_LOCAL_MODEL_DIR`
 - `COFFEE_FIRST_CRACK_ONNX_THREADS`
+- `COFFEE_FIRST_CRACK_CONFIDENCE_THRESHOLD`
+- `COFFEE_FIRST_CRACK_MIN_POSITIVE_WINDOWS`
+- `COFFEE_FIRST_CRACK_CONFIRMATION_WINDOW_SECONDS`
 - `COFFEE_AUDIO_SOURCE`
 - `COFFEE_AUDIO_INPUT_DEVICE`
 - `COFFEE_AUDIO_SAMPLE_RATE`
 - `COFFEE_AUDIO_WAV_PATH`
 - `COFFEE_AUDIO_REPLAY_MODE`
 - `COFFEE_AUDIO_WINDOW_SECONDS`
+- `COFFEE_AUDIO_OVERLAP`
+- `COFFEE_AUDIO_HOP_SECONDS`
 - `COFFEE_ROAST_LOG_DIR`
 - `COFFEE_AUTO_T0_DROP_THRESHOLD_C`
 - `HF_HOME`
@@ -196,6 +208,9 @@ first_crack:
   precision: int8
   local_model_dir: null
   onnx_threads: 2
+  confidence_threshold: 0.9
+  min_positive_windows: 1
+  confirmation_window_seconds: 20.0
   allow_manual_override: true
 ```
 
@@ -218,6 +233,8 @@ audio:
   wav_path: null
   replay_mode: realtime
   window_seconds: 1.0
+  overlap: 0.0
+  hop_seconds: null
 ```
 
 `precision: int8` selects `onnx/int8/model_quantized.onnx`.
@@ -234,6 +251,7 @@ audio:
   wav_path: /path/to/replay.wav
   replay_mode: detector_paced
   window_seconds: 10.0
+  overlap: 0.7
 ```
 
 The WAV sample rate must match `audio.sample_rate`. `replay_mode: realtime`
@@ -241,8 +259,10 @@ keeps the normal background capture behavior. `replay_mode: detector_paced` is
 for local labelled-fixture validation: it reads the next complete WAV window
 only when the detector drains it, so replay can run faster than wall-clock audio
 without normal detector queue drops. Use `audio.window_seconds` to match the
-released detector's expected window duration for the validation source. Real
-microphone validation is gated manual work and is not required for normal CI or
+released detector's expected window duration for the validation source, and use
+`audio.overlap` or `audio.hop_seconds` when validating sliding-window detector
+behavior. Real microphone validation is gated manual work and is not required
+for normal CI or
 this story.
 
 The E7-S5a labelled replay check is opt-in/local because it uses the released

--- a/docs/session-summaries/2026-05-25-e7-s6a-sliding-window-validation.md
+++ b/docs/session-summaries/2026-05-25-e7-s6a-sliding-window-validation.md
@@ -1,0 +1,108 @@
+# E7-S6a Sliding-Window First-Crack Validation
+
+Date: 2026-05-25
+
+Branch: `feature/150-align-mcp-first-crack-sliding-window-validation`
+
+Issue: #150
+
+## Scope
+
+Aligned the RoastPilot MCP first-crack runtime with configurable sliding-window
+detector validation before the full E7-S6 manual Warp roast.
+
+Included:
+
+- detector configuration for confidence threshold, min positive windows, and
+  confirmation window seconds
+- audio configuration for overlap and explicit hop seconds
+- overlapping window emission in both realtime capture and detector-paced WAV
+  replay
+- recent-positive first-crack confirmation before writing exactly one
+  `first_crack_detected` event
+- configurable ONNX confidence threshold while preserving released-artifact
+  resolution and backend boundaries
+- first-crack artifact, confidence, and confirmation metadata in JSONL, CSV,
+  and `summary.json`
+- public MCP WAV replay validation with the committed fixture and pinned
+  released INT8 Hugging Face artifacts
+
+Excluded:
+
+- live Hottop validation
+- real microphone validation
+- full end-to-end Warp manual roast validation
+- model training, ONNX export, Hugging Face sync, model cards, or dataset cards
+- live PyPI or MCP Registry publishing
+- hardware-ready release labeling
+
+## Prerequisite Verification
+
+- PR #151 was merged at `2026-05-25T16:34:54Z`.
+- E7-S6a / issue #150 was open and routed before E7-S6 / issue #112.
+- Local `main` was clean, checked out, and fast-forwarded from `9f8a064` to
+  `b7c5151` before branching.
+
+## Implementation Notes
+
+- Defaults remain mock-safe: roaster driver `mock`, first-crack mode
+  `disabled`, and no model resolution/download unless `first_crack.mode:
+  audio` is configured.
+- `audio.overlap` and `audio.hop_seconds` control the detector hop. If
+  `hop_seconds` is unset, hop is derived from `window_seconds * (1 -
+  overlap)`.
+- The detector adapter keeps recent positive windows inside
+  `first_crack.confirmation_window_seconds` and records the earliest positive
+  window only after `first_crack.min_positive_windows` is reached.
+- The committed replay fixture is exactly `20.0` seconds long, so the
+  validation profile uses `window_seconds: 10.0`, `overlap: 0.7`,
+  `confidence_threshold: 0.6`, `min_positive_windows: 3`, and
+  `confirmation_window_seconds: 20.0`. That produces three full overlapping
+  windows before confirmation; using five positives is not possible on this
+  fixture without padding or extending the source audio.
+
+## WAV Validation
+
+- Fixture: `tests/fixtures/audio/roastpilot-fc-replay-001.wav`
+- Labels: `tests/fixtures/audio/roastpilot-fc-replay-001.labels.json`
+- Manifest: `tests/fixtures/audio/roastpilot-fc-replay-001.manifest.json`
+- Model repo: `syamaner/coffee-first-crack-detection`
+- Revision: `b349a919c34b6130472da97c01817be404e4f629`
+- Precision: `int8`
+- Artifacts:
+  - `onnx/int8/model_quantized.onnx`
+  - `onnx/int8/preprocessor_config.json`
+- Label interval after T0: `3.82710390663442-20.0` seconds
+- Detected after T0: `10.017558290999885` seconds
+- Previous non-overlapping result: about `20.017` seconds after T0
+- Emitted windows: `3`
+- Processed windows: `3`
+- Dropped windows: `0`
+- Confidence: `0.7762153826546956`
+- Confidence threshold: `0.6`
+- Min positive windows: `3`
+- Confirmation window: `20.0` seconds
+- Exported paths:
+  - JSONL: `/private/var/folders/1b/g1kk3f852c9_5srvd67j_r9w0000gn/T/roastpilot-fc-replay-y04kfl8t/logs/roasts/2936bdf8a6044ac78bfeeb09714753ca/roast.jsonl`
+  - CSV: `/private/var/folders/1b/g1kk3f852c9_5srvd67j_r9w0000gn/T/roastpilot-fc-replay-y04kfl8t/logs/roasts/2936bdf8a6044ac78bfeeb09714753ca/roast.csv`
+  - Summary: `/private/var/folders/1b/g1kk3f852c9_5srvd67j_r9w0000gn/T/roastpilot-fc-replay-y04kfl8t/logs/roasts/2936bdf8a6044ac78bfeeb09714753ca/summary.json`
+
+## Validation
+
+- `./.venv/bin/python -m pytest tests/test_config.py tests/test_audio.py tests/test_detector.py tests/test_first_crack_runtime.py tests/test_first_crack_integration.py tests/test_exports.py`: 105 passed
+- `./.venv/bin/python scripts/validate_first_crack_wav_replay.py --timeout-seconds 180`: passed
+- `./.venv/bin/python -m pytest`: 380 passed
+- `./.venv/bin/python -m ruff check .`: passed
+- `./.venv/bin/python -m ruff format --check .`: passed
+- `./.venv/bin/python -m pyright`: 0 errors
+- `./.venv/bin/coffee-roaster-mcp --help`: passed
+- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.2`
+
+Full gate results are recorded in the E7-S6a validation notes in
+`docs/state/epics/coffee-roaster-mcp-v0.1.md`.
+
+## Next Routing
+
+After the E7-S6a PR for issue #150 merges, continue to E7-S6 / issue #112: run
+the supervised manual Warp roast validation with released Hugging Face ONNX
+audio inference, real microphone input, and Hottop hardware.

--- a/docs/session-summaries/2026-05-25-e7-s6a-sliding-window-validation.md
+++ b/docs/session-summaries/2026-05-25-e7-s6a-sliding-window-validation.md
@@ -89,9 +89,9 @@ Excluded:
 
 ## Validation
 
-- `./.venv/bin/python -m pytest tests/test_config.py tests/test_audio.py tests/test_detector.py tests/test_first_crack_runtime.py tests/test_first_crack_integration.py tests/test_exports.py`: 105 passed
+- `./.venv/bin/python -m pytest tests/test_config.py tests/test_audio.py tests/test_detector.py tests/test_first_crack_runtime.py tests/test_first_crack_integration.py tests/test_exports.py`: 119 passed
 - `./.venv/bin/python scripts/validate_first_crack_wav_replay.py --timeout-seconds 180`: passed
-- `./.venv/bin/python -m pytest`: 380 passed
+- `./.venv/bin/python -m pytest`: 394 passed
 - `./.venv/bin/python -m ruff check .`: passed
 - `./.venv/bin/python -m ruff format --check .`: passed
 - `./.venv/bin/python -m pyright`: 0 errors

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -2323,10 +2323,10 @@ After completing a story:
     Warp manual roast validation, model training/export/sync, live PyPI/MCP
     Registry publishing, and hardware-ready release labeling out of scope.
   - Ran `./.venv/bin/python -m pytest tests/test_config.py tests/test_audio.py tests/test_detector.py tests/test_first_crack_runtime.py tests/test_first_crack_integration.py tests/test_exports.py`:
-    105 passed.
+    119 passed.
   - Ran `./.venv/bin/python scripts/validate_first_crack_wav_replay.py --timeout-seconds 180`:
     passed.
-  - Ran `./.venv/bin/python -m pytest`: 380 passed.
+  - Ran `./.venv/bin/python -m pytest`: 394 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
   - Ran `./.venv/bin/python -m pyright`: 0 errors.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,9 +16,10 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: Bootstrap
-- Active story: `E7-S5`
-- Current target: produce the v0.1 release checklist and route next to `E7-S6`
-  end-to-end agent roast validation
+- Active story: `E7-S6`
+- Current target: run the full E7-S6 manual Warp roast validation with
+  released Hugging Face ONNX audio inference, real microphone input, and
+  supervised Hottop hardware control
 - Latest package release: `v0.1.2` metadata-only release for related project
   links
 - Product/display name: `RoastPilot`
@@ -107,6 +108,20 @@ The first implementation milestone is a mock vertical slice that requires no roa
   sliding-window configuration and confirmation behavior, then validate the
   corrected timing against the committed labelled WAV fixture and pinned
   Hugging Face revision before any real microphone/Hottop roast validation.
+- `E7-S6a` is complete. The MCP first-crack runtime now supports configurable
+  detector confidence threshold, recent-positive confirmation count,
+  confirmation window seconds, and audio overlap/hop settings. Audio capture
+  can emit overlapping detector windows, and the session-owned detector runtime
+  records exactly one first-crack event only after the configured recent
+  positive-window rule confirms. The opt-in public-MCP WAV replay validation
+  uses the committed fixture and pinned released INT8 Hugging Face revision
+  `b349a919c34b6130472da97c01817be404e4f629`; the sliding profile detected at
+  `10.017558290999885` seconds after T0, inside the label interval
+  `3.82710390663442-20.0` and materially earlier than the old
+  non-overlapping `20.017` second result. Exported JSONL, CSV, and
+  `summary.json` preserve first-crack model, artifact, confidence, and
+  confirmation metadata. E7-S6 remains next for real microphone/Hottop Warp
+  validation.
 - `E2-S1` keeps the initial MCP tool surface bootstrap-safe with `get_server_info` and `get_runtime_config`. Roast-session lifecycle and roast-control tools remain later Epic 2 work.
 - `E2-S2` uses one in-process `RoastSessionStore` with at most one active `RoastSession` at a time. Session state now owns monotonic timing, phase, event timeline storage, telemetry retention, and log-writer references before tool wiring lands.
 - `E2-S3` keeps event writes behind `RoastSessionStore.record_event(...)`. The session timeline now records deterministic append order, authoritative UTC plus monotonic timestamps for core roast events, and idempotent singleton handling for beans added, first crack, bean drop, and cooling transitions.
@@ -906,7 +921,7 @@ Goal: prove the package works from install through mock roast, MCP client calls,
     end-to-end agent roast validation, live publishing, and hardware-ready
     labeling remain out of scope for this story.
 
-- [ ] `E7-S6a` Align MCP first-crack detector with sliding-window validation.
+- [x] `E7-S6a` Align MCP first-crack detector with sliding-window validation.
   - Issue: #150.
   - Done when the MCP first-crack runtime supports the sliding-window detector
     parameters required for release validation, emits overlapping windows when
@@ -923,6 +938,19 @@ Goal: prove the package works from install through mock roast, MCP client calls,
   - Live Hottop validation, real microphone validation, full end-to-end Warp
     manual roast validation, model training/export/sync, live publishing, and
     hardware-ready labeling remain out of scope.
+  - Implemented on
+    `feature/150-align-mcp-first-crack-sliding-window-validation` with
+    configuration fields for detector confidence threshold, min positive
+    windows, confirmation window seconds, audio overlap, and audio hop seconds.
+    The audio pipeline now advances by the configured hop, detector-paced WAV
+    replay preserves source-audio sliding-window timestamps, the detector
+    adapter confirms from recent positive windows before returning one event,
+    and summary export now carries first-crack artifact and confirmation
+    metadata alongside JSONL and CSV metadata. The committed replay fixture
+    validated through public MCP tools with pinned INT8 revision
+    `b349a919c34b6130472da97c01817be404e4f629`, detecting at
+    `10.017558290999885` seconds after T0 with `3` emitted windows, `3`
+    processed windows, and `0` dropped windows.
 
 - [ ] `E7-S6` Run end-to-end agent roast validation with HF ONNX audio path.
   - Done when a real MCP client or agent can install/connect to the package and
@@ -2263,3 +2291,44 @@ After completing a story:
     15 passed.
   - Ran `./.venv/bin/python -m ruff check .`: passed.
   - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+- Validation run for E7-S6a:
+  - Added detector configuration for confidence threshold, min positive
+    windows, confirmation window seconds, audio overlap, and audio hop seconds.
+  - Added overlapping audio window emission for realtime capture and
+    detector-paced WAV replay.
+  - Added recent-positive first-crack confirmation before the detector runtime
+    writes exactly one `first_crack_detected` event.
+  - Preserved mock-safe defaults: roaster driver `mock`, first-crack mode
+    `disabled`, and no released-artifact resolution unless
+    `first_crack.mode: audio` is configured.
+  - Preserved released Hugging Face artifact resolution and ONNX backend
+    boundaries, adding only configurable threshold behavior.
+  - Extended summary export so JSONL, CSV, and `summary.json` preserve
+    first-crack model, artifact, confidence, and confirmation metadata.
+  - Ran public MCP WAV replay validation with
+    `tests/fixtures/audio/roastpilot-fc-replay-001.wav`, labels, manifest, and
+    pinned released INT8 revision
+    `b349a919c34b6130472da97c01817be404e4f629`: detected at
+    `10.017558290999885` seconds after T0 inside the
+    `3.82710390663442-20.0` second label interval, with `3` emitted windows,
+    `3` processed windows, `0` dropped windows, confidence
+    `0.7762153826546956`, confidence threshold `0.6`, min positive windows
+    `3`, and confirmation window `20.0` seconds.
+  - Exported validation logs:
+    `/private/var/folders/1b/g1kk3f852c9_5srvd67j_r9w0000gn/T/roastpilot-fc-replay-y04kfl8t/logs/roasts/2936bdf8a6044ac78bfeeb09714753ca/roast.jsonl`,
+    `/private/var/folders/1b/g1kk3f852c9_5srvd67j_r9w0000gn/T/roastpilot-fc-replay-y04kfl8t/logs/roasts/2936bdf8a6044ac78bfeeb09714753ca/roast.csv`,
+    and
+    `/private/var/folders/1b/g1kk3f852c9_5srvd67j_r9w0000gn/T/roastpilot-fc-replay-y04kfl8t/logs/roasts/2936bdf8a6044ac78bfeeb09714753ca/summary.json`.
+  - Kept live Hottop validation, real microphone validation, full end-to-end
+    Warp manual roast validation, model training/export/sync, live PyPI/MCP
+    Registry publishing, and hardware-ready release labeling out of scope.
+  - Ran `./.venv/bin/python -m pytest tests/test_config.py tests/test_audio.py tests/test_detector.py tests/test_first_crack_runtime.py tests/test_first_crack_integration.py tests/test_exports.py`:
+    105 passed.
+  - Ran `./.venv/bin/python scripts/validate_first_crack_wav_replay.py --timeout-seconds 180`:
+    passed.
+  - Ran `./.venv/bin/python -m pytest`: 380 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran `./.venv/bin/coffee-roaster-mcp --help`: passed.
+  - Ran `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.2`.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -39,6 +39,18 @@ architecture, original prototype, Hugging Face model/dataset/demo links, and
 README wording that frames this package as the consolidated deterministic
 rebuild of the prototype.
 
+E7-S6a is complete and routes next to E7-S6 / issue #112. The MCP
+first-crack runtime now supports configurable confidence threshold, recent
+positive-window confirmation, confirmation window seconds, and audio overlap or
+hop settings. Detector-paced WAV replay with the committed E7-S5a fixture and
+pinned released INT8 Hugging Face revision
+`b349a919c34b6130472da97c01817be404e4f629` detected first crack at
+`10.017558290999885` seconds after T0 inside the `3.82710390663442-20.0`
+second label interval, with `3` emitted windows, `3` processed windows, and
+`0` dropped windows. Live Hottop validation, real microphone validation, full
+Warp manual roast validation, live publishing, and hardware-ready labeling
+remain out of scope until E7-S6.
+
 Epic 3 is complete. The Hottop driver now has validated lifecycle, command-loop,
 packet, temperature-unit, heat, fan, drop, cooling, cleanup, and emergency-stop
 behavior at the driver boundary. The full connected-Hottop E3-S9 validation run

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -430,16 +430,14 @@ release checklist covering required checks, package build validation, version
 alignment, the pinned E7-S5a Hugging Face first-crack artifact revision
 `b349a919c34b6130472da97c01817be404e4f629`, PyPI publishing, MCP Registry
 publishing, GitHub Release follow-up, and hardware-ready labeling
-prerequisites. E7-S6a / issue #150 is inserted before the full E7-S6 manual
-Warp roast because the current MCP first-crack runtime uses non-overlapping
-detector windows and records detection at the inferred window end; E7-S6a must
-align the runtime with sliding-window confirmation behavior and validate the
-fix using the committed labelled WAV fixture with pinned released INT8 Hugging
-Face artifacts. The next story after the E7-S5 PR merges is E7-S6a / issue
-#150. Do not run live Hottop validation, real microphone validation, full
-end-to-end agent roast validation, model training/export/sync, live PyPI/MCP
-Registry publishing, or hardware-ready release labeling until E7-S6a is
-complete and issue #112 explicitly requires the real-roast validation.
+prerequisites. E7-S6a / issue #150 is complete and aligned the MCP
+first-crack runtime with sliding-window confirmation behavior using the
+committed labelled WAV fixture with pinned released INT8 Hugging Face
+artifacts. The next story after the E7-S6a PR merges is E7-S6 / issue #112. Do
+not run live Hottop validation, real microphone validation, full end-to-end
+agent roast validation, model training/export/sync, live PyPI/MCP Registry
+publishing, or hardware-ready release labeling until issue #112 explicitly
+requires the real-roast validation.
 
 The first implementation milestone is now complete. The mock vertical slice can start the MCP server with the mock driver, run a simulated roast through MCP tools, and export JSONL, CSV, and summary logs without roaster hardware or model download.
 

--- a/scripts/validate_first_crack_wav_replay.py
+++ b/scripts/validate_first_crack_wav_replay.py
@@ -52,6 +52,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=1.0,
         help="Allowed detection tolerance after the labelled interval start.",
     )
+    parser.add_argument(
+        "--old-non-overlap-detection-seconds",
+        type=float,
+        default=20.017,
+        help="Fail when sliding-window validation only reproduces the old timing.",
+    )
     return parser
 
 
@@ -115,10 +121,21 @@ async def _run_validation(args: argparse.Namespace) -> int:
                 f"{detected_after_t0:.3f}s after T0 is outside label interval "
                 f"{label_start:.3f}-{label_end:.3f}s."
             )
+        if detected_after_t0 >= float(args.old_non_overlap_detection_seconds):
+            raise RuntimeError(
+                "sliding-window validation reproduced the old non-overlapping "
+                f"detection timing at {detected_after_t0:.3f}s after T0."
+            )
 
         export = await _call(session.call_tool("export_roast_log", {"session_id": session_id}))
         elapsed_wall_seconds = time.monotonic() - started_at
         metrics = cast(dict[str, Any], state_content["first_crack_status"])
+        summary_path = Path(cast(str, export.structuredContent["summary_path"]))
+        exported_summary = cast(
+            dict[str, Any],
+            json.loads(summary_path.read_text(encoding="utf-8")),
+        )
+        first_crack_model = cast(dict[str, Any], exported_summary["first_crack_model"])
         summary = {
             "session_id": session_id,
             "fixture": str(FIXTURE_DIR / f"{FIXTURE_STEM}.wav"),
@@ -132,6 +149,19 @@ async def _run_validation(args: argparse.Namespace) -> int:
                 "emitted_window_count": metrics["emitted_window_count"],
                 "processed_window_count": metrics["processed_window_count"],
                 "dropped_window_count": metrics["dropped_window_count"],
+            },
+            "detector_confirmation": {
+                "confidence": first_crack_model["confidence"],
+                "confidence_threshold": first_crack_model["confidence_threshold"],
+                "min_positive_windows": first_crack_model["min_positive_windows"],
+                "confirmation_window_seconds": first_crack_model["confirmation_window_seconds"],
+            },
+            "model_artifacts": {
+                "repo_id": first_crack_model["repo_id"],
+                "revision": first_crack_model["revision"],
+                "precision": first_crack_model["precision"],
+                "onnx_model_filename": first_crack_model["onnx_model_filename"],
+                "feature_extractor_filename": first_crack_model["feature_extractor_filename"],
             },
             "exports": {
                 "jsonl_path": export.structuredContent["jsonl_path"],
@@ -163,6 +193,9 @@ def _write_config(config_path: Path, *, log_dir: Path) -> None:
                 "  precision: int8",
                 "  local_model_dir: null",
                 "  onnx_threads: 2",
+                "  confidence_threshold: 0.6",
+                "  min_positive_windows: 3",
+                "  confirmation_window_seconds: 20.0",
                 "  allow_manual_override: true",
                 "audio:",
                 "  source: wav",
@@ -171,6 +204,7 @@ def _write_config(config_path: Path, *, log_dir: Path) -> None:
                 f"  wav_path: {wav_path}",
                 "  replay_mode: detector_paced",
                 "  window_seconds: 10.0",
+                "  overlap: 0.7",
                 "logging:",
                 f"  log_dir: {log_dir_path}",
                 "  sample_interval_seconds: 5.0",

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -55,6 +55,8 @@ class AudioCaptureSettings:
         replay_mode: WAV replay mode. `detector_paced` emits windows only when
             the detector drains them, without wall-clock sleeps or queue drops.
         window_seconds: Detector window duration in seconds.
+        overlap: Fraction of each detector window shared with the next window.
+        hop_seconds: Optional explicit interval between consecutive windows.
         queue_limit: Maximum detector windows retained for downstream consumers.
         idle_sleep_seconds: Sleep duration when an input read returns no samples.
     """
@@ -65,6 +67,8 @@ class AudioCaptureSettings:
     wav_path: Path | None = None
     replay_mode: str = "realtime"
     window_seconds: float = DEFAULT_AUDIO_WINDOW_SECONDS
+    overlap: float = 0.0
+    hop_seconds: float | None = None
     queue_limit: int = DEFAULT_AUDIO_WINDOW_QUEUE_LIMIT
     idle_sleep_seconds: float = DEFAULT_AUDIO_IDLE_SLEEP_SECONDS
 
@@ -72,6 +76,21 @@ class AudioCaptureSettings:
     def window_sample_count(self) -> int:
         """Return the exact number of samples required for one detector window."""
         return max(1, round(self.sample_rate * self.window_seconds))
+
+    @property
+    def hop_sample_count(self) -> int:
+        """Return the number of samples to advance between detector windows."""
+        hop_seconds = (
+            self.window_seconds * (1.0 - self.overlap)
+            if self.hop_seconds is None
+            else self.hop_seconds
+        )
+        return max(1, round(self.sample_rate * hop_seconds))
+
+    @property
+    def effective_hop_seconds(self) -> float:
+        """Return the effective interval between detector windows."""
+        return self.hop_sample_count / self.sample_rate
 
 
 @dataclass(frozen=True)
@@ -129,6 +148,8 @@ def audio_capture_settings_from_config(
         wav_path=config.wav_path,
         replay_mode=config.replay_mode,
         window_seconds=config.window_seconds if window_seconds is None else window_seconds,
+        overlap=config.overlap,
+        hop_seconds=config.hop_seconds,
         queue_limit=queue_limit,
         idle_sleep_seconds=idle_sleep_seconds,
     )
@@ -480,7 +501,7 @@ class AudioCapturePipeline:
         window_sample_count = self._settings.window_sample_count
         while len(self._sample_buffer) >= window_sample_count:
             window_samples = tuple(self._sample_buffer[:window_sample_count])
-            del self._sample_buffer[:window_sample_count]
+            del self._sample_buffer[: self._settings.hop_sample_count]
             window = AudioWindow(
                 sequence_number=self._next_sequence_number,
                 input_device=self._settings.input_device,
@@ -610,7 +631,7 @@ class DetectorPacedWavReplayPipeline(AudioCapturePipeline):
             self._sample_buffer.extend(_normalize_sample(sample) for sample in samples)
 
         window_samples = tuple(self._sample_buffer[:window_sample_count])
-        del self._sample_buffer[:window_sample_count]
+        del self._sample_buffer[: self._settings.hop_sample_count]
         with self._state_lock:
             if self._timeline_start_monotonic_seconds is None:
                 self._timeline_start_monotonic_seconds = self._monotonic_now()
@@ -619,7 +640,7 @@ class DetectorPacedWavReplayPipeline(AudioCapturePipeline):
             self._replay_emitted_window_count += 1
             started_at_monotonic_seconds = (
                 self._timeline_start_monotonic_seconds
-                + sequence_number * self._settings.window_seconds
+                + sequence_number * self._settings.effective_hop_seconds
             )
 
         return AudioWindow(
@@ -648,6 +669,15 @@ def _validate_settings(settings: AudioCaptureSettings) -> None:
         raise AudioCaptureError("audio.sample_rate must be > 0.")
     if not math.isfinite(settings.window_seconds) or settings.window_seconds <= 0:
         raise AudioCaptureError("audio window_seconds must be > 0.")
+    if not math.isfinite(settings.overlap) or not 0.0 <= settings.overlap < 1.0:
+        raise AudioCaptureError("audio overlap must be greater than or equal to 0 and less than 1.")
+    if settings.hop_seconds is not None:
+        if not math.isfinite(settings.hop_seconds) or settings.hop_seconds <= 0:
+            raise AudioCaptureError("audio hop_seconds must be > 0.")
+        if settings.hop_seconds > settings.window_seconds:
+            raise AudioCaptureError(
+                "audio hop_seconds must be less than or equal to window_seconds."
+            )
     if settings.queue_limit < 1:
         raise AudioCaptureError("audio queue_limit must be >= 1.")
     if not math.isfinite(settings.idle_sleep_seconds) or settings.idle_sleep_seconds < 0:

--- a/src/coffee_roaster_mcp/config.py
+++ b/src/coffee_roaster_mcp/config.py
@@ -40,7 +40,22 @@ class RoasterConfig:
 
 @dataclass(frozen=True)
 class FirstCrackConfig:
-    """First-crack detector configuration."""
+    """First-crack detector configuration.
+
+    Attributes:
+        mode: First-crack mode: `disabled`, `audio`, or `manual`.
+        repo_id: Hugging Face model repository id for released detector artifacts.
+        revision: Optional Hub revision, branch, tag, or commit SHA to pin artifacts.
+        precision: ONNX model precision, either `int8` or `fp32`.
+        local_model_dir: Optional local directory containing released artifact files.
+        onnx_threads: Number of ONNX Runtime intra-op threads.
+        confidence_threshold: Detector confidence threshold in the inclusive
+            range `0.0` to `1.0`.
+        min_positive_windows: Number of recent positive windows required before
+            automatic first crack is confirmed.
+        confirmation_window_seconds: Recent-positive confirmation span in seconds.
+        allow_manual_override: Whether explicit `mark_first_crack` is allowed.
+    """
 
     mode: FirstCrackMode = "disabled"
     repo_id: str = "syamaner/coffee-first-crack-detection"
@@ -56,7 +71,20 @@ class FirstCrackConfig:
 
 @dataclass(frozen=True)
 class AudioConfig:
-    """Audio capture configuration."""
+    """Audio capture configuration.
+
+    Attributes:
+        source: Audio source type: `microphone` or `wav`.
+        input_device: Optional PortAudio or platform-specific input device id.
+        sample_rate: Mono detector sample rate in Hz.
+        wav_path: Optional WAV path when `source` is `wav`.
+        replay_mode: WAV replay mode: `realtime` or `detector_paced`.
+        window_seconds: Detector window duration in seconds.
+        overlap: Fraction of each window shared with the next window, from `0.0`
+            inclusive to `1.0` exclusive.
+        hop_seconds: Optional explicit hop duration in seconds. When set, this
+            overrides the cadence derived from `overlap`.
+    """
 
     source: AudioSource = "microphone"
     input_device: str | None = None
@@ -263,6 +291,13 @@ def _audio_from_mapping(raw: Mapping[str, Any]) -> AudioConfig:
         1.0,
         label="audio.window_seconds",
     )
+    hop_seconds = _optional_positive_float(raw, "hop_seconds", label="audio.hop_seconds")
+    _validate_audio_hop_seconds(
+        hop_seconds,
+        window_seconds,
+        hop_label="audio.hop_seconds",
+        window_label="audio.window_seconds",
+    )
     return AudioConfig(
         source=_audio_source(
             _string(raw, "source", "microphone", label="audio.source"),
@@ -282,7 +317,7 @@ def _audio_from_mapping(raw: Mapping[str, Any]) -> AudioConfig:
             0.0,
             label="audio.overlap",
         ),
-        hop_seconds=_optional_positive_float(raw, "hop_seconds", label="audio.hop_seconds"),
+        hop_seconds=hop_seconds,
     )
 
 
@@ -467,6 +502,12 @@ def _apply_env_overrides(config: AppConfig, environ: Mapping[str, str]) -> AppCo
                 else _parse_positive_float(hop_seconds, "COFFEE_AUDIO_HOP_SECONDS")
             ),
         )
+    _validate_audio_hop_seconds(
+        audio.hop_seconds,
+        audio.window_seconds,
+        hop_label="COFFEE_AUDIO_HOP_SECONDS",
+        window_label="COFFEE_AUDIO_WINDOW_SECONDS",
+    )
 
     if "COFFEE_ROAST_LOG_DIR" in environ:
         logging = replace(
@@ -663,6 +704,20 @@ def _parse_overlap_float(value: object, key: str) -> float:
     if not math.isfinite(parsed) or not 0.0 <= parsed < 1.0:
         raise ConfigError(f"{key} must be greater than or equal to 0 and less than 1.")
     return parsed
+
+
+def _validate_audio_hop_seconds(
+    hop_seconds: float | None,
+    window_seconds: float,
+    *,
+    hop_label: str,
+    window_label: str,
+) -> None:
+    if hop_seconds is not None and hop_seconds > window_seconds:
+        raise ConfigError(
+            f"{hop_label} must be less than or equal to {window_label} "
+            f"({hop_seconds} > {window_seconds})."
+        )
 
 
 def _parse_float(value: object, key: str) -> float:

--- a/src/coffee_roaster_mcp/config.py
+++ b/src/coffee_roaster_mcp/config.py
@@ -48,6 +48,9 @@ class FirstCrackConfig:
     precision: ModelPrecision = "int8"
     local_model_dir: Path | None = None
     onnx_threads: int = 2
+    confidence_threshold: float = 0.9
+    min_positive_windows: int = 1
+    confirmation_window_seconds: float = 20.0
     allow_manual_override: bool = True
 
 
@@ -61,6 +64,8 @@ class AudioConfig:
     wav_path: Path | None = None
     replay_mode: AudioReplayMode = "realtime"
     window_seconds: float = 1.0
+    overlap: float = 0.0
+    hop_seconds: float | None = None
 
 
 @dataclass(frozen=True)
@@ -224,6 +229,24 @@ def _first_crack_from_mapping(raw: Mapping[str, Any]) -> FirstCrackConfig:
         ),
         local_model_dir=local_model_dir,
         onnx_threads=_integer(raw, "onnx_threads", 2, label="first_crack.onnx_threads"),
+        confidence_threshold=_unit_interval_float(
+            raw,
+            "confidence_threshold",
+            0.9,
+            label="first_crack.confidence_threshold",
+        ),
+        min_positive_windows=_positive_integer(
+            raw,
+            "min_positive_windows",
+            1,
+            label="first_crack.min_positive_windows",
+        ),
+        confirmation_window_seconds=_positive_float(
+            raw,
+            "confirmation_window_seconds",
+            20.0,
+            label="first_crack.confirmation_window_seconds",
+        ),
         allow_manual_override=_boolean(
             raw,
             "allow_manual_override",
@@ -234,6 +257,12 @@ def _first_crack_from_mapping(raw: Mapping[str, Any]) -> FirstCrackConfig:
 
 
 def _audio_from_mapping(raw: Mapping[str, Any]) -> AudioConfig:
+    window_seconds = _positive_float(
+        raw,
+        "window_seconds",
+        1.0,
+        label="audio.window_seconds",
+    )
     return AudioConfig(
         source=_audio_source(
             _string(raw, "source", "microphone", label="audio.source"),
@@ -246,12 +275,14 @@ def _audio_from_mapping(raw: Mapping[str, Any]) -> AudioConfig:
             _string(raw, "replay_mode", "realtime", label="audio.replay_mode"),
             label="audio.replay_mode",
         ),
-        window_seconds=_positive_float(
+        window_seconds=window_seconds,
+        overlap=_overlap_float(
             raw,
-            "window_seconds",
-            1.0,
-            label="audio.window_seconds",
+            "overlap",
+            0.0,
+            label="audio.overlap",
         ),
+        hop_seconds=_optional_positive_float(raw, "hop_seconds", label="audio.hop_seconds"),
     )
 
 
@@ -362,6 +393,30 @@ def _apply_env_overrides(config: AppConfig, environ: Mapping[str, str]) -> AppCo
                 "COFFEE_FIRST_CRACK_ONNX_THREADS",
             ),
         )
+    if "COFFEE_FIRST_CRACK_CONFIDENCE_THRESHOLD" in environ:
+        first_crack = replace(
+            first_crack,
+            confidence_threshold=_parse_unit_interval_float(
+                environ["COFFEE_FIRST_CRACK_CONFIDENCE_THRESHOLD"],
+                "COFFEE_FIRST_CRACK_CONFIDENCE_THRESHOLD",
+            ),
+        )
+    if "COFFEE_FIRST_CRACK_MIN_POSITIVE_WINDOWS" in environ:
+        first_crack = replace(
+            first_crack,
+            min_positive_windows=_parse_positive_integer(
+                environ["COFFEE_FIRST_CRACK_MIN_POSITIVE_WINDOWS"],
+                "COFFEE_FIRST_CRACK_MIN_POSITIVE_WINDOWS",
+            ),
+        )
+    if "COFFEE_FIRST_CRACK_CONFIRMATION_WINDOW_SECONDS" in environ:
+        first_crack = replace(
+            first_crack,
+            confirmation_window_seconds=_parse_positive_float(
+                environ["COFFEE_FIRST_CRACK_CONFIRMATION_WINDOW_SECONDS"],
+                "COFFEE_FIRST_CRACK_CONFIRMATION_WINDOW_SECONDS",
+            ),
+        )
 
     if "COFFEE_AUDIO_SOURCE" in environ:
         audio = replace(
@@ -395,6 +450,21 @@ def _apply_env_overrides(config: AppConfig, environ: Mapping[str, str]) -> AppCo
             window_seconds=_parse_positive_float(
                 environ["COFFEE_AUDIO_WINDOW_SECONDS"],
                 "COFFEE_AUDIO_WINDOW_SECONDS",
+            ),
+        )
+    if "COFFEE_AUDIO_OVERLAP" in environ:
+        audio = replace(
+            audio,
+            overlap=_parse_overlap_float(environ["COFFEE_AUDIO_OVERLAP"], "COFFEE_AUDIO_OVERLAP"),
+        )
+    if "COFFEE_AUDIO_HOP_SECONDS" in environ:
+        hop_seconds = _none_if_empty(environ["COFFEE_AUDIO_HOP_SECONDS"])
+        audio = replace(
+            audio,
+            hop_seconds=(
+                None
+                if hop_seconds is None
+                else _parse_positive_float(hop_seconds, "COFFEE_AUDIO_HOP_SECONDS")
             ),
         )
 
@@ -487,6 +557,16 @@ def _integer(raw: Mapping[str, Any], key: str, default: int, label: str | None =
     return _parse_integer(value, error_key)
 
 
+def _positive_integer(
+    raw: Mapping[str, Any],
+    key: str,
+    default: int,
+    label: str | None = None,
+) -> int:
+    error_key = label or key
+    return _parse_positive_integer(raw.get(key, default), error_key)
+
+
 def _parse_integer(value: object, key: str) -> int:
     if isinstance(value, bool):
         raise ConfigError(f"{key} must be an integer.")
@@ -498,6 +578,13 @@ def _parse_integer(value: object, key: str) -> int:
         except ValueError as exc:
             raise ConfigError(f"{key} must be an integer.") from exc
     raise ConfigError(f"{key} must be an integer.")
+
+
+def _parse_positive_integer(value: object, key: str) -> int:
+    parsed = _parse_integer(value, key)
+    if parsed <= 0:
+        raise ConfigError(f"{key} must be greater than 0.")
+    return parsed
 
 
 def _float(raw: Mapping[str, Any], key: str, default: float, label: str | None = None) -> float:
@@ -529,6 +616,52 @@ def _parse_positive_float(value: object, key: str) -> float:
     parsed = _parse_float(value, key)
     if not math.isfinite(parsed) or parsed <= 0:
         raise ConfigError(f"{key} must be greater than 0.")
+    return parsed
+
+
+def _optional_positive_float(
+    raw: Mapping[str, Any],
+    key: str,
+    label: str | None = None,
+) -> float | None:
+    error_key = label or key
+    value = raw.get(key)
+    if value is None:
+        return None
+    return _parse_positive_float(value, error_key)
+
+
+def _unit_interval_float(
+    raw: Mapping[str, Any],
+    key: str,
+    default: float,
+    label: str | None = None,
+) -> float:
+    error_key = label or key
+    return _parse_unit_interval_float(raw.get(key, default), error_key)
+
+
+def _parse_unit_interval_float(value: object, key: str) -> float:
+    parsed = _parse_float(value, key)
+    if not math.isfinite(parsed) or not 0.0 <= parsed <= 1.0:
+        raise ConfigError(f"{key} must be between 0 and 1.")
+    return parsed
+
+
+def _overlap_float(
+    raw: Mapping[str, Any],
+    key: str,
+    default: float,
+    label: str | None = None,
+) -> float:
+    error_key = label or key
+    return _parse_overlap_float(raw.get(key, default), error_key)
+
+
+def _parse_overlap_float(value: object, key: str) -> float:
+    parsed = _parse_float(value, key)
+    if not math.isfinite(parsed) or not 0.0 <= parsed < 1.0:
+        raise ConfigError(f"{key} must be greater than or equal to 0 and less than 1.")
     return parsed
 
 

--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import math
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from importlib import import_module
 from pathlib import Path
 from types import MethodType
@@ -110,6 +110,14 @@ class FirstCrackDetectionEvent:
         onnx_model_filename: Repository-relative ONNX model artifact.
         feature_extractor_filename: Repository-relative feature extractor artifact.
         window_sequence_number: Source audio window sequence number.
+        confirmed_by_window_sequence_number: Window sequence number that met
+            the configured recent-positive confirmation rule.
+        positive_window_count: Positive detector windows currently inside the
+            confirmation window.
+        confidence_threshold: Configured detector confidence threshold.
+        min_positive_windows: Configured positive-window count required for
+            confirmation.
+        confirmation_window_seconds: Configured recent-positive window span.
         detected_at_inferred: Whether the detection timestamp was inferred from
             the source window end because the backend omitted an explicit timestamp.
     """
@@ -123,6 +131,11 @@ class FirstCrackDetectionEvent:
     onnx_model_filename: str
     feature_extractor_filename: str
     window_sequence_number: int
+    confirmed_by_window_sequence_number: int
+    positive_window_count: int
+    confidence_threshold: float
+    min_positive_windows: int
+    confirmation_window_seconds: float
     detected_at_inferred: bool
 
     def payload(self) -> dict[str, str | int | float | None]:
@@ -136,6 +149,11 @@ class FirstCrackDetectionEvent:
             "onnx_model_filename": self.onnx_model_filename,
             "feature_extractor_filename": self.feature_extractor_filename,
             "window_sequence_number": self.window_sequence_number,
+            "confirmed_by_window_sequence_number": self.confirmed_by_window_sequence_number,
+            "positive_window_count": self.positive_window_count,
+            "confidence_threshold": self.confidence_threshold,
+            "min_positive_windows": self.min_positive_windows,
+            "confirmation_window_seconds": self.confirmation_window_seconds,
         }
         if self.confidence is not None:
             payload["confidence"] = self.confidence
@@ -143,24 +161,34 @@ class FirstCrackDetectionEvent:
 
 
 @dataclass(frozen=True)
+class _PositiveWindowCandidate:
+    event: FirstCrackDetectionEvent
+
+
+@dataclass
 class FirstCrackDetectorAdapter:
     """Adapt detector backend outputs into confirmed first-crack event candidates."""
 
     config: FirstCrackConfig
     artifacts: ResolvedDetectorArtifacts
     backend: FirstCrackDetectorBackend
+    _positive_candidates: list[_PositiveWindowCandidate] = field(
+        default_factory=lambda: cast(list[_PositiveWindowCandidate], [])
+    )
 
     def process_window(self, window: AudioWindow) -> FirstCrackDetectionEvent | None:
         """Process one audio window and return a confirmed event candidate if present."""
         output = self.backend.detect(window)
         if type(output.confirmed) is not bool:
             raise FirstCrackDetectorError("detector output confirmed must be a boolean.")
+        _validate_confirmation_config(self.config)
+        self._prune_positive_candidates(window.started_at_monotonic_seconds)
         if not output.confirmed:
             return None
 
         confidence = _validate_optional_confidence(output.confidence)
         detected_at_monotonic_seconds = _detection_timestamp(window, output)
-        return FirstCrackDetectionEvent(
+        candidate = FirstCrackDetectionEvent(
             kind="first_crack_detected",
             detected_at_monotonic_seconds=detected_at_monotonic_seconds,
             precision=self.config.precision,
@@ -170,8 +198,32 @@ class FirstCrackDetectorAdapter:
             onnx_model_filename=self.artifacts.onnx_model.filename,
             feature_extractor_filename=self.artifacts.feature_extractor_config.filename,
             window_sequence_number=window.sequence_number,
+            confirmed_by_window_sequence_number=window.sequence_number,
+            positive_window_count=1,
+            confidence_threshold=self.config.confidence_threshold,
+            min_positive_windows=self.config.min_positive_windows,
+            confirmation_window_seconds=self.config.confirmation_window_seconds,
             detected_at_inferred=output.detected_at_monotonic_seconds is None,
         )
+        self._positive_candidates.append(_PositiveWindowCandidate(event=candidate))
+        self._prune_positive_candidates(detected_at_monotonic_seconds)
+        if len(self._positive_candidates) < self.config.min_positive_windows:
+            return None
+
+        earliest = self._positive_candidates[0].event
+        return replace(
+            earliest,
+            confirmed_by_window_sequence_number=window.sequence_number,
+            positive_window_count=len(self._positive_candidates),
+        )
+
+    def _prune_positive_candidates(self, current_monotonic_seconds: float) -> None:
+        cutoff = current_monotonic_seconds - self.config.confirmation_window_seconds
+        self._positive_candidates = [
+            candidate
+            for candidate in self._positive_candidates
+            if candidate.event.detected_at_monotonic_seconds >= cutoff
+        ]
 
 
 @dataclass(frozen=True)
@@ -293,6 +345,7 @@ def build_released_onnx_first_crack_detector_backend(
         session=create_session(artifacts.onnx_model.local_path, config.onnx_threads),
         feature_extractor=create_feature_extractor(artifacts.feature_extractor_config.local_path),
         preprocessor_config=preprocessor_config,
+        confidence_threshold=config.confidence_threshold,
     )
 
 
@@ -422,6 +475,25 @@ def _validate_optional_confidence(confidence: float | None) -> float | None:
     if not math.isfinite(normalized) or not 0.0 <= normalized <= 1.0:
         raise FirstCrackDetectorError("detector output confidence must be between 0 and 1.")
     return normalized
+
+
+def _validate_confirmation_config(config: FirstCrackConfig) -> None:
+    if (
+        not math.isfinite(config.confidence_threshold)
+        or not 0.0 <= config.confidence_threshold <= 1.0
+    ):
+        raise FirstCrackDetectorError(
+            "first_crack.confidence_threshold must be finite and between 0 and 1."
+        )
+    if config.min_positive_windows <= 0:
+        raise FirstCrackDetectorError("first_crack.min_positive_windows must be greater than 0.")
+    if (
+        not math.isfinite(config.confirmation_window_seconds)
+        or config.confirmation_window_seconds <= 0
+    ):
+        raise FirstCrackDetectorError(
+            "first_crack.confirmation_window_seconds must be greater than 0."
+        )
 
 
 def _load_onnx_preprocessor_config(path: Path) -> OnnxPreprocessorConfig:

--- a/src/coffee_roaster_mcp/exports.py
+++ b/src/coffee_roaster_mcp/exports.py
@@ -223,19 +223,39 @@ def _event_row(*, session: RoastSession, event: RoastEvent) -> dict[str, Any]:
     }
 
 
-def _summary_first_crack_model(session: RoastSession) -> dict[str, str | None]:
+def _summary_first_crack_model(session: RoastSession) -> dict[str, EventPayloadValue | None]:
     """Return first-crack model metadata for summary export."""
     payload = _first_crack_payload_from(session.event_timeline)
     return {
         "repo_id": _string_payload_value(payload.get("repo_id")),
         "revision": _string_payload_value(payload.get("revision")),
         "precision": _string_payload_value(payload.get("precision")),
+        "onnx_model_filename": _string_payload_value(payload.get("onnx_model_filename")),
+        "feature_extractor_filename": _string_payload_value(
+            payload.get("feature_extractor_filename")
+        ),
+        "confidence": _number_payload_value(payload.get("confidence")),
+        "confidence_threshold": _number_payload_value(payload.get("confidence_threshold")),
+        "min_positive_windows": _integer_payload_value(payload.get("min_positive_windows")),
+        "confirmation_window_seconds": _number_payload_value(
+            payload.get("confirmation_window_seconds")
+        ),
     }
 
 
 def _string_payload_value(value: EventPayloadValue | None) -> str | None:
     """Return a payload value only when it is string metadata."""
     return value if isinstance(value, str) else None
+
+
+def _number_payload_value(value: EventPayloadValue | None) -> float | int | None:
+    """Return a payload value only when it is numeric metadata."""
+    return value if isinstance(value, (float, int)) and not isinstance(value, bool) else None
+
+
+def _integer_payload_value(value: EventPayloadValue | None) -> int | None:
+    """Return a payload value only when it is integer metadata."""
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
 def _csv_rows(

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -444,6 +444,71 @@ def test_audio_capture_pipeline_feeds_detector_windows_from_mock_input() -> None
     assert [window.started_at_monotonic_seconds for window in windows] == [101.0, 102.0]
 
 
+def test_audio_capture_pipeline_emits_overlapping_windows_from_mock_input() -> None:
+    audio_input = FiniteAudioInput(tuple(float(value) for value in range(10)))
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device="mock-mic",
+            sample_rate=4,
+            window_seconds=1.0,
+            overlap=0.5,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().emitted_window_count == 4)
+    pipeline.stop()
+
+    windows = pipeline.drain_windows()
+    assert [window.sequence_number for window in windows] == [0, 1, 2, 3]
+    assert [window.samples for window in windows] == [
+        (0.0, 1.0, 2.0, 3.0),
+        (2.0, 3.0, 4.0, 5.0),
+        (4.0, 5.0, 6.0, 7.0),
+        (6.0, 7.0, 8.0, 9.0),
+    ]
+
+
+def test_detector_paced_wav_replay_emits_overlapping_source_timeline(tmp_path: Path) -> None:
+    wav_path = tmp_path / "overlap.wav"
+    _write_pcm16_wav(
+        wav_path,
+        sample_rate=4,
+        channel_count=1,
+        samples=tuple(range(10)),
+    )
+    pipeline = build_audio_capture_pipeline(
+        AudioConfig(
+            source="wav",
+            sample_rate=4,
+            wav_path=wav_path,
+            replay_mode="detector_paced",
+            window_seconds=1.0,
+            overlap=0.5,
+        ),
+        monotonic_now=lambda: 100.0,
+    )
+
+    pipeline.start()
+    windows = pipeline.drain_windows()
+
+    assert [window.sequence_number for window in windows] == [0, 1, 2, 3]
+    assert [window.started_at_monotonic_seconds for window in windows] == [
+        100.0,
+        100.5,
+        101.0,
+        101.5,
+    ]
+    assert [window.samples for window in windows] == [
+        (0.0, 1 / 32768.0, 2 / 32768.0, 3 / 32768.0),
+        (2 / 32768.0, 3 / 32768.0, 4 / 32768.0, 5 / 32768.0),
+        (4 / 32768.0, 5 / 32768.0, 6 / 32768.0, 7 / 32768.0),
+        (6 / 32768.0, 7 / 32768.0, 8 / 32768.0, 9 / 32768.0),
+    ]
+
+
 def test_audio_capture_pipeline_drops_windows_when_detector_queue_is_full() -> None:
     audio_input = FiniteAudioInput(tuple(float(value) for value in range(12)))
     pipeline = AudioCapturePipeline(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,10 +22,15 @@ def test_default_config_allows_mock_run_without_file(
     assert config.first_crack.mode == "disabled"
     assert config.first_crack.repo_id == "syamaner/coffee-first-crack-detection"
     assert config.first_crack.precision == "int8"
+    assert config.first_crack.confidence_threshold == 0.9
+    assert config.first_crack.min_positive_windows == 1
+    assert config.first_crack.confirmation_window_seconds == 20.0
     assert config.audio.source == "microphone"
     assert config.audio.wav_path is None
     assert config.audio.replay_mode == "realtime"
     assert config.audio.window_seconds == 1.0
+    assert config.audio.overlap == 0.0
+    assert config.audio.hop_seconds is None
     assert config.logging.log_dir == Path("./logs")
     assert config.logging.sample_interval_seconds == 5.0
     assert config.logging.export_formats == ("jsonl", "csv", "summary")
@@ -57,11 +62,15 @@ first_crack:
   precision: " fp32 "
   local_model_dir: ./models/fp32
   onnx_threads: 4
+  confidence_threshold: 0.6
+  min_positive_windows: 5
+  confirmation_window_seconds: 20.0
   allow_manual_override: false
 audio:
   input_device: roast-mic
   sample_rate: 48000
   window_seconds: 10.0
+  overlap: 0.7
 logging:
   log_dir: ./roast-logs
   sample_interval_seconds: 0.5
@@ -91,6 +100,9 @@ session:
     assert config.first_crack.precision == "fp32"
     assert config.first_crack.local_model_dir == Path("./models/fp32")
     assert config.first_crack.onnx_threads == 4
+    assert config.first_crack.confidence_threshold == 0.6
+    assert config.first_crack.min_positive_windows == 5
+    assert config.first_crack.confirmation_window_seconds == 20.0
     assert config.first_crack.allow_manual_override is False
     assert config.audio.source == "microphone"
     assert config.audio.input_device == "roast-mic"
@@ -98,6 +110,8 @@ session:
     assert config.audio.wav_path is None
     assert config.audio.replay_mode == "realtime"
     assert config.audio.window_seconds == 10.0
+    assert config.audio.overlap == 0.7
+    assert config.audio.hop_seconds is None
     assert config.logging.log_dir == Path("./roast-logs")
     assert config.logging.sample_interval_seconds == 0.5
     assert config.logging.export_formats == ("jsonl", "summary")
@@ -155,12 +169,17 @@ logging:
             "COFFEE_FIRST_CRACK_PRECISION": "fp32 ",
             "COFFEE_FIRST_CRACK_LOCAL_MODEL_DIR": "/models/env",
             "COFFEE_FIRST_CRACK_ONNX_THREADS": "8",
+            "COFFEE_FIRST_CRACK_CONFIDENCE_THRESHOLD": "0.7",
+            "COFFEE_FIRST_CRACK_MIN_POSITIVE_WINDOWS": "3",
+            "COFFEE_FIRST_CRACK_CONFIRMATION_WINDOW_SECONDS": "30",
             "COFFEE_AUDIO_SOURCE": "microphone",
             "COFFEE_AUDIO_INPUT_DEVICE": "env-mic",
             "COFFEE_AUDIO_SAMPLE_RATE": "16000",
             "COFFEE_AUDIO_WAV_PATH": "",
             "COFFEE_AUDIO_REPLAY_MODE": "realtime",
             "COFFEE_AUDIO_WINDOW_SECONDS": "2.5",
+            "COFFEE_AUDIO_OVERLAP": "0.25",
+            "COFFEE_AUDIO_HOP_SECONDS": "1.25",
             "COFFEE_ROAST_LOG_DIR": "/tmp/roasts",
             "COFFEE_AUTO_T0_DROP_THRESHOLD_C": "30",
         },
@@ -175,12 +194,17 @@ logging:
     assert config.first_crack.precision == "fp32"
     assert config.first_crack.local_model_dir == Path("/models/env")
     assert config.first_crack.onnx_threads == 8
+    assert config.first_crack.confidence_threshold == 0.7
+    assert config.first_crack.min_positive_windows == 3
+    assert config.first_crack.confirmation_window_seconds == 30.0
     assert config.audio.source == "microphone"
     assert config.audio.input_device == "env-mic"
     assert config.audio.sample_rate == 16_000
     assert config.audio.wav_path is None
     assert config.audio.replay_mode == "realtime"
     assert config.audio.window_seconds == 2.5
+    assert config.audio.overlap == 0.25
+    assert config.audio.hop_seconds == 1.25
     assert config.logging.log_dir == Path("/tmp/roasts")
     assert config.session.auto_t0_drop_threshold_c == 30.0
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -240,6 +240,75 @@ def test_invalid_audio_source_fails(tmp_path: Path) -> None:
         load_config(config_path, environ={})
 
 
+@pytest.mark.parametrize(
+    ("yaml_body", "message"),
+    (
+        ("first_crack:\n  confidence_threshold: 1.5\n", "first_crack.confidence_threshold"),
+        ("first_crack:\n  confidence_threshold: nan\n", "first_crack.confidence_threshold"),
+        ("first_crack:\n  min_positive_windows: 0\n", "first_crack.min_positive_windows"),
+        (
+            "first_crack:\n  confirmation_window_seconds: -1\n",
+            "first_crack.confirmation_window_seconds",
+        ),
+        ("audio:\n  overlap: 1.0\n", "audio.overlap"),
+        ("audio:\n  overlap: -0.1\n", "audio.overlap"),
+        ("audio:\n  hop_seconds: 0\n", "audio.hop_seconds"),
+        (
+            "audio:\n  window_seconds: 1.0\n  hop_seconds: 2.0\n",
+            "audio.hop_seconds",
+        ),
+    ),
+)
+def test_invalid_detector_window_config_fails(
+    tmp_path: Path,
+    yaml_body: str,
+    message: str,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(yaml_body, encoding="utf-8")
+
+    with pytest.raises(ConfigError, match=message):
+        load_config(config_path, environ={})
+
+
+@pytest.mark.parametrize(
+    ("env", "message"),
+    (
+        (
+            {"COFFEE_FIRST_CRACK_CONFIDENCE_THRESHOLD": "-0.1"},
+            "COFFEE_FIRST_CRACK_CONFIDENCE_THRESHOLD",
+        ),
+        (
+            {"COFFEE_FIRST_CRACK_MIN_POSITIVE_WINDOWS": "0"},
+            "COFFEE_FIRST_CRACK_MIN_POSITIVE_WINDOWS",
+        ),
+        (
+            {"COFFEE_FIRST_CRACK_CONFIRMATION_WINDOW_SECONDS": "nan"},
+            "COFFEE_FIRST_CRACK_CONFIRMATION_WINDOW_SECONDS",
+        ),
+        ({"COFFEE_AUDIO_OVERLAP": "1.0"}, "COFFEE_AUDIO_OVERLAP"),
+        ({"COFFEE_AUDIO_HOP_SECONDS": "-1"}, "COFFEE_AUDIO_HOP_SECONDS"),
+        (
+            {
+                "COFFEE_AUDIO_WINDOW_SECONDS": "1.0",
+                "COFFEE_AUDIO_HOP_SECONDS": "2.0",
+            },
+            "COFFEE_AUDIO_HOP_SECONDS",
+        ),
+    ),
+)
+def test_invalid_detector_window_environment_overrides_fail(
+    tmp_path: Path,
+    env: dict[str, str],
+    message: str,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("roaster:\n  driver: mock\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match=message):
+        load_config(config_path, environ=env)
+
+
 def test_invalid_auto_t0_threshold_fails(tmp_path: Path) -> None:
     config_path = tmp_path / "coffee-roaster-mcp.yaml"
     config_path.write_text("session:\n  auto_t0_drop_threshold_c: 0\n", encoding="utf-8")

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -159,6 +159,11 @@ def test_detector_adapter_maps_confirmed_output_to_first_crack_event() -> None:
     assert event.onnx_model_filename == "onnx/fp32/model.onnx"
     assert event.feature_extractor_filename == "onnx/fp32/preprocessor_config.json"
     assert event.window_sequence_number == 7
+    assert event.confirmed_by_window_sequence_number == 7
+    assert event.positive_window_count == 1
+    assert event.confidence_threshold == 0.9
+    assert event.min_positive_windows == 1
+    assert event.confirmation_window_seconds == 20.0
     assert event.detected_at_inferred is False
     assert event.payload() == {
         "source": "first_crack_detector",
@@ -169,6 +174,11 @@ def test_detector_adapter_maps_confirmed_output_to_first_crack_event() -> None:
         "onnx_model_filename": "onnx/fp32/model.onnx",
         "feature_extractor_filename": "onnx/fp32/preprocessor_config.json",
         "window_sequence_number": 7,
+        "confirmed_by_window_sequence_number": 7,
+        "positive_window_count": 1,
+        "confidence_threshold": 0.9,
+        "min_positive_windows": 1,
+        "confirmation_window_seconds": 20.0,
         "confidence": 0.87,
     }
 
@@ -189,6 +199,81 @@ def test_detector_adapter_uses_window_end_timestamp_when_output_has_no_timestamp
     assert event.confidence is None
     assert event.detected_at_inferred is True
     assert "confidence" not in event.payload()
+
+
+def test_detector_adapter_confirms_from_recent_positive_windows() -> None:
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.61),
+            FirstCrackDetectorOutput(confirmed=False, confidence=0.10),
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.82),
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.91),
+        )
+    )
+    adapter = build_first_crack_detector_adapter(
+        FirstCrackConfig(
+            confidence_threshold=0.6,
+            min_positive_windows=3,
+            confirmation_window_seconds=20.0,
+        ),
+        _resolved_detector_artifacts(),
+        backend,
+    )
+
+    first = adapter.process_window(
+        _audio_window(sequence_number=10, started_at_monotonic_seconds=100.0)
+    )
+    second = adapter.process_window(
+        _audio_window(sequence_number=11, started_at_monotonic_seconds=103.0)
+    )
+    third = adapter.process_window(
+        _audio_window(sequence_number=12, started_at_monotonic_seconds=106.0)
+    )
+    confirmed = adapter.process_window(
+        _audio_window(sequence_number=13, started_at_monotonic_seconds=109.0)
+    )
+
+    assert first is None
+    assert second is None
+    assert third is None
+    assert confirmed is not None
+    assert confirmed.detected_at_monotonic_seconds == 101.0
+    assert confirmed.window_sequence_number == 10
+    assert confirmed.confirmed_by_window_sequence_number == 13
+    assert confirmed.positive_window_count == 3
+    assert confirmed.confidence == 0.61
+
+
+def test_detector_adapter_prunes_old_positive_windows_before_confirmation() -> None:
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.91),
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.92),
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.93),
+        )
+    )
+    adapter = build_first_crack_detector_adapter(
+        FirstCrackConfig(min_positive_windows=2, confirmation_window_seconds=5.0),
+        _resolved_detector_artifacts(),
+        backend,
+    )
+
+    first = adapter.process_window(
+        _audio_window(sequence_number=1, started_at_monotonic_seconds=100.0)
+    )
+    second = adapter.process_window(
+        _audio_window(sequence_number=2, started_at_monotonic_seconds=106.0)
+    )
+    confirmed = adapter.process_window(
+        _audio_window(sequence_number=3, started_at_monotonic_seconds=109.0)
+    )
+
+    assert first is None
+    assert second is None
+    assert confirmed is not None
+    assert confirmed.detected_at_monotonic_seconds == 107.0
+    assert confirmed.window_sequence_number == 2
+    assert confirmed.confirmed_by_window_sequence_number == 3
 
 
 @pytest.mark.parametrize("confidence", (-0.01, 1.01, float("nan")))
@@ -327,6 +412,21 @@ def test_released_onnx_backend_returns_unconfirmed_below_threshold(tmp_path: Pat
     assert output.confirmed is False
     assert output.confidence is not None
     assert abs(output.confidence - 0.00033535) < 0.000001
+
+
+def test_released_onnx_backend_uses_configured_confidence_threshold(tmp_path: Path) -> None:
+    backend = build_released_onnx_first_crack_detector_backend(
+        FirstCrackConfig(mode="audio", confidence_threshold=0.6),
+        _resolved_detector_artifacts_with_files(tmp_path),
+        session_factory=lambda _path, _threads: FakeOnnxSession(((0.0, 0.5),)),
+        feature_extractor_factory=lambda _path: FakeFeatureExtractor(),
+    )
+
+    output = backend.detect(_audio_window(sample_rate=16_000))
+
+    assert output.confirmed is True
+    assert output.confidence is not None
+    assert abs(output.confidence - 0.622459) < 0.000001
 
 
 def test_released_onnx_backend_rejects_non_audio_mode(tmp_path: Path) -> None:

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -72,6 +72,12 @@ EXPECTED_FIRST_CRACK_MODEL_KEYS = {
     "repo_id",
     "revision",
     "precision",
+    "onnx_model_filename",
+    "feature_extractor_filename",
+    "confidence",
+    "confidence_threshold",
+    "min_positive_windows",
+    "confirmation_window_seconds",
 }
 
 
@@ -111,6 +117,11 @@ def test_snapshot_export_preserves_first_crack_detector_metadata(tmp_path: Path)
         "onnx_model_filename": "onnx/int8/model_quantized.onnx",
         "feature_extractor_filename": "onnx/int8/preprocessor_config.json",
         "window_sequence_number": 9,
+        "confirmed_by_window_sequence_number": 13,
+        "positive_window_count": 5,
+        "confidence_threshold": 0.6,
+        "min_positive_windows": 5,
+        "confirmation_window_seconds": 20.0,
         "confidence": 0.93,
     }
     clock.monotonic_value = 140.0
@@ -156,6 +167,12 @@ def test_snapshot_export_preserves_first_crack_detector_metadata(tmp_path: Path)
         "repo_id": "syamaner/coffee-first-crack-detection",
         "revision": "v0.1.0",
         "precision": "int8",
+        "onnx_model_filename": "onnx/int8/model_quantized.onnx",
+        "feature_extractor_filename": "onnx/int8/preprocessor_config.json",
+        "confidence": 0.93,
+        "confidence_threshold": 0.6,
+        "min_positive_windows": 5,
+        "confirmation_window_seconds": 20.0,
     }
     assert summary["metrics"]["development_time_seconds"] == 32.75
     assert summary["metrics"]["development_percent"] == 50.385
@@ -213,6 +230,12 @@ def test_snapshot_export_summary_includes_plan_required_schema(
         "repo_id": "syamaner/coffee-first-crack-detection",
         "revision": "release-2026-05",
         "precision": "fp32",
+        "onnx_model_filename": None,
+        "feature_extractor_filename": None,
+        "confidence": 0.91,
+        "confidence_threshold": None,
+        "min_positive_windows": None,
+        "confirmation_window_seconds": None,
     }
 
 

--- a/tests/test_first_crack_integration.py
+++ b/tests/test_first_crack_integration.py
@@ -209,6 +209,11 @@ def test_confirmed_detector_output_records_first_crack_event_once() -> None:
         "onnx_model_filename": "onnx/int8/model_quantized.onnx",
         "feature_extractor_filename": "onnx/int8/preprocessor_config.json",
         "window_sequence_number": 11,
+        "confirmed_by_window_sequence_number": 11,
+        "positive_window_count": 1,
+        "confidence_threshold": 0.9,
+        "min_positive_windows": 1,
+        "confirmation_window_seconds": 20.0,
         "confidence": 0.91,
     }
     assert len(first_result.session.event_timeline) == 2

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -344,6 +344,56 @@ def test_audio_runtime_keeps_pending_status_when_detector_does_not_confirm() -> 
     assert [event.kind for event in session.event_timeline] == ["beans_added"]
 
 
+def test_audio_runtime_records_earliest_positive_after_confirmation() -> None:
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    clock.monotonic_value = 500.0
+    store.record_event(session, "beans_added")
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.61),
+            FirstCrackDetectorOutput(confirmed=False, confidence=0.2),
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.82),
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.91),
+        )
+    )
+    pipeline = FakeAudioPipeline(
+        (
+            _audio_window(sequence_number=1, started_at_monotonic_seconds=503.0),
+            _audio_window(sequence_number=2, started_at_monotonic_seconds=506.0),
+            _audio_window(sequence_number=3, started_at_monotonic_seconds=509.0),
+            _audio_window(sequence_number=4, started_at_monotonic_seconds=512.0),
+        )
+    )
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(
+            first_crack=FirstCrackConfig(
+                mode="audio",
+                confidence_threshold=0.6,
+                min_positive_windows=3,
+                confirmation_window_seconds=20.0,
+            )
+        ),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            backend,
+        ),
+    )
+
+    runtime.start_for_session(session)
+    clock.monotonic_value = 515.0
+    detected = runtime.process_available_windows(session_store=store, session=session)
+
+    assert detected.status == "detected"
+    assert session.first_crack_monotonic_seconds == 4.0
+    assert session.event_timeline[-1].payload["window_sequence_number"] == 1
+    assert session.event_timeline[-1].payload["confirmed_by_window_sequence_number"] == 4
+    assert session.event_timeline[-1].payload["positive_window_count"] == 3
+
+
 def test_detector_paced_wav_replay_preserves_source_audio_timeline() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -483,6 +483,12 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
             "repo_id": None,
             "revision": None,
             "precision": None,
+            "onnx_model_filename": None,
+            "feature_extractor_filename": None,
+            "confidence": None,
+            "confidence_threshold": None,
+            "min_positive_windows": None,
+            "confirmation_window_seconds": None,
         }
         assert export_summary["metrics"]["development_percent"] is not None
         assert export_summary["metrics"]["roast_elapsed_seconds"] is not None


### PR DESCRIPTION
## Summary
- add configurable first-crack threshold, min-positive-window confirmation, confirmation window, and audio overlap/hop settings
- emit overlapping realtime and detector-paced WAV windows, then confirm first crack from recent positive windows before recording one event
- extend replay validation and exports so JSONL, CSV, and summary metadata include detector artifacts, confidence, and confirmation settings
- tighten config-load validation for impossible hop/window settings and document the new public config knobs
- update docs/state and add the E7-S6a session summary routing next to E7-S6 / #112

Closes #150

## Validation
- `./.venv/bin/python -m pytest tests/test_config.py tests/test_audio.py tests/test_detector.py tests/test_first_crack_runtime.py tests/test_first_crack_integration.py tests/test_exports.py`: 119 passed
- `./.venv/bin/python scripts/validate_first_crack_wav_replay.py --timeout-seconds 180`: passed; detected first crack at `10.017558290999885s` after T0 inside label interval `3.82710390663442-20.0s`, with 3 emitted, 3 processed, 0 dropped windows
- `./.venv/bin/python -m pytest`: 394 passed
- `./.venv/bin/python -m ruff check .`: passed
- `./.venv/bin/python -m ruff format --check .`: passed
- `./.venv/bin/python -m pyright`: 0 errors
- `./.venv/bin/coffee-roaster-mcp --help`: passed
- `./.venv/bin/coffee-roaster-mcp --version`: `coffee-roaster-mcp 0.1.2`

## Out of scope
- live Hottop validation
- real microphone validation
- full end-to-end Warp manual roast validation
- model training/export/sync
- live PyPI/MCP Registry publishing
- hardware-ready release labeling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable first-crack confirmation: confidence threshold, minimum positive windows, and confirmation window duration
  * Overlapping audio windows with tunable overlap/hop for finer detector timing
  * Session/export summaries now include richer first-crack model & confirmation metadata

* **Documentation**
  * Updated guides and examples for first-crack tuning, audio overlap/hop, and detector-paced WAV replay
  * New sliding-window validation session notes

* **Tests**
  * Added coverage for overlapping windows and confirmation-based detection logic

* **Tools**
  * Validation script emits expanded summary fields and an opt-in old-timing cutoff option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->