### PR TITLE
mic-check: prove the configured microphone captures real audio (#158)

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.syamaner/coffee-roaster-mcp",
   "title": "RoastPilot",
   "description": "RoastPilot controls coffee roasting sessions through local stdio MCP tools and exports logs.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "websiteUrl": "https://github.com/syamaner/coffee-roaster-mcp#readme",
   "repository": {
     "url": "https://github.com/syamaner/coffee-roaster-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "coffee-roaster-mcp",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "runtimeHint": "uvx",
       "packageArguments": [
         {

--- a/src/coffee_roaster_mcp/__init__.py
+++ b/src/coffee_roaster_mcp/__init__.py
@@ -1,3 +1,3 @@
 """RoastPilot MCP server package."""
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/src/coffee_roaster_mcp/cli.py
+++ b/src/coffee_roaster_mcp/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -13,6 +14,8 @@ from coffee_roaster_mcp.hottop_validation import (
     run_hottop_validation,
 )
 from coffee_roaster_mcp.mcp_server import run_stdio_server
+from coffee_roaster_mcp.mic_check import DEFAULT_RMS_FLOOR, MicCheckOptions, run_mic_check
+from coffee_roaster_mcp.mic_check import report_to_json as mic_report_to_json
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -95,6 +98,35 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Run the emergency-stop command as the final control step.",
     )
+
+    mic_parser = subparsers.add_parser(
+        "mic-check",
+        help="Prove the configured microphone is capturing real audio (pre-roast).",
+    )
+    mic_parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Optional path to a coffee-roaster-mcp YAML config file (selects the device).",
+    )
+    mic_parser.add_argument(
+        "--duration-seconds",
+        type=float,
+        default=5.0,
+        help="How long to capture before reporting; make noise during this window.",
+    )
+    mic_parser.add_argument(
+        "--rms-floor",
+        type=float,
+        default=DEFAULT_RMS_FLOOR,
+        help="RMS level above which captured audio counts as real signal.",
+    )
+    mic_parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional JSON evidence file to write.",
+    )
     return parser
 
 
@@ -123,6 +155,33 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         print(report_to_json(report), end="")
         if not report.hardware_ready_release_label_allowed:
+            return 1
+    if args.command == "mic-check":
+        print(
+            f"Listening on the configured microphone for {args.duration_seconds:.0f}s — "
+            "make noise (snap / speak / tap)…",
+            file=sys.stderr,
+            flush=True,
+        )
+
+        def _meter(rms: float, peak: float) -> None:
+            bar = "#" * min(40, int(rms / DEFAULT_RMS_FLOOR * 4))
+            print(f"  level {rms:7.4f} peak {peak:7.4f} |{bar}", file=sys.stderr, flush=True)
+
+        report = run_mic_check(
+            MicCheckOptions(
+                config_path=args.config,
+                duration_seconds=args.duration_seconds,
+                rms_floor=args.rms_floor,
+            ),
+            on_chunk=_meter,
+        )
+        if args.output is not None:
+            args.output.write_text(mic_report_to_json(report), encoding="utf-8")
+        print(mic_report_to_json(report))
+        verdict = "PASS — microphone is capturing real audio" if report.passed else "FAIL"
+        print(f"\n{verdict}", file=sys.stderr)
+        if not report.passed:
             return 1
     return 0
 

--- a/src/coffee_roaster_mcp/cli.py
+++ b/src/coffee_roaster_mcp/cli.py
@@ -164,8 +164,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             flush=True,
         )
 
+        floor = args.rms_floor if args.rms_floor > 0 else DEFAULT_RMS_FLOOR
+
         def _meter(rms: float, peak: float) -> None:
-            bar = "#" * min(40, int(rms / DEFAULT_RMS_FLOOR * 4))
+            bar = "#" * min(40, int(rms / floor * 4))
             print(f"  level {rms:7.4f} peak {peak:7.4f} |{bar}", file=sys.stderr, flush=True)
 
         report = run_mic_check(

--- a/src/coffee_roaster_mcp/mic_check.py
+++ b/src/coffee_roaster_mcp/mic_check.py
@@ -86,8 +86,13 @@ class MicCheckReport:
         rms_mean: Mean RMS across the captured chunks.
         peak_amplitude: Largest absolute sample seen.
         audio_detected: Whether `rms_max` cleared `rms_floor` (real signal).
-        error: Capture/enumeration error message, if any.
-        passed: Device available AND opened AND real audio detected.
+        device_warning: Non-fatal note, e.g. the configured device did not match
+            an input by name (it may still be a valid index / platform id).
+        error: Capture/enumeration/configuration error message, if any.
+        passed: Real audio was captured above the floor. The capture is bound to
+            the configured device, so this implies the device opened and
+            delivered signal; name-matching is diagnostic only (a numeric/index
+            device id need not match a name).
     """
 
     source: str
@@ -100,6 +105,7 @@ class MicCheckReport:
     rms_mean: float = 0.0
     peak_amplitude: float = 0.0
     audio_detected: bool = False
+    device_warning: str | None = None
     error: str | None = None
     passed: bool = False
 
@@ -112,10 +118,15 @@ def _default_device_lister() -> Sequence[str]:
         raise AudioCaptureError(
             "Microphone enumeration requires the sounddevice package and PortAudio runtime."
         ) from exc
-    devices: Any = sounddevice.query_devices()
-    return [
-        str(device["name"]) for device in devices if int(device.get("max_input_channels", 0)) > 0
-    ]
+    try:
+        devices: Any = sounddevice.query_devices()
+        return [
+            str(device["name"])
+            for device in devices
+            if int(device.get("max_input_channels", 0)) > 0
+        ]
+    except Exception as exc:  # noqa: BLE001 - PortAudio backend errors vary by platform.
+        raise AudioCaptureError(f"Microphone enumeration failed: {exc}") from exc
 
 
 def _match_device(selector: str | None, available: Sequence[str]) -> str | None:
@@ -163,15 +174,44 @@ def run_mic_check(
     factory = audio_input_factory or build_configured_audio_input
     lister = device_lister or _default_device_lister
 
+    # Reject configurations that would make a "pass" meaningless.
+    if settings.source != "microphone":
+        return MicCheckReport(
+            source=settings.source,
+            configured_device=settings.input_device,
+            matched_device=None,
+            error=(
+                f"mic-check requires audio.source=microphone; configured source is "
+                f"{settings.source!r}. A wav source would 'pass' from a file, not the mic."
+            ),
+        )
+    if options.rms_floor <= 0:
+        return MicCheckReport(
+            source=settings.source,
+            configured_device=settings.input_device,
+            matched_device=None,
+            error=(
+                f"rms_floor must be > 0 (got {options.rms_floor}); "
+                "a non-positive floor passes silence."
+            ),
+        )
+
     available: list[str] = []
     matched: str | None = None
     device_found = False
+    device_warning: str | None = None
     try:
         available = list(lister())
         matched = _match_device(settings.input_device, available)
         device_found = (matched is not None) or (
             settings.input_device is None and len(available) > 0
         )
+        if settings.input_device is not None and matched is None and available:
+            device_warning = (
+                f"configured device {settings.input_device!r} did not match an input by name "
+                f"(available: {available}); if it is a device index or platform id this is fine, "
+                "otherwise verify the device is connected."
+            )
     except AudioCaptureError as exc:
         return MicCheckReport(
             source=settings.source,
@@ -208,6 +248,7 @@ def run_mic_check(
             available_input_devices=available,
             device_found=device_found,
             chunks_read=len(rms_values),
+            device_warning=device_warning,
             error=str(exc),
         )
 
@@ -225,7 +266,11 @@ def run_mic_check(
         rms_mean=round(rms_mean, 6),
         peak_amplitude=round(peak, 6),
         audio_detected=audio_detected,
-        passed=device_found and audio_detected,
+        device_warning=device_warning,
+        # Real audio captured above the floor. The capture is bound to the
+        # configured device, so this implies the device opened + delivered
+        # signal; name-matching (device_found) is diagnostic only.
+        passed=audio_detected,
     )
 
 

--- a/src/coffee_roaster_mcp/mic_check.py
+++ b/src/coffee_roaster_mcp/mic_check.py
@@ -1,0 +1,234 @@
+"""Live-microphone pre-roast proof.
+
+The first-crack detector is only as good as the audio reaching it. A device that
+will not open surfaces as `unavailable`/`faulted`, but a device that *opens and
+delivers silence* (OS microphone permission blocked, the device muted, or grabbed
+by another process) is indistinguishable from "no crack yet" via the pipeline's
+window counters — they advance on silence too, and per-window confidence is only
+emitted on a detection candidate. So nothing in the normal run proves *real audio
+is flowing*.
+
+This module closes that gap with a guarded, operator-run check that uses the same
+capture path as `serve` (the configured device, sample rate) and reports a signal
+level that **responds to sound**: the operator runs it, makes noise (snap / speak /
+tap), and a non-trivial RMS proves capture is live and unblocked. A flat-floor
+level means silence (blocked/muted); a capture error means the device would not
+open. It is injectable end to end (audio input + device lister) so the logic is
+unit-tested without hardware; the decisive proof is the operator's real run.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import json
+import math
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+from coffee_roaster_mcp.audio import (
+    AudioCaptureError,
+    AudioInput,
+    audio_capture_settings_from_config,
+    build_configured_audio_input,
+)
+from coffee_roaster_mcp.config import load_config
+
+#: RMS above which captured audio is treated as real signal (not silence/zeros).
+#: Deliberately equal to the first-crack detector's own energy noise gate: the
+#: coffee-first-crack-detection inference gates any window with
+#: ``sqrt(mean(window**2)) < 0.01`` to probability 0.0 (silence). So audio below
+#: this floor would be ignored by detection regardless — proving the mic clears
+#: it proves the detector will actually use the signal. Float samples are in
+#: [-1, 1]; a snap / speech goes well over it, a blocked/muted device stays under.
+DEFAULT_RMS_FLOOR = 0.01
+#: Per-read chunk duration; short enough for a responsive live meter.
+_CHUNK_SECONDS = 0.1
+
+AudioInputFactory = Callable[[Any], AudioInput]
+DeviceLister = Callable[[], Sequence[str]]
+
+
+@dataclass(frozen=True)
+class MicCheckOptions:
+    """Options for a microphone capture check.
+
+    Attributes:
+        config_path: Optional coffee-roaster-mcp YAML config path; the audio
+            section selects the device and sample rate exactly as `serve` would.
+        duration_seconds: How long to capture before reporting.
+        rms_floor: RMS level above which captured audio counts as real signal.
+        output_path: Optional JSON evidence file to write.
+    """
+
+    config_path: Path | None = None
+    duration_seconds: float = 5.0
+    rms_floor: float = DEFAULT_RMS_FLOOR
+    output_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class MicCheckReport:
+    """Evidence that the configured microphone is capturing real audio.
+
+    Attributes:
+        source: Configured audio source (`microphone` / `wav`).
+        configured_device: The configured input-device selector, or `None` for
+            the system default.
+        matched_device: The available input device whose name matched the
+            selector, or `None` if no match / system default.
+        available_input_devices: Names of all input-capable devices found.
+        device_found: Whether the configured device (or a default) is available.
+        chunks_read: Number of audio chunks captured.
+        rms_max: Peak RMS across the captured chunks.
+        rms_mean: Mean RMS across the captured chunks.
+        peak_amplitude: Largest absolute sample seen.
+        audio_detected: Whether `rms_max` cleared `rms_floor` (real signal).
+        error: Capture/enumeration error message, if any.
+        passed: Device available AND opened AND real audio detected.
+    """
+
+    source: str
+    configured_device: str | None
+    matched_device: str | None
+    available_input_devices: list[str] = field(default_factory=lambda: cast(list[str], []))
+    device_found: bool = False
+    chunks_read: int = 0
+    rms_max: float = 0.0
+    rms_mean: float = 0.0
+    peak_amplitude: float = 0.0
+    audio_detected: bool = False
+    error: str | None = None
+    passed: bool = False
+
+
+def _default_device_lister() -> Sequence[str]:
+    """Return the names of all input-capable audio devices via sounddevice."""
+    try:
+        sounddevice = importlib.import_module("sounddevice")
+    except (ImportError, OSError) as exc:
+        raise AudioCaptureError(
+            "Microphone enumeration requires the sounddevice package and PortAudio runtime."
+        ) from exc
+    devices: Any = sounddevice.query_devices()
+    return [
+        str(device["name"]) for device in devices if int(device.get("max_input_channels", 0)) > 0
+    ]
+
+
+def _match_device(selector: str | None, available: Sequence[str]) -> str | None:
+    """Match the configured selector (substring, case-insensitive) to a device."""
+    if selector is None:
+        return None
+    needle = selector.casefold()
+    for name in available:
+        if needle in name.casefold():
+            return name
+    return None
+
+
+def _rms(samples: Sequence[float]) -> float:
+    """Root-mean-square of a sample chunk (0.0 for an empty chunk)."""
+    if not samples:
+        return 0.0
+    return math.sqrt(sum(sample * sample for sample in samples) / len(samples))
+
+
+def run_mic_check(
+    options: MicCheckOptions,
+    *,
+    audio_input_factory: AudioInputFactory | None = None,
+    device_lister: DeviceLister | None = None,
+    on_chunk: Callable[[float, float], None] | None = None,
+) -> MicCheckReport:
+    """Capture from the configured microphone and report whether real audio flows.
+
+    Args:
+        options: Check options (config, duration, floor).
+        audio_input_factory: Builds the :class:`AudioInput` from capture settings;
+            defaults to the real configured input. Injected in tests.
+        device_lister: Returns available input-device names; defaults to the real
+            sounddevice enumeration. Injected in tests.
+        on_chunk: Optional callback invoked per chunk with `(rms, peak)` for a
+            live meter.
+
+    Returns:
+        A :class:`MicCheckReport`. Never raises for capture/enumeration problems —
+        they are recorded in ``error`` with ``passed=False``.
+    """
+    config = load_config(path=options.config_path)
+    settings = audio_capture_settings_from_config(config.audio)
+    factory = audio_input_factory or build_configured_audio_input
+    lister = device_lister or _default_device_lister
+
+    available: list[str] = []
+    matched: str | None = None
+    device_found = False
+    try:
+        available = list(lister())
+        matched = _match_device(settings.input_device, available)
+        device_found = (matched is not None) or (
+            settings.input_device is None and len(available) > 0
+        )
+    except AudioCaptureError as exc:
+        return MicCheckReport(
+            source=settings.source,
+            configured_device=settings.input_device,
+            matched_device=None,
+            available_input_devices=available,
+            error=str(exc),
+        )
+
+    chunk_samples = max(1, round(settings.sample_rate * _CHUNK_SECONDS))
+    chunk_target = max(1, round(options.duration_seconds / _CHUNK_SECONDS))
+    rms_values: list[float] = []
+    peak = 0.0
+    try:
+        audio_input = factory(settings)
+        try:
+            for _ in range(chunk_target):
+                samples = audio_input.read_samples(chunk_samples)
+                chunk_rms = _rms(samples)
+                chunk_peak = max((abs(sample) for sample in samples), default=0.0)
+                rms_values.append(chunk_rms)
+                peak = max(peak, chunk_peak)
+                if on_chunk is not None:
+                    on_chunk(chunk_rms, chunk_peak)
+        finally:
+            close = getattr(audio_input, "close", None)
+            if callable(close):
+                close()
+    except AudioCaptureError as exc:
+        return MicCheckReport(
+            source=settings.source,
+            configured_device=settings.input_device,
+            matched_device=matched,
+            available_input_devices=available,
+            device_found=device_found,
+            chunks_read=len(rms_values),
+            error=str(exc),
+        )
+
+    rms_max = max(rms_values, default=0.0)
+    rms_mean = (sum(rms_values) / len(rms_values)) if rms_values else 0.0
+    audio_detected = rms_max >= options.rms_floor
+    return MicCheckReport(
+        source=settings.source,
+        configured_device=settings.input_device,
+        matched_device=matched,
+        available_input_devices=available,
+        device_found=device_found,
+        chunks_read=len(rms_values),
+        rms_max=round(rms_max, 6),
+        rms_mean=round(rms_mean, 6),
+        peak_amplitude=round(peak, 6),
+        audio_detected=audio_detected,
+        passed=device_found and audio_detected,
+    )
+
+
+def report_to_json(report: MicCheckReport) -> str:
+    """Serialize a :class:`MicCheckReport` to pretty JSON."""
+    return json.dumps(dataclasses.asdict(report), indent=2)

--- a/tests/test_mic_check.py
+++ b/tests/test_mic_check.py
@@ -75,8 +75,9 @@ def test_mic_check_fails_on_silence(tmp_path: Path) -> None:
     assert report.rms_max == 0.0
 
 
-def test_mic_check_fails_when_device_not_found(tmp_path: Path) -> None:
-    """The configured device not being among the inputs is a FAIL."""
+def test_mic_check_name_mismatch_is_diagnostic_not_a_gate(tmp_path: Path) -> None:
+    """A configured id that doesn't match a device NAME still passes if capture
+    delivers real audio (it may be a valid index/platform id) — but it warns."""
     report = run_mic_check(
         MicCheckOptions(
             config_path=_config(tmp_path, input_device="Nonexistent"), duration_seconds=0.3
@@ -86,7 +87,37 @@ def test_mic_check_fails_when_device_not_found(tmp_path: Path) -> None:
     )
     assert report.device_found is False
     assert report.matched_device is None
+    assert report.device_warning is not None  # surfaced for the operator
+    assert report.passed is True  # real audio captured — name-match is diagnostic only
+
+
+def test_mic_check_rejects_wav_source(tmp_path: Path) -> None:
+    """A wav source would 'pass' from a file, not the mic — reject it up front."""
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        "audio:\n  source: wav\n  wav_path: /tmp/x.wav\n  sample_rate: 16000\n",
+        encoding="utf-8",
+    )
+    report = run_mic_check(
+        MicCheckOptions(config_path=path, duration_seconds=0.3),
+        audio_input_factory=lambda _settings: ConstantAudioInput(0.2),
+        device_lister=lambda: _DEVICES,
+    )
     assert report.passed is False
+    assert report.error is not None
+    assert "microphone" in report.error
+
+
+def test_mic_check_rejects_nonpositive_floor(tmp_path: Path) -> None:
+    """A floor of 0 would pass silence — reject it."""
+    report = run_mic_check(
+        MicCheckOptions(config_path=_config(tmp_path), duration_seconds=0.3, rms_floor=0.0),
+        audio_input_factory=lambda _settings: ConstantAudioInput(0.0),
+        device_lister=lambda: _DEVICES,
+    )
+    assert report.passed is False
+    assert report.error is not None
+    assert "rms_floor" in report.error
 
 
 def test_mic_check_records_capture_error(tmp_path: Path) -> None:

--- a/tests/test_mic_check.py
+++ b/tests/test_mic_check.py
@@ -1,0 +1,143 @@
+"""Tests for the pre-roast microphone capture check."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from coffee_roaster_mcp.audio import AudioCaptureError
+from coffee_roaster_mcp.mic_check import (
+    MicCheckOptions,
+    report_to_json,
+    run_mic_check,
+)
+
+
+class ConstantAudioInput:
+    """Audio input that returns a fixed-amplitude chunk on every read."""
+
+    def __init__(self, amplitude: float) -> None:
+        self._amplitude = amplitude
+        self.closed = False
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        return tuple(self._amplitude for _ in range(sample_count))
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FailingAudioInput:
+    """Audio input that fails to open (device gone / OS-blocked)."""
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        raise AudioCaptureError("Could not open microphone audio source: boom")
+
+
+def _config(tmp_path: Path, *, input_device: str = "USB PnP") -> Path:
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        f'audio:\n  source: microphone\n  input_device: "{input_device}"\n  sample_rate: 16000\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+_DEVICES = ("Built-in Microphone", "USB PnP Audio Device", "Aggregate Device")
+
+
+def test_mic_check_passes_on_real_audio(tmp_path: Path) -> None:
+    """A matched device delivering non-silent audio is a PASS."""
+    report = run_mic_check(
+        MicCheckOptions(config_path=_config(tmp_path), duration_seconds=0.3),
+        audio_input_factory=lambda _settings: ConstantAudioInput(0.2),
+        device_lister=lambda: _DEVICES,
+    )
+    assert report.passed is True
+    assert report.audio_detected is True
+    assert report.device_found is True
+    assert report.matched_device == "USB PnP Audio Device"
+    assert report.rms_max >= 0.19  # ~0.2 constant amplitude
+    assert report.chunks_read == 3
+
+
+def test_mic_check_fails_on_silence(tmp_path: Path) -> None:
+    """A matched device delivering silence/zeros is a FAIL (the OS-blocked case)."""
+    report = run_mic_check(
+        MicCheckOptions(config_path=_config(tmp_path), duration_seconds=0.3),
+        audio_input_factory=lambda _settings: ConstantAudioInput(0.0),
+        device_lister=lambda: _DEVICES,
+    )
+    assert report.device_found is True  # device present + opened
+    assert report.audio_detected is False  # but no real signal
+    assert report.passed is False
+    assert report.rms_max == 0.0
+
+
+def test_mic_check_fails_when_device_not_found(tmp_path: Path) -> None:
+    """The configured device not being among the inputs is a FAIL."""
+    report = run_mic_check(
+        MicCheckOptions(
+            config_path=_config(tmp_path, input_device="Nonexistent"), duration_seconds=0.3
+        ),
+        audio_input_factory=lambda _settings: ConstantAudioInput(0.2),
+        device_lister=lambda: _DEVICES,
+    )
+    assert report.device_found is False
+    assert report.matched_device is None
+    assert report.passed is False
+
+
+def test_mic_check_records_capture_error(tmp_path: Path) -> None:
+    """A device that will not open surfaces as an error, not a crash."""
+    report = run_mic_check(
+        MicCheckOptions(config_path=_config(tmp_path), duration_seconds=0.3),
+        audio_input_factory=lambda _settings: FailingAudioInput(),
+        device_lister=lambda: _DEVICES,
+    )
+    assert report.passed is False
+    assert report.error is not None
+    assert "Could not open microphone" in report.error
+
+
+def test_mic_check_device_enumeration_error_is_reported(tmp_path: Path) -> None:
+    """A missing sounddevice/PortAudio runtime is reported, not raised."""
+
+    def _broken_lister() -> Sequence[str]:
+        raise AudioCaptureError("Microphone enumeration requires sounddevice + PortAudio.")
+
+    report = run_mic_check(
+        MicCheckOptions(config_path=_config(tmp_path), duration_seconds=0.3),
+        audio_input_factory=lambda _settings: ConstantAudioInput(0.2),
+        device_lister=_broken_lister,
+    )
+    assert report.passed is False
+    assert report.error is not None
+    assert "PortAudio" in report.error
+
+
+def test_on_chunk_callback_receives_levels(tmp_path: Path) -> None:
+    """The live-meter callback fires once per captured chunk with (rms, peak)."""
+    seen: list[tuple[float, float]] = []
+    run_mic_check(
+        MicCheckOptions(config_path=_config(tmp_path), duration_seconds=0.3),
+        audio_input_factory=lambda _settings: ConstantAudioInput(0.2),
+        device_lister=lambda: _DEVICES,
+        on_chunk=lambda rms, peak: seen.append((rms, peak)),
+    )
+    assert len(seen) == 3
+    assert all(rms > 0.0 for rms, _ in seen)
+
+
+def test_report_to_json_round_trips(tmp_path: Path) -> None:
+    """The report serializes to JSON evidence."""
+    report = run_mic_check(
+        MicCheckOptions(config_path=_config(tmp_path), duration_seconds=0.1),
+        audio_input_factory=lambda _settings: ConstantAudioInput(0.2),
+        device_lister=lambda: _DEVICES,
+    )
+    parsed = json.loads(report_to_json(report))
+    assert parsed["passed"] is True
+    assert parsed["matched_device"] == "USB PnP Audio Device"
+    assert parsed["source"] == "microphone"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -107,7 +107,7 @@ def test_main_without_subcommand_prints_help(capsys: pytest.CaptureFixture[str])
     assert main([]) == 0
     output = capsys.readouterr().out
     assert "usage: coffee-roaster-mcp" in output
-    assert "{serve,hottop-validate}" in output
+    assert "{serve,hottop-validate,mic-check}" in output
 
 
 def test_main_prints_version(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -94,7 +94,7 @@ _EXPECTED_T0_STATUS_KEYS = {
 
 
 def test_version_is_defined() -> None:
-    assert __version__ == "0.1.3"
+    assert __version__ == "0.1.4"
 
 
 def test_cli_parser_program_name() -> None:


### PR DESCRIPTION
Closes #158.

## Why
Before a supervised roast there was no proof the USB mic is actually capturing real audio into the FC detector. A device that won't *open* surfaces as `unavailable`/`faulted`, but a device that **opens and delivers silence/zeros** (macOS mic permission blocked, muted, or grabbed by another process) is indistinguishable from "no crack yet": `audio_running=True`, the window counters advance on silence, and per-window confidence is only emitted on a detection candidate.

## What
`coffee-roaster-mcp mic-check [--config … --duration-seconds … --rms-floor … --output …]`:
- loads the real config, enumerates input devices, confirms the configured device (e.g. `USB PnP`) is present + selected;
- opens the **same capture path as `serve`** and prints a live RMS/peak meter for ~5 s — the operator makes noise and watches it respond;
- **pass** = device present + opens + real signal above the floor; **fail** = not found / won't open (`AudioCaptureError`) / flat-floor silence;
- writes JSON evidence; exits non-zero on fail.

## The floor is principled, not a guess
`DEFAULT_RMS_FLOOR = 0.01` is **the first-crack detector's own energy noise gate** — `coffee-first-crack-detection` gates any window with `sqrt(mean(x**2)) < 0.01` to probability 0.0. So clearing the floor proves the *detector will actually use* the signal, not just that bytes arrived. (Cross-repo grounded.)

## Testing
Injectable end to end (audio-input factory + device lister) → 7 unit tests cover real-audio pass, silence fail, device-not-found, capture error, enumeration error, the live-meter callback, and JSON round-trip — **no hardware needed**. `ruff` / `ruff format` / `pyright` / `pytest` all green. The decisive proof is the operator's real hardware run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `mic-check` CLI subcommand for microphone diagnostics with real-time audio level monitoring
  * Supports configurable capture duration, device selection, and sensitivity thresholds
  * Provides PASS/FAIL verdict and optional JSON output for troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->