### PR TITLE
fix(#160): tolerate transient mic input overflow instead of faulting (0.1.5)

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.syamaner/coffee-roaster-mcp",
   "title": "RoastPilot",
   "description": "RoastPilot controls coffee roasting sessions through local stdio MCP tools and exports logs.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "websiteUrl": "https://github.com/syamaner/coffee-roaster-mcp#readme",
   "repository": {
     "url": "https://github.com/syamaner/coffee-roaster-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "coffee-roaster-mcp",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "runtimeHint": "uvx",
       "packageArguments": [
         {

--- a/src/coffee_roaster_mcp/__init__.py
+++ b/src/coffee_roaster_mcp/__init__.py
@@ -1,3 +1,3 @@
 """RoastPilot MCP server package."""
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import math
 import struct
 import time
@@ -287,6 +288,16 @@ class WavAudioInput:
         self.close()
 
 
+_LOGGER = logging.getLogger(__name__)
+
+#: A PortAudio input overflow is transient (the device dropped some input because
+#: a read missed its deadline, e.g. under CPU contention); the read still returns
+#: the samples it captured. Tolerate it and continue rather than killing capture,
+#: faulting only when overflows persist for this many *consecutive* reads, which
+#: signals the device genuinely cannot keep up rather than a momentary hiccup.
+_DEFAULT_MAX_CONSECUTIVE_OVERFLOWS = 30
+
+
 class MicrophoneAudioInput:
     """Read mono float samples from the configured system microphone."""
 
@@ -295,17 +306,24 @@ class MicrophoneAudioInput:
         settings: AudioCaptureSettings,
         *,
         sounddevice_module: Any | None = None,
+        max_consecutive_overflows: int = _DEFAULT_MAX_CONSECUTIVE_OVERFLOWS,
     ) -> None:
         """Configure a microphone input that opens lazily on first read.
 
         Args:
             settings: Validated audio capture settings.
             sounddevice_module: Optional injected sounddevice-compatible module for tests.
+            max_consecutive_overflows: Consecutive input overflows tolerated before
+                capture faults. A transient overflow is logged and the captured
+                samples are still returned; only a sustained run (the device cannot
+                keep up at all) raises ``AudioCaptureError``.
         """
         _validate_settings(settings)
         self._settings = settings
         self._sounddevice = sounddevice_module or _load_sounddevice()
         self._stream: Any | None = None
+        self._max_consecutive_overflows = max_consecutive_overflows
+        self._consecutive_overflows = 0
 
     def _ensure_stream(self) -> Any:
         if self._stream is not None:
@@ -339,9 +357,26 @@ class MicrophoneAudioInput:
         try:
             raw_data, overflowed = stream.read(sample_count)
         except Exception as exc:  # noqa: BLE001 - backend exceptions vary by platform.
+            # A genuine read failure (device gone, backend error) is still fatal.
             raise AudioCaptureError(f"Could not read microphone audio source: {exc}") from exc
         if overflowed:
-            raise AudioCaptureError("Microphone audio input overflowed.")
+            # Transient: the device dropped some input but `raw_data` still holds
+            # the samples it captured. Log, count, and keep going rather than
+            # killing capture for the whole roast; only a sustained run of
+            # consecutive overflows (the device cannot keep up at all) faults.
+            self._consecutive_overflows += 1
+            _LOGGER.warning(
+                "Microphone audio input overflowed (%d consecutive); continuing.",
+                self._consecutive_overflows,
+            )
+            if self._consecutive_overflows >= self._max_consecutive_overflows:
+                raise AudioCaptureError(
+                    "Microphone audio input overflowed on "
+                    f"{self._consecutive_overflows} consecutive reads; the device "
+                    "cannot keep up with the configured sample rate."
+                )
+        else:
+            self._consecutive_overflows = 0
         return tuple(float(sample[0]) for sample in struct.iter_unpack("f", bytes(raw_data)))
 
     def close(self) -> None:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -315,14 +315,51 @@ def test_microphone_audio_input_uses_configured_portaudio_stream() -> None:
     assert samples == (0.25, -0.5, 0.75)
 
 
-def test_microphone_audio_input_reports_overflow() -> None:
+def test_microphone_audio_input_tolerates_transient_overflow() -> None:
+    """A transient input overflow is non-fatal (#160): the captured samples still
+    come through and capture continues. Only a sustained run of consecutive
+    overflows (the device cannot keep up at all) faults."""
     FakeRawInputStream.created.clear()
     settings = audio_capture_settings_from_config(AudioConfig(source="microphone", sample_rate=4))
-    audio_input = MicrophoneAudioInput(settings, sounddevice_module=OverflowingSoundDeviceModule())
+    audio_input = MicrophoneAudioInput(
+        settings,
+        sounddevice_module=OverflowingSoundDeviceModule(),
+        max_consecutive_overflows=3,
+    )
 
     try:
-        with pytest.raises(AudioCaptureError, match="overflowed"):
+        # The first overflows do NOT raise; the samples captured despite the
+        # overflow are returned so detection keeps running.
+        assert audio_input.read_samples(1) == (0.25,)
+        assert audio_input.read_samples(1) == (-0.5,)
+        # The third consecutive overflow trips the sustained-failure backstop.
+        with pytest.raises(AudioCaptureError, match="consecutive"):
             audio_input.read_samples(1)
+    finally:
+        audio_input.close()
+
+
+def test_microphone_audio_input_resets_overflow_streak_on_clean_read() -> None:
+    """A clean read between overflows resets the consecutive-overflow counter, so
+    intermittent overflows never accumulate into a fault (#160)."""
+    FakeRawInputStream.created.clear()
+    settings = audio_capture_settings_from_config(AudioConfig(source="microphone", sample_rate=4))
+    audio_input = MicrophoneAudioInput(
+        settings,
+        sounddevice_module=FakeSoundDeviceModule(),
+        max_consecutive_overflows=2,
+    )
+
+    try:
+        audio_input.read_samples(1)  # opens the stream; clean read
+        stream = FakeRawInputStream.created[-1]
+        stream.overflowed = True
+        audio_input.read_samples(1)  # first consecutive overflow (streak = 1)
+        stream.overflowed = False
+        audio_input.read_samples(1)  # clean read resets the streak to 0
+        stream.overflowed = True
+        # A fresh streak: this is overflow #1 again, not #2, so it must not raise.
+        audio_input.read_samples(1)
     finally:
         audio_input.close()
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -94,7 +94,7 @@ _EXPECTED_T0_STATUS_KEYS = {
 
 
 def test_version_is_defined() -> None:
-    assert __version__ == "0.1.4"
+    assert __version__ == "0.1.5"
 
 
 def test_cli_parser_program_name() -> None:


### PR DESCRIPTION
## The bug (surfaced in the first hardware roast, roastpilot-agent #134)
A PortAudio input overflow is **transient** (the device dropped some input because a read missed its deadline, e.g. under CPU contention), and `stream.read` still returns the samples it captured. But `MicrophoneAudioInput.read_samples` raised `AudioCaptureError` on **any** overflow, which `_run_capture_loop` treats as fatal (`_stop_requested.set()`, worker dies) and `FirstCrackRuntime` turns into a permanent `faulted` with no recovery. So a single momentary overflow killed audio first-crack detection for the **entire roast** — and it was invisible in the console logs (only the agent's mic-status icon surfaced it).

## Fix
On `overflowed=True`, log + count it and **return the captured samples** so detection keeps running. Fault only after `max_consecutive_overflows` (default **30**) *consecutive* overflows, which signals the device genuinely cannot keep up rather than a hiccup; a clean read resets the streak. A genuine hard read error (device gone / backend failure, the `except` branch) still faults as before. Localised to `MicrophoneAudioInput`; no protocol, pipeline, or runtime change.

This also addresses the "silent in the logs" secondary symptom: every overflow now logs a warning.

## Why mic-check didn't catch it
`mic-check` only exercises capture briefly on an idle host; it never runs the sustained-load path that overflows under real operation.

## Tests
- `test_microphone_audio_input_tolerates_transient_overflow`: the first overflows return the captured samples (no raise); the Nth consecutive overflow faults.
- `test_microphone_audio_input_resets_overflow_streak_on_clean_read`: a clean read between overflows resets the counter, so intermittent overflows never accumulate to a fault.
- Full `test_audio.py` + `test_first_crack_runtime.py` green; ruff + pyright(strict) clean.

Bumps to **0.1.5** (release gated on operator approval).

Closes #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.5.

* **New Features**
  * Microphone input now tolerates transient audio overflow events with configurable thresholds; warnings are logged instead of immediate failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->