### PR TITLE
fix(#163): drop_beans keeps the drum running so beans eject; stop_cooling stops the drum

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -8,6 +8,17 @@ The release workflow is `.github/workflows/release.yml`. It supports two paths:
 - Manual dry run through `workflow_dispatch` with `dry_run: true`.
 - Live release through a pushed version tag such as `v0.1.3`.
 
+## Changelog
+
+### 0.1.6
+
+- fix(#163): `drop_beans` keeps the drum running so beans eject; `stop_cooling`
+  stops the drum. On a real Hottop the previous drop stopped the drum the instant
+  the chute opened, trapping roughly half the charge. The rotating drum now
+  tumbles beans out through the open chute, and `stop_cooling` (the end-of-roast
+  action) is what finally stops the drum. `emergency_stop` is unchanged: it keeps
+  the drum stopped and the solenoid closed to cool the beans in place.
+
 ## Operator Prerequisites
 
 Before enabling a live release, the release owner must confirm:
@@ -128,8 +139,8 @@ Before tagging, confirm these values all match the release version:
 - the pushed tag name, using `v{version}`
 - installed CLI output from `coffee-roaster-mcp --version`
 
-For the current published state, all package and registry metadata are aligned
-at `0.1.2`. A later release candidate must update all three checked-in version
+The current release candidate aligns all package and registry metadata at
+`0.1.6`. A later release candidate must update all three checked-in version
 fields in the same PR before tagging.
 
 ### Hugging Face First-Crack Artifact Pin

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.syamaner/coffee-roaster-mcp",
   "title": "RoastPilot",
   "description": "RoastPilot controls coffee roasting sessions through local stdio MCP tools and exports logs.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "websiteUrl": "https://github.com/syamaner/coffee-roaster-mcp#readme",
   "repository": {
     "url": "https://github.com/syamaner/coffee-roaster-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "coffee-roaster-mcp",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "runtimeHint": "uvx",
       "packageArguments": [
         {

--- a/src/coffee_roaster_mcp/__init__.py
+++ b/src/coffee_roaster_mcp/__init__.py
@@ -1,3 +1,3 @@
 """RoastPilot MCP server package."""
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/src/coffee_roaster_mcp/drivers.py
+++ b/src/coffee_roaster_mcp/drivers.py
@@ -941,7 +941,11 @@ class HottopRoasterDriver:
         """Apply Hottop compound bean-drop command state."""
         with self._state_lock:
             self._heat_level_percent = 0
-            self._drum_motor_on = False
+            # Keep the drum motor RUNNING through the drop so the rotating drum
+            # tumbles beans out the open chute. A stopped drum traps ~half the
+            # charge below the chute (coffee-roaster-mcp#163). stop_cooling is
+            # the end-of-roast action that stops the drum once beans are clear.
+            self._drum_motor_on = True
             self._solenoid_open = True
             self._cooling_motor_on = True
             self._main_fan_level_percent = 100
@@ -955,10 +959,15 @@ class HottopRoasterDriver:
         return self.read_state()
 
     def stop_cooling(self) -> RoasterState:
-        """Stop Hottop cooling, close drop path, and clear main fan."""
+        """Stop Hottop cooling, close drop path, stop the drum, and clear main fan."""
         with self._state_lock:
             self._cooling_motor_on = False
             self._solenoid_open = False
+            # drop_beans now leaves the drum running through cooling to fully
+            # clear the beans (coffee-roaster-mcp#163). stop_cooling is the
+            # end-of-roast action, so it must stop the drum here; otherwise the
+            # drum would spin indefinitely after cooling ends.
+            self._drum_motor_on = False
             self._main_fan_level_percent = 0
         return self.read_state()
 

--- a/src/coffee_roaster_mcp/hottop_validation.py
+++ b/src/coffee_roaster_mcp/hottop_validation.py
@@ -412,7 +412,9 @@ def _drop_step_status(
         state.heat_level_percent != 0
         or not state.cooling_on
         or state.fan_level_percent != 100
-        or _raw_bool(state, "drum_motor_on")
+        # The drop must keep the drum RUNNING so beans eject through the open
+        # chute; a stopped drum traps ~half the charge (#163).
+        or not _raw_bool(state, "drum_motor_on")
         or not _raw_bool(state, "solenoid_open")
     ):
         return "failed"
@@ -450,7 +452,14 @@ def _cooling_stop_status(
         == "failed"
     ):
         return "failed"
-    if state.cooling_on or state.fan_level_percent != 0 or _raw_bool(state, "solenoid_open"):
+    if (
+        state.cooling_on
+        or state.fan_level_percent != 0
+        or _raw_bool(state, "solenoid_open")
+        # stop_cooling is the end-of-roast action and must stop the drum that
+        # drop_beans left running through cooling (#163).
+        or _raw_bool(state, "drum_motor_on")
+    ):
         return "failed"
     return "passed"
 

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1043,6 +1043,8 @@ def test_hottop_driver_drop_and_cooling_commands_stream_safe_compound_states() -
     try:
         driver.set_heat(heat_level_percent=80)
         drop_state = driver.drop_beans()
+        # write[17] is the drum-motor command byte (_HOTTOP_COMMAND_DRUM_MOTOR_INDEX):
+        # the drop must keep the drum RUNNING (==1) so beans eject (#163).
         drop_packet = _wait_for_hottop_write(
             serial_factory.transport,
             lambda write: (
@@ -1051,13 +1053,19 @@ def test_hottop_driver_drop_and_cooling_commands_stream_safe_compound_states() -
                 and write[10] == 0
                 and write[12] == 10
                 and write[16] == 1
-                and write[17] == 0
+                and write[17] == 1
                 and write[18] == 1
             ),
         )
 
+        # start_cooling leaves the drum bit untouched (#163), so the drum keeps
+        # running after the drop while the operator runs the cooling cycle.
+        cooling_state = driver.start_cooling()
+
         stop_cooling_start_index = len(serial_factory.transport.writes_snapshot())
         stopped_state = driver.stop_cooling()
+        # stop_cooling is the end-of-roast action: it must stop the drum
+        # (write[17] == 0) now that drop_beans leaves it running (#163).
         stopped_packet = _wait_for_hottop_write(
             serial_factory.transport,
             lambda write: (
@@ -1066,6 +1074,7 @@ def test_hottop_driver_drop_and_cooling_commands_stream_safe_compound_states() -
                 and write[10] == 0
                 and write[12] == 0
                 and write[16] == 0
+                and write[17] == 0
                 and write[18] == 0
             ),
             start_index=stop_cooling_start_index,
@@ -1075,10 +1084,14 @@ def test_hottop_driver_drop_and_cooling_commands_stream_safe_compound_states() -
         assert drop_state.fan_level_percent == 100
         assert drop_state.cooling_on is True
         assert drop_state.raw_vendor_data["solenoid_open"] is True
-        assert drop_state.raw_vendor_data["drum_motor_on"] is False
+        assert drop_state.raw_vendor_data["drum_motor_on"] is True
+        assert cooling_state.cooling_on is True
+        assert cooling_state.fan_level_percent == 100
+        assert cooling_state.raw_vendor_data["drum_motor_on"] is True
         assert stopped_state.cooling_on is False
         assert stopped_state.fan_level_percent == 0
         assert stopped_state.raw_vendor_data["solenoid_open"] is False
+        assert stopped_state.raw_vendor_data["drum_motor_on"] is False
         assert drop_packet[35] == sum(drop_packet[:35]) & 0xFF
         assert stopped_packet[35] == sum(stopped_packet[:35]) & 0xFF
     finally:

--- a/tests/test_hottop_validation.py
+++ b/tests/test_hottop_validation.py
@@ -114,7 +114,8 @@ class FakeValidationDriver:
         self.cooling_on = True
         self.fan_level_percent = 100
         self.heat_level_percent = 0
-        self.drum_motor_on = False
+        # Drop keeps the drum running so beans eject through the open chute (#163).
+        self.drum_motor_on = True
         self.solenoid_open = True
         return self.read_state()
 
@@ -131,6 +132,8 @@ class FakeValidationDriver:
         self.cooling_on = False
         self.fan_level_percent = 0
         self.solenoid_open = False
+        # End-of-roast: stop the drum that drop_beans left running (#163).
+        self.drum_motor_on = False
         return self.read_state()
 
     def emergency_stop(self, *, reason: str) -> EmergencyStopResult:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -94,7 +94,7 @@ _EXPECTED_T0_STATUS_KEYS = {
 
 
 def test_version_is_defined() -> None:
-    assert __version__ == "0.1.5"
+    assert __version__ == "0.1.6"
 
 
 def test_cli_parser_program_name() -> None:


### PR DESCRIPTION
## Summary

Fixes #163 (surfaced live via roastpilot-agent#311). On a real Hottop, `drop_beans` stopped the drum motor the instant the chute opened, so beans below the chute never tumbled out and ~half the charge stayed trapped; the operator had to hand-rotate the drum to clear it.

## The fix

- **`HottopRoasterDriver.drop_beans`** now sets `self._drum_motor_on = True` (heat 0, solenoid open, cooling on, main fan 100 all unchanged). The rotating drum ejects beans through the open chute.
- **`HottopRoasterDriver.stop_cooling`** now sets `self._drum_motor_on = False`. The drop now leaves the drum running through cooling to fully clear the beans, so `stop_cooling` (the end-of-roast action) is what stops the drum; otherwise it would spin indefinitely after cooling ends. This interaction is why fixing `drop_beans` alone is insufficient.
- **`emergency_stop` is deliberately unchanged.** It keeps the drum stopped + solenoid closed + cooling on, which is the fail-safe "cool the beans in place" behaviour (an e-stop should not eject).
- **Mock driver unchanged** — it has no `_drum_motor_on` concept; the `RoasterDriver` contract test still passes.

`hottop_validation.py`'s drop step now requires the drum running, and its cooling-stop step now requires the drum stopped.

## Tests

- `test_hottop_driver_drop_and_cooling_commands_stream_safe_compound_states`: now asserts `drum_motor_on is True` after `drop_beans` (and command byte `write[17] == 1`), `True` through `start_cooling`, and `False` after `stop_cooling` (`write[17] == 0`). The added `start_cooling` step also closes a pre-existing coverage gap on that method.
- `test_hottop_driver_emergency_stop_streams_safe_stop_state`: unchanged, still asserts `drum_motor_on is False` (the fail-safe).
- The `hottop_validation` fake driver mirrors the new contract; `test_hottop_validation_can_capture_full_manual_sequence` still reports `drop` and `emergency_stop` as `passed`.

## Gate results (local, macOS)

- `pytest`: all pass.
- `ruff check` / `ruff format --check`: clean.
- `pyright` (strict): 0 errors.
- CLI smoke: `coffee-roaster-mcp --version` reports `0.1.6`.
- Coverage: the patched drop/cooling region is **100% covered** (`codecov/patch` will pass). Project-level total reads 89.67% locally because the `mic-check` / `hottop-validate` CLI subcommands and `audio.py` PortAudio paths need a real microphone/serial device; clean `main` reads the same 89.58% on this host, so this is a pre-existing macOS-vs-CI environment gap, not a regression in this PR. CI (Linux) exercises those paths and clears the 90% gate.

## Release readiness (0.1.5 -> 0.1.6)

Every version-alignment field the release flow validates is bumped to `0.1.6`:

- `src/coffee_roaster_mcp/__init__.py` `__version__`
- `server.json` `version`
- `server.json` `packages[0].version`
- `tests/test_package.py` version assertion
- changelog entry in `docs/release.md` (+ alignment note refreshed to 0.1.6)

After merge to `main`, pushing tag `v0.1.6` triggers `.github/workflows/release.yml`: `validate-release-metadata` checks the tag matches `__version__` and that both `server.json` versions agree, then `publish-pypi` and `publish-mcp-registry` run behind the `release` GitHub environment's manual-approval gate.

**Do not merge yet** — leaving for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
