### PR TITLE
fix(t0): backdate auto-T0 to the turning point, not the confirmation tick (#167)

### DIFF
--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -323,6 +323,10 @@ class RoastSession:
         fan_level_percent: Latest in-memory fan setting for the active mock path.
         cooling_on: Whether cooling is currently active in the session state.
         auto_t0_charge_temperature_c: Max preheat/charge bean temperature before T0.
+        auto_t0_charge_temperature_monotonic_seconds: Monotonic elapsed seconds
+            of the candidate turning point — the most recent local-max
+            bean-temperature sample before the sustained decline. Automatic T0
+            is backdated to this timestamp on confirmation (#167).
         auto_t0_current_drop_c: Current drop from the tracked charge temperature.
         auto_t0_preheat_sample_count: Number of valid pre-T0 bean-temperature samples.
         event_timeline: Shared ordered event timeline for future runtime stories.
@@ -354,6 +358,7 @@ class RoastSession:
     fan_level_percent: int = 0
     cooling_on: bool = False
     auto_t0_charge_temperature_c: float | None = None
+    auto_t0_charge_temperature_monotonic_seconds: float | None = None
     auto_t0_current_drop_c: float | None = None
     auto_t0_preheat_sample_count: int = 0
     event_timeline: list[RoastEvent] = field(default_factory=_event_timeline_default)
@@ -1542,7 +1547,11 @@ class RoastSessionStore:
 
         Returns:
             The recorded beans-added event when this reading crosses the
-            threshold, otherwise `None`, plus an atomic session snapshot.
+            threshold, otherwise `None`, plus an atomic session snapshot. On
+            confirmation the event is backdated to the candidate turning
+            point — the most recent local-max bean-temperature sample before
+            the sustained decline — not the confirmation tick (#167). The raw
+            confirmation timestamp stays available in the event payload.
 
         Raises:
             SessionLifecycleError: If called outside the pre-T0 active phase or
@@ -1562,9 +1571,16 @@ class RoastSessionStore:
             if not math.isfinite(threshold) or threshold <= 0:
                 raise SessionLifecycleError("Automatic T0 threshold must be greater than 0.")
 
+            confirmation_elapsed_seconds = session.elapsed_monotonic_seconds(self._monotonic_now)
+            confirmation_at_utc = self._utc_now()
+
             previous_max = session.auto_t0_charge_temperature_c
             if previous_max is None or current_temp > previous_max:
+                # A new local max — this sample is the current candidate
+                # turning point. Remember when it occurred so T0 can be
+                # backdated to here once the decline is confirmed (#167).
                 session.auto_t0_charge_temperature_c = current_temp
+                session.auto_t0_charge_temperature_monotonic_seconds = confirmation_elapsed_seconds
                 previous_max = current_temp
 
             session.auto_t0_preheat_sample_count += 1
@@ -1573,18 +1589,91 @@ class RoastSessionStore:
             if session.auto_t0_preheat_sample_count < 2 or drop_c < threshold:
                 return None, _copy_session_for_read(session)
 
-            event = self.record_event(
+            turning_point_elapsed_seconds = session.auto_t0_charge_temperature_monotonic_seconds
+            if turning_point_elapsed_seconds is None:  # pragma: no cover - defensive
+                # The candidate is always set with the first local max above,
+                # so reaching confirmation without one is unreachable; fall
+                # back to the confirmation tick rather than crash.
+                turning_point_elapsed_seconds = confirmation_elapsed_seconds
+
+            event = self._record_backdated_beans_added(
                 session,
-                "beans_added",
+                turning_point_elapsed_seconds=turning_point_elapsed_seconds,
+                confirmation_elapsed_seconds=confirmation_elapsed_seconds,
+                confirmation_at_utc=confirmation_at_utc,
                 payload={
                     "source": "auto_t0",
                     "charge_temperature_c": round(previous_max, 3),
                     "detected_bean_temperature_c": round(current_temp, 3),
                     "drop_c": round(drop_c, 3),
                     "drop_threshold_c": round(threshold, 3),
+                    "turning_point_monotonic_seconds": round(turning_point_elapsed_seconds, 3),
+                    "confirmed_at_monotonic_seconds": round(confirmation_elapsed_seconds, 3),
+                    "confirmed_at_utc": confirmation_at_utc.isoformat(),
                 },
             )
             return event, _copy_session_for_read(session)
+
+    def _record_backdated_beans_added(
+        self,
+        session: RoastSession,
+        *,
+        turning_point_elapsed_seconds: float,
+        confirmation_elapsed_seconds: float,
+        confirmation_at_utc: datetime,
+        payload: dict[str, EventPayloadValue],
+    ) -> RoastEvent:
+        """Record automatic T0 backdated to the candidate turning point.
+
+        The reported `beans_added` timestamp is the local-max bean-temperature
+        sample (#167), never the confirmation tick. The raw confirmation
+        timestamp is preserved in ``payload`` so existing consumers keep the
+        confirmation moment available.
+
+        Args:
+            session: Session to mutate. Caller holds the store lock.
+            turning_point_elapsed_seconds: Backdated T0 elapsed seconds — the
+                monotonic elapsed time of the most recent local max.
+            confirmation_elapsed_seconds: Elapsed seconds at the confirmation
+                tick, used to clamp the backdated value into the valid range.
+            confirmation_at_utc: Wall-clock confirmation timestamp.
+            payload: Structured event details including the raw confirmation
+                timestamp.
+
+        Returns:
+            The recorded, backdated ``beans_added`` event.
+        """
+        backdated_elapsed_seconds = round(turning_point_elapsed_seconds, 6)
+        # The turning point can never be after the confirmation tick or before
+        # the session start; clamp defensively so the timeline stays ordered.
+        backdated_elapsed_seconds = max(
+            0.0,
+            min(backdated_elapsed_seconds, confirmation_elapsed_seconds),
+        )
+        monotonic_seconds = _normalize_event_monotonic_seconds(
+            session,
+            monotonic_seconds=backdated_elapsed_seconds,
+        )
+        recorded_at_utc = session.created_at_utc + timedelta(seconds=monotonic_seconds)
+        recorded_at_utc = _normalize_event_recorded_at_utc(
+            session,
+            recorded_at_utc=recorded_at_utc,
+        )
+        _validate_event_monotonic_order(
+            session,
+            kind="beans_added",
+            monotonic_seconds=monotonic_seconds,
+        )
+        event = RoastEvent(
+            kind="beans_added",
+            recorded_at_utc=recorded_at_utc,
+            monotonic_seconds=monotonic_seconds,
+            payload=dict(payload),
+        )
+        _append_event_log_row(session, event)
+        session.event_timeline.append(event)
+        _apply_event_timestamp(session, event)
+        return event
 
     def record_first_crack_detection_snapshot(
         self,
@@ -2200,6 +2289,9 @@ def _copy_session_for_read(session: RoastSession) -> RoastSession:
         fan_level_percent=session.fan_level_percent,
         cooling_on=session.cooling_on,
         auto_t0_charge_temperature_c=session.auto_t0_charge_temperature_c,
+        auto_t0_charge_temperature_monotonic_seconds=(
+            session.auto_t0_charge_temperature_monotonic_seconds
+        ),
         auto_t0_current_drop_c=session.auto_t0_current_drop_c,
         auto_t0_preheat_sample_count=session.auto_t0_preheat_sample_count,
         event_timeline=deepcopy(session.event_timeline),

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -1575,10 +1575,12 @@ class RoastSessionStore:
             confirmation_at_utc = self._utc_now()
 
             previous_max = session.auto_t0_charge_temperature_c
-            if previous_max is None or current_temp > previous_max:
-                # A new local max — this sample is the current candidate
-                # turning point. Remember when it occurred so T0 can be
-                # backdated to here once the decline is confirmed (#167).
+            if previous_max is None or current_temp >= previous_max:
+                # A new local max — OR a repeat of the running max (a plateau of
+                # quantized/equal sensor readings). Either way this sample is the
+                # current candidate turning point: #167 wants the MOST RECENT
+                # local max before the decline, so advance the timestamp to the
+                # latest sample at the running max, not the first plateau sample.
                 session.auto_t0_charge_temperature_c = current_temp
                 session.auto_t0_charge_temperature_monotonic_seconds = confirmation_elapsed_seconds
                 previous_max = current_temp

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -341,13 +341,20 @@ def test_get_roast_state_records_automatic_t0_after_configured_drop(
     assert threshold_state.t0_status.drop_threshold_c == 25.0
     assert threshold_state.t0_status.detected_bean_temperature_c == 145.0
     assert [event.kind for event in threshold_state.events] == ["beans_added"]
-    assert threshold_state.events[0].payload == {
-        "source": "auto_t0",
-        "charge_temperature_c": 170.0,
-        "detected_bean_temperature_c": 145.0,
-        "drop_c": 25.0,
-        "drop_threshold_c": 25.0,
-    }
+    t0_payload = threshold_state.events[0].payload
+    assert t0_payload["source"] == "auto_t0"
+    assert t0_payload["charge_temperature_c"] == 170.0
+    assert t0_payload["detected_bean_temperature_c"] == 145.0
+    assert t0_payload["drop_c"] == 25.0
+    assert t0_payload["drop_threshold_c"] == 25.0
+    # T0 is backdated to the candidate turning point (the 170 °C local max),
+    # while the raw confirmation timestamp stays available (#167).
+    assert "turning_point_monotonic_seconds" in t0_payload
+    assert "confirmed_at_monotonic_seconds" in t0_payload
+    assert "confirmed_at_utc" in t0_payload
+    assert cast(float, t0_payload["turning_point_monotonic_seconds"]) <= cast(
+        float, t0_payload["confirmed_at_monotonic_seconds"]
+    )
 
 
 def test_get_roast_state_discards_queued_first_crack_windows_after_auto_t0(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import cast
 
@@ -834,6 +834,8 @@ def test_auto_t0_records_beans_added_from_drop_against_preheat_max() -> None:
     )
     session = store.start_session()
 
+    # The 170 °C local max is captured at session start (elapsed 0.0); this is
+    # the candidate turning point T0 is backdated to on confirmation (#167).
     event, first_snapshot = store.process_auto_t0_reading_snapshot(
         session,
         bean_temp_c=170.0,
@@ -842,8 +844,10 @@ def test_auto_t0_records_beans_added_from_drop_against_preheat_max() -> None:
     assert event is None
     assert first_snapshot.phase == "pre_roast"
     assert first_snapshot.auto_t0_charge_temperature_c == 170.0
+    assert first_snapshot.auto_t0_charge_temperature_monotonic_seconds == 0.0
 
-    clock.utc_value = datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    confirmation_utc = datetime(2026, 5, 4, 12, 1, tzinfo=UTC)
+    clock.utc_value = confirmation_utc
     clock.monotonic_value = 105.0
     event, snapshot = store.process_auto_t0_reading_snapshot(
         session,
@@ -853,17 +857,26 @@ def test_auto_t0_records_beans_added_from_drop_against_preheat_max() -> None:
 
     assert event is not None
     assert event.kind == "beans_added"
-    assert event.recorded_at_utc == clock.utc_value
-    assert event.monotonic_seconds == 5.0
+    # T0 is backdated to the turning point (elapsed 0.0 / session start),
+    # NOT the confirmation tick at elapsed 5.0.
+    assert event.monotonic_seconds == 0.0
+    assert event.recorded_at_utc == session.created_at_utc
+    assert event.recorded_at_utc != confirmation_utc
     assert event.payload == {
         "source": "auto_t0",
         "charge_temperature_c": 170.0,
         "detected_bean_temperature_c": 143.5,
         "drop_c": 26.5,
         "drop_threshold_c": 25.0,
+        "turning_point_monotonic_seconds": 0.0,
+        # The raw confirmation timestamp stays available alongside the
+        # backdated T0.
+        "confirmed_at_monotonic_seconds": 5.0,
+        "confirmed_at_utc": confirmation_utc.isoformat(),
     }
     assert snapshot.phase == "roasting"
-    assert snapshot.beans_added_at_utc == clock.utc_value
+    assert snapshot.beans_added_at_utc == session.created_at_utc
+    assert snapshot.beans_added_monotonic_seconds == 0.0
     assert snapshot.auto_t0_charge_temperature_c == 170.0
     assert snapshot.auto_t0_current_drop_c == 26.5
 
@@ -896,6 +909,118 @@ def test_auto_t0_uses_max_preheat_for_gradual_drop() -> None:
     assert event.kind == "beans_added"
     assert event.payload["charge_temperature_c"] == 170.0
     assert event.payload["drop_c"] == 25.1
+    assert snapshot.phase == "roasting"
+
+
+def test_auto_t0_backdates_to_turning_point_not_confirmation_tick() -> None:
+    """T0 is reported at the local max, not where the X-degree drop confirms.
+
+    Mirrors roast 3 (21 Jun): the bean peaks well before the sustained
+    decline is confirmed, so a confirmation-tick T0 lands ~15-20 s late and
+    mis-origins every downstream metric (#167). The debounce still waits for
+    the confirmed drop, but the reported timestamp is backdated.
+    """
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    # Climb to a peak (the charge turning point) at elapsed 5.0s, then decline
+    # over several ticks before the drop is confirmed at elapsed 9.0s.
+    readings = [
+        (101.0, 150.0),  # elapsed 1.0
+        (102.0, 165.0),  # elapsed 2.0
+        (103.0, 178.0),  # elapsed 3.0
+        (104.0, 180.0),  # elapsed 4.0
+        (105.0, 181.0),  # elapsed 5.0 — the local max / turning point
+        (106.0, 178.0),  # elapsed 6.0 — decline begins, still under threshold
+        (107.0, 172.0),  # elapsed 7.0
+        (108.0, 165.0),  # elapsed 8.0
+    ]
+    for monotonic_value, bean_temp_c in readings:
+        clock.monotonic_value = monotonic_value
+        event, _ = store.process_auto_t0_reading_snapshot(
+            session,
+            bean_temp_c=bean_temp_c,
+            drop_threshold_c=25.0,
+        )
+        # The debounce holds: no false-positive T0 before the drop confirms.
+        assert event is None
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 0, 9, tzinfo=UTC)
+    clock.monotonic_value = 109.0  # elapsed 9.0 — drop of 181-155=26 confirms
+    event, snapshot = store.process_auto_t0_reading_snapshot(
+        session,
+        bean_temp_c=155.0,
+        drop_threshold_c=25.0,
+    )
+
+    assert event is not None
+    assert event.kind == "beans_added"
+    # Backdated to the 181 °C peak at elapsed 5.0s, NOT the elapsed-9.0s
+    # confirmation tick.
+    assert event.monotonic_seconds == 5.0
+    assert event.payload["charge_temperature_c"] == 181.0
+    assert event.payload["turning_point_monotonic_seconds"] == 5.0
+    # The raw confirmation moment stays available for consumers told the lag.
+    assert event.payload["confirmed_at_monotonic_seconds"] == 9.0
+    assert event.payload["confirmed_at_utc"] == clock.utc_value.isoformat()
+    assert snapshot.beans_added_monotonic_seconds == 5.0
+    assert snapshot.beans_added_at_utc == session.created_at_utc + timedelta(seconds=5.0)
+
+
+def test_auto_t0_debounce_rejects_transient_dip_below_threshold() -> None:
+    """A brief dip that does not reach the threshold never fires T0.
+
+    Backdating must not weaken the false-positive guard: a transient drop
+    under the confirmation threshold leaves the session pre-roast and keeps
+    the turning-point candidate tracking the running local max.
+    """
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    clock.monotonic_value = 101.0
+    store.process_auto_t0_reading_snapshot(session, bean_temp_c=180.0, drop_threshold_c=25.0)
+    # A 10 °C transient dip — below the 25 °C confirmation threshold.
+    clock.monotonic_value = 102.0
+    event, snapshot = store.process_auto_t0_reading_snapshot(
+        session,
+        bean_temp_c=170.0,
+        drop_threshold_c=25.0,
+    )
+
+    assert event is None
+    assert snapshot.phase == "pre_roast"
+    assert snapshot.beans_added_at_utc is None
+    assert snapshot.auto_t0_charge_temperature_c == 180.0
+    assert snapshot.auto_t0_charge_temperature_monotonic_seconds == 1.0
+
+    # Temperature recovers to a new local max — the candidate moves forward.
+    clock.monotonic_value = 103.0
+    _, recovered = store.process_auto_t0_reading_snapshot(
+        session,
+        bean_temp_c=185.0,
+        drop_threshold_c=25.0,
+    )
+    assert recovered.auto_t0_charge_temperature_c == 185.0
+    assert recovered.auto_t0_charge_temperature_monotonic_seconds == 3.0
+
+    # Now a confirmed drop fires T0 backdated to the elapsed-3.0s new max.
+    clock.utc_value = datetime(2026, 5, 4, 12, 0, 6, tzinfo=UTC)
+    clock.monotonic_value = 106.0
+    event, snapshot = store.process_auto_t0_reading_snapshot(
+        session,
+        bean_temp_c=158.0,
+        drop_threshold_c=25.0,
+    )
+    assert event is not None
+    assert event.monotonic_seconds == 3.0
     assert snapshot.phase == "roasting"
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -10,6 +10,7 @@ import pytest
 import coffee_roaster_mcp.session as session_module
 from coffee_roaster_mcp.session import (
     RoastEventKind,
+    RoastSession,
     RoastSessionStore,
     SessionLifecycleError,
     TelemetrySample,
@@ -969,6 +970,66 @@ def test_auto_t0_backdates_to_turning_point_not_confirmation_tick() -> None:
     assert event.payload["confirmed_at_utc"] == clock.utc_value.isoformat()
     assert snapshot.beans_added_monotonic_seconds == 5.0
     assert snapshot.beans_added_at_utc == session.created_at_utc + timedelta(seconds=5.0)
+
+
+def test_auto_t0_backdates_to_last_sample_of_max_temperature_plateau() -> None:
+    """On a plateau of equal max readings, T0 lands at the LAST plateau sample.
+
+    Quantized/repeated sensor readings can hold the bean at its peak for
+    several ticks. #167 wants the most recent local max before the decline,
+    which is the LAST sample of that plateau, not the first — so the
+    turning-point candidate advances on equality, not only on a strict
+    increase.
+    """
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+    )
+    session = store.start_session()
+
+    # Climb to 181 then hold flat at 181 across a three-tick plateau
+    # (elapsed 3.0 -> 5.0) before declining.
+    readings = [
+        (101.0, 170.0),  # elapsed 1.0
+        (102.0, 178.0),  # elapsed 2.0
+        (103.0, 181.0),  # elapsed 3.0 — plateau begins
+        (104.0, 181.0),  # elapsed 4.0 — plateau (equal max)
+        (105.0, 181.0),  # elapsed 5.0 — last plateau sample / most recent max
+        (106.0, 176.0),  # elapsed 6.0 — decline begins
+        (107.0, 168.0),  # elapsed 7.0
+    ]
+    plateau_snapshot: RoastSession | None = None
+    for monotonic_value, bean_temp_c in readings:
+        clock.monotonic_value = monotonic_value
+        event, plateau_snapshot = store.process_auto_t0_reading_snapshot(
+            session,
+            bean_temp_c=bean_temp_c,
+            drop_threshold_c=25.0,
+        )
+        assert event is None
+    assert plateau_snapshot is not None
+    # The candidate tracks the LAST sample at the running max (elapsed 5.0),
+    # not the first plateau sample (elapsed 3.0).
+    assert plateau_snapshot.auto_t0_charge_temperature_c == 181.0
+    assert plateau_snapshot.auto_t0_charge_temperature_monotonic_seconds == 5.0
+
+    clock.utc_value = datetime(2026, 5, 4, 12, 0, 8, tzinfo=UTC)
+    clock.monotonic_value = 108.0  # elapsed 8.0 — drop of 181-155=26 confirms
+    event, snapshot = store.process_auto_t0_reading_snapshot(
+        session,
+        bean_temp_c=155.0,
+        drop_threshold_c=25.0,
+    )
+
+    assert event is not None
+    assert event.kind == "beans_added"
+    # Backdated to the LAST plateau sample (elapsed 5.0), not the first (3.0)
+    # and not the elapsed-8.0 confirmation tick.
+    assert event.monotonic_seconds == 5.0
+    assert event.payload["turning_point_monotonic_seconds"] == 5.0
+    assert event.payload["confirmed_at_monotonic_seconds"] == 8.0
+    assert snapshot.beans_added_monotonic_seconds == 5.0
 
 
 def test_auto_t0_debounce_rejects_transient_dip_below_threshold() -> None:


### PR DESCRIPTION
Closes #167.

## Problem
Automatic T0 was stamped at the **confirmation** moment — after the bean temperature had already dropped the X-degree threshold — so the reported T0 landed well **after** the actual charge. Roast 3 (21 Jun): the bean peaked **181 °C at 385 s** but T0 was stamped **~402 s (~17 s late)**, inflating the charge clock and mis-origining development %, DTR, and the chart x-axis.

## Change
Keep the X-degree confirmed-decline debounce (it rejects false positives), but on confirmation **report T0 at the candidate turning point** — the most recent local-max bean-temperature sample before the sustained drop — instead of "now".

- `RoastSession` now tracks `auto_t0_charge_temperature_monotonic_seconds`: the monotonic elapsed time of the current local max, updated whenever a new max is seen.
- On confirmation, `process_auto_t0_reading_snapshot` records a **backdated** `beans_added` event via a new `_record_backdated_beans_added` helper (mirrors the existing FC-detection backdating pattern). The backdated elapsed time is clamped to `[0, confirmation_elapsed]` and passes the existing monotonic-order / recorded-at normalization, so the timeline stays ordered.
- The **raw confirmation timestamp stays available** in the event payload: `confirmed_at_monotonic_seconds`, `confirmed_at_utc`, plus `turning_point_monotonic_seconds`. Existing payload keys are unchanged.

`beans_added_at_utc` / `beans_added_monotonic_seconds` and the JSONL/summary exports all flow from the backdated event, so the charge clock now starts at the true turning point with no extra export wiring.

## Consumer note (roastpilot-agent)
The agent accepts T0 from MCP detection. For accurate metrics it must honour MCP's **reported (backdated)** `beans_added` timestamp (`monotonic_seconds` / `recorded_at_utc` on the event), not the tick it receives the event on. The new `confirmed_at_*` payload fields preserve the confirmation moment for any consumer that wants it. Tracked agent-side separately if a change is needed there.

## Tests
- `test_auto_t0_backdates_to_turning_point_not_confirmation_tick`: bean peaks at elapsed 5.0 s, decline confirms at elapsed 9.0 s → T0 reported at **5.0 s** (the peak), with `confirmed_at_monotonic_seconds == 9.0`. Asserts the debounce held (no T0 before confirmation).
- `test_auto_t0_debounce_rejects_transient_dip_below_threshold`: a sub-threshold transient dip never fires; the local-max candidate moves forward to a later peak; the eventual confirmed drop backdates to that new max.
- Updated existing auto-T0 tests for the backdated timestamp + new payload keys.

## Gate (local)
- `ruff check .` — All checks passed!
- `ruff format --check .` — 35 files already formatted
- `pyright` — 0 errors, 0 warnings, 0 informations
- `pytest` — 407 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)