### PR TITLE
fix(#165): audio-teardown UAF segfault at end of roast

### DIFF
--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -324,6 +324,7 @@ class MicrophoneAudioInput:
         self._stream: Any | None = None
         self._max_consecutive_overflows = max_consecutive_overflows
         self._consecutive_overflows = 0
+        self._close_lock = Lock()
 
     def _ensure_stream(self) -> Any:
         if self._stream is not None:
@@ -380,15 +381,23 @@ class MicrophoneAudioInput:
         return tuple(float(sample[0]) for sample in struct.iter_unpack("f", bytes(raw_data)))
 
     def close(self) -> None:
-        """Stop and close the microphone stream."""
-        stream = self._stream
-        if stream is None:
-            return
-        try:
-            stream.stop()
-        finally:
-            stream.close()
-            self._stream = None
+        """Stop and close the microphone stream.
+
+        Idempotent and thread-safe: closing the underlying PortAudio stream frees
+        its native ring buffer, so a repeated close (capture worker plus stop
+        caller) must never race into a double free. Callers must ensure no read is
+        in flight on another thread before closing; the capture pipeline
+        guarantees this by closing only from the worker thread that owns reads.
+        """
+        with self._close_lock:
+            stream = self._stream
+            if stream is None:
+                return
+            try:
+                stream.stop()
+            finally:
+                stream.close()
+                self._stream = None
 
     def __enter__(self) -> Self:
         """Return this microphone input as a context manager."""
@@ -462,7 +471,25 @@ class AudioCapturePipeline:
         return self.snapshot()
 
     def stop(self, *, timeout_seconds: float = 1.0) -> AudioCaptureSnapshot:
-        """Request capture stop and wait briefly for the worker to finish."""
+        """Request capture stop and wait briefly for the worker to finish.
+
+        The audio input is closed by the worker thread itself once its read loop
+        exits, so its native (PortAudio) stream is never freed while a read is in
+        flight on the worker. This method only closes the input directly as a
+        fallback when no worker thread is (still) running — for example, when
+        ``start`` failed or the worker already finished without closing. Closing
+        from this caller thread while the worker is still alive would free the
+        ring buffer under an in-flight ``read`` and crash the process.
+
+        Args:
+            timeout_seconds: Maximum time to wait for the worker thread to exit.
+
+        Returns:
+            The capture status snapshot taken after the stop request.
+
+        Raises:
+            AudioCaptureError: If ``timeout_seconds`` is negative.
+        """
         if timeout_seconds < 0:
             raise AudioCaptureError("timeout_seconds must be >= 0.")
         self._stop_requested.set()
@@ -470,7 +497,10 @@ class AudioCapturePipeline:
         if thread is not None:
             thread.join(timeout=timeout_seconds)
         snapshot = self.snapshot()
-        _close_audio_input_if_supported(self._audio_input)
+        if thread is None or not thread.is_alive():
+            # No worker owns the input (or it already exited): safe to close here.
+            # A still-alive worker closes the input itself in its loop finally.
+            _close_audio_input_if_supported(self._audio_input)
         return snapshot
 
     def close(self) -> None:
@@ -526,6 +556,12 @@ class AudioCapturePipeline:
             with self._state_lock:
                 self._latest_error = str(exc)
             self._stop_requested.set()
+        finally:
+            # Close the audio input on the same thread that owns its reads. This
+            # guarantees the underlying PortAudio stream's ring buffer is never
+            # freed while a read is in flight, which would otherwise segfault the
+            # process at end of roast (worker mid-read while the caller closes).
+            _close_audio_input_if_supported(self._audio_input)
 
     def _read_next_samples(self) -> tuple[float, ...]:
         needed_samples = self._settings.window_sample_count - len(self._sample_buffer)

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -497,9 +497,14 @@ class AudioCapturePipeline:
         if thread is not None:
             thread.join(timeout=timeout_seconds)
         snapshot = self.snapshot()
-        if thread is None or not thread.is_alive():
-            # No worker owns the input (or it already exited): safe to close here.
-            # A still-alive worker closes the input itself in its loop finally.
+        if thread is None:
+            # No worker thread ever ran (e.g. start() failed before spawning the
+            # worker): close the input here as a fallback. Whenever a worker DID
+            # run it closes the input itself in its loop finally — on the thread
+            # that owns reads — whether it has already exited or is still draining
+            # a blocking read. So stop() must not also close it: that would double
+            # free / free under an in-flight read. (close() is idempotent anyway,
+            # but correctness here does not depend on that.)
             _close_audio_input_if_supported(self._audio_input)
         return snapshot
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -6,7 +6,7 @@ import wave
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from queue import Queue
-from threading import Lock, Thread
+from threading import Event, Lock, Thread, current_thread
 
 import pytest
 
@@ -685,6 +685,77 @@ def test_audio_capture_pipeline_validates_finite_samples() -> None:
     snapshot = pipeline.stop()
 
     assert snapshot.latest_error == "audio samples must be finite numbers."
+
+
+class BlockingClosableAudioInput:
+    """Audio input whose reads block, recording which thread closes it.
+
+    Models the real microphone path: a worker thread is parked inside a blocking
+    ``read`` when ``stop`` is requested. Closing the underlying stream from any
+    thread other than the one reading it frees the native ring buffer under an
+    in-flight read and crashes the process, so this records the closing thread
+    and whether the worker was still alive at close time.
+    """
+
+    def __init__(self) -> None:
+        self._release = Event()
+        self.closed = False
+        self.closed_by_worker: bool | None = None
+        self.worker_alive_at_close: bool | None = None
+        self.worker_thread: Thread | None = None
+        self.read_started = Event()
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        self.worker_thread = current_thread()
+        self.read_started.set()
+        # Block until released, mimicking a microphone read that outlasts the
+        # stop join timeout.
+        self._release.wait(timeout=2.0)
+        return (0.1,) * sample_count
+
+    def release(self) -> None:
+        self._release.set()
+
+    def close(self) -> None:
+        self.closed = True
+        self.closed_by_worker = current_thread() is self.worker_thread
+        self.worker_alive_at_close = (
+            self.worker_thread is not None and self.worker_thread.is_alive()
+        )
+
+
+def test_audio_capture_stop_does_not_close_input_while_worker_reads() -> None:
+    """A worker blocked mid-read must close its own input, never the stop caller.
+
+    Regression for the end-of-roast SIGSEGV: ``stop`` closed the PortAudio stream
+    after a join timeout even though the worker was still inside ``read``, freeing
+    the ring buffer under the in-flight read and crashing the process.
+    """
+    audio_input = BlockingClosableAudioInput()
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device="mock-mic",
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+    )
+
+    pipeline.start()
+    assert audio_input.read_started.wait(timeout=1.0)
+    # Worker is parked inside read(); a zero-timeout join must not close the input.
+    pipeline.stop(timeout_seconds=0.0)
+    assert audio_input.closed is False
+
+    # Releasing the read lets the worker observe the stop request, exit, and close.
+    audio_input.release()
+    _wait_for(lambda: audio_input.closed)
+    assert audio_input.closed_by_worker is True
+    worker = audio_input.worker_thread
+    assert worker is not None
+    worker.join(timeout=1.0)
+    assert not worker.is_alive()
 
 
 def _wait_for(predicate: Callable[[], bool], *, timeout_seconds: float = 1.0) -> None:


### PR DESCRIPTION
Closes #165. Root-caused + reproduced hardware-free: `AudioCapturePipeline.stop()` closed the PortAudio input while the capture worker was mid-`read()`, freeing the native ring buffer under an in-flight read → SIGSEGV at end of roast (both 21 Jun hardware roasts; only with `first_crack.mode=audio`). Fix: worker closes its own input in the loop `finally`; `stop()` closes only as a fallback when no worker is alive; `close()` is idempotent + lock-guarded. Regression test fails without the fix. Local gates green (ruff, pyright strict, pytest 401). **Gates v0.1.6** (with #163 drum + #160 mic-overflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)