### PR TITLE
fix(fc): backdate first crack to the confirming-window onset, not the audio-confirmation tick (#168)

### DIFF
--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -120,6 +120,10 @@ class FirstCrackDetectionEvent:
         confirmation_window_seconds: Configured recent-positive window span.
         detected_at_inferred: Whether the detection timestamp was inferred from
             the source window end because the backend omitted an explicit timestamp.
+        confirmed_at_monotonic_seconds: Raw confirmation timestamp — the
+            detection timestamp of the window that satisfied the recent-positive
+            rule. `detected_at_monotonic_seconds` is backdated to the crack
+            onset (#168); this preserves the original audio-confirmation moment.
     """
 
     kind: FirstCrackDetectorEventKind
@@ -137,12 +141,14 @@ class FirstCrackDetectionEvent:
     min_positive_windows: int
     confirmation_window_seconds: float
     detected_at_inferred: bool
+    confirmed_at_monotonic_seconds: float
 
     def payload(self) -> dict[str, str | int | float | None]:
         """Return session-event payload metadata for this confirmed detection."""
         payload: dict[str, str | int | float | None] = {
             "source": "first_crack_detector",
             "detected_at_monotonic_seconds": self.detected_at_monotonic_seconds,
+            "confirmed_at_monotonic_seconds": self.confirmed_at_monotonic_seconds,
             "precision": self.precision,
             "revision": self.revision,
             "repo_id": self.repo_id,
@@ -163,6 +169,8 @@ class FirstCrackDetectionEvent:
 @dataclass(frozen=True)
 class _PositiveWindowCandidate:
     event: FirstCrackDetectionEvent
+    window_onset_monotonic_seconds: float
+    detected_at_monotonic_seconds: float
 
 
 @dataclass
@@ -188,6 +196,7 @@ class FirstCrackDetectorAdapter:
 
         confidence = _validate_optional_confidence(output.confidence)
         detected_at_monotonic_seconds = _detection_timestamp(window, output)
+        window_onset_monotonic_seconds = round(window.started_at_monotonic_seconds, 6)
         candidate = FirstCrackDetectionEvent(
             kind="first_crack_detected",
             detected_at_monotonic_seconds=detected_at_monotonic_seconds,
@@ -204,17 +213,32 @@ class FirstCrackDetectorAdapter:
             min_positive_windows=self.config.min_positive_windows,
             confirmation_window_seconds=self.config.confirmation_window_seconds,
             detected_at_inferred=output.detected_at_monotonic_seconds is None,
+            confirmed_at_monotonic_seconds=detected_at_monotonic_seconds,
         )
-        self._positive_candidates.append(_PositiveWindowCandidate(event=candidate))
+        self._positive_candidates.append(
+            _PositiveWindowCandidate(
+                event=candidate,
+                window_onset_monotonic_seconds=window_onset_monotonic_seconds,
+                detected_at_monotonic_seconds=detected_at_monotonic_seconds,
+            )
+        )
         self._prune_positive_candidates(detected_at_monotonic_seconds)
         if len(self._positive_candidates) < self.config.min_positive_windows:
             return None
 
-        earliest = self._positive_candidates[0].event
+        # Backdate the reported first crack to the ONSET of the confirming crack
+        # window — the start of the earliest positive window still inside the
+        # confirmation span — rather than the audio-confirmation tick (#168).
+        # The confirming window's detection timestamp is preserved as the raw
+        # confirmation moment, which the agent prompt is told lags the true
+        # crack (memory fc-detector-lag).
+        earliest = self._positive_candidates[0]
         return replace(
-            earliest,
+            earliest.event,
+            detected_at_monotonic_seconds=earliest.window_onset_monotonic_seconds,
             confirmed_by_window_sequence_number=window.sequence_number,
             positive_window_count=len(self._positive_candidates),
+            confirmed_at_monotonic_seconds=detected_at_monotonic_seconds,
         )
 
     def _prune_positive_candidates(self, current_monotonic_seconds: float) -> None:
@@ -222,7 +246,7 @@ class FirstCrackDetectorAdapter:
         self._positive_candidates = [
             candidate
             for candidate in self._positive_candidates
-            if candidate.event.detected_at_monotonic_seconds >= cutoff
+            if candidate.detected_at_monotonic_seconds >= cutoff
         ]
 
 
@@ -432,6 +456,7 @@ def integrate_first_crack_window_with_session(
         session,
         detected_at_monotonic_seconds=detection_event.detected_at_monotonic_seconds,
         max_future_seconds=future_tolerance,
+        confirmed_at_monotonic_seconds=detection_event.confirmed_at_monotonic_seconds,
         payload=detection_event.payload(),
     )
     return FirstCrackTimelineIntegrationResult(event=event, session=snapshot)

--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -118,12 +118,19 @@ class FirstCrackDetectionEvent:
         min_positive_windows: Configured positive-window count required for
             confirmation.
         confirmation_window_seconds: Configured recent-positive window span.
-        detected_at_inferred: Whether the detection timestamp was inferred from
-            the source window end because the backend omitted an explicit timestamp.
+        detected_at_inferred: Whether the BACKDATED detection timestamp was
+            inferred from a source window end because the backend omitted an
+            explicit timestamp (the earliest positive window's flag).
         confirmed_at_monotonic_seconds: Raw confirmation timestamp — the
             detection timestamp of the window that satisfied the recent-positive
             rule. `detected_at_monotonic_seconds` is backdated to the crack
             onset (#168); this preserves the original audio-confirmation moment.
+        confirmed_at_inferred: Whether the CONFIRMING window's timestamp was
+            inferred from its window end. The future-timeline tolerance is
+            validated against `confirmed_at_monotonic_seconds`, so it must key
+            off this flag (the confirming window's basis), not the earliest
+            window's — they can differ when explicit/inferred timestamps mix
+            across windows.
     """
 
     kind: FirstCrackDetectorEventKind
@@ -142,6 +149,7 @@ class FirstCrackDetectionEvent:
     confirmation_window_seconds: float
     detected_at_inferred: bool
     confirmed_at_monotonic_seconds: float
+    confirmed_at_inferred: bool
 
     def payload(self) -> dict[str, str | int | float | None]:
         """Return session-event payload metadata for this confirmed detection."""
@@ -214,6 +222,7 @@ class FirstCrackDetectorAdapter:
             confirmation_window_seconds=self.config.confirmation_window_seconds,
             detected_at_inferred=output.detected_at_monotonic_seconds is None,
             confirmed_at_monotonic_seconds=detected_at_monotonic_seconds,
+            confirmed_at_inferred=output.detected_at_monotonic_seconds is None,
         )
         self._positive_candidates.append(
             _PositiveWindowCandidate(
@@ -232,6 +241,12 @@ class FirstCrackDetectorAdapter:
         # The confirming window's detection timestamp is preserved as the raw
         # confirmation moment, which the agent prompt is told lags the true
         # crack (memory fc-detector-lag).
+        #
+        # `detected_at_inferred` carries the EARLIEST window's flag (it describes
+        # the backdated onset), while `confirmed_at_inferred` carries THIS
+        # (confirming) window's flag — they can differ when explicit/inferred
+        # timestamps mix across windows, and the future-timeline tolerance keys
+        # off the confirming one.
         earliest = self._positive_candidates[0]
         return replace(
             earliest.event,
@@ -239,6 +254,7 @@ class FirstCrackDetectorAdapter:
             confirmed_by_window_sequence_number=window.sequence_number,
             positive_window_count=len(self._positive_candidates),
             confirmed_at_monotonic_seconds=detected_at_monotonic_seconds,
+            confirmed_at_inferred=output.detected_at_monotonic_seconds is None,
         )
 
     def _prune_positive_candidates(self, current_monotonic_seconds: float) -> None:
@@ -469,11 +485,17 @@ def _future_tolerance_for_detection(
     max_future_seconds: float | None,
     allow_future_timeline: bool,
 ) -> float | None:
-    if allow_future_timeline and detection_event.detected_at_inferred:
+    # The future-timeline bound is validated against the CONFIRMING window's
+    # timestamp (`confirmed_at_monotonic_seconds`), so the tolerance must key
+    # off the confirming window's inferred flag — not the earliest (backdated)
+    # window's, which can differ when explicit/inferred timestamps mix across
+    # windows. `window` here is always the confirming window, so its duration is
+    # the correct inferred allowance.
+    if allow_future_timeline and detection_event.confirmed_at_inferred:
         return None
     if max_future_seconds is not None:
         return max_future_seconds
-    if detection_event.detected_at_inferred:
+    if detection_event.confirmed_at_inferred:
         return window.duration_seconds
     return 0.0
 

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -1592,6 +1592,7 @@ class RoastSessionStore:
         *,
         detected_at_monotonic_seconds: float,
         max_future_seconds: float | None = 0.0,
+        confirmed_at_monotonic_seconds: float | None = None,
         payload: dict[str, EventPayloadValue] | None = None,
     ) -> tuple[RoastEvent, RoastSession]:
         """Record automatic first crack at the detector-provided monotonic time.
@@ -1599,13 +1600,22 @@ class RoastSessionStore:
         Args:
             session: Session to mutate.
             detected_at_monotonic_seconds: Absolute monotonic timestamp reported
-                by the detector for the first-crack event.
+                by the detector for the first-crack event. With #168 this is the
+                backdated crack onset (the confirming-window onset), not the
+                audio-confirmation tick.
             max_future_seconds: Allowed future timestamp tolerance. This lets
                 adapter-inferred window-end defaults record when the capture
                 window has just been emitted but its inferred end timestamp is
                 slightly ahead of the integration clock. Use `None` for
                 detector-paced replay where source-audio time can intentionally
                 advance faster than wall-clock time.
+            confirmed_at_monotonic_seconds: Raw audio-confirmation timestamp when
+                the recorded timestamp is backdated (#168). The future-timeline
+                bound is validated against this confirmation timestamp — the
+                actual detector signal that could be ahead of the integration
+                clock — so an implausible-future detector signal is still
+                rejected even though the recorded event is backdated to an
+                earlier onset. Defaults to ``detected_at_monotonic_seconds``.
             payload: Optional structured event details.
 
         Returns:
@@ -1629,10 +1639,25 @@ class RoastSessionStore:
                 return existing_event, _copy_session_for_read(session)
             _validate_event_transition(session, "first_crack_detected")
 
+            current_elapsed_seconds = session.elapsed_monotonic_seconds(self._monotonic_now)
+            # Validate the future-timeline bound against the raw confirmation
+            # timestamp (the actual detector signal), not the backdated onset:
+            # a wildly-future detector signal must still be rejected (#168).
+            confirmation_seconds = (
+                detected_at_monotonic_seconds
+                if confirmed_at_monotonic_seconds is None
+                else confirmed_at_monotonic_seconds
+            )
+            _detected_elapsed_seconds(
+                session,
+                detected_at_monotonic_seconds=confirmation_seconds,
+                current_elapsed_seconds=current_elapsed_seconds,
+                max_future_seconds=max_future_seconds,
+            )
             detected_elapsed_seconds = _detected_elapsed_seconds(
                 session,
                 detected_at_monotonic_seconds=detected_at_monotonic_seconds,
-                current_elapsed_seconds=session.elapsed_monotonic_seconds(self._monotonic_now),
+                current_elapsed_seconds=current_elapsed_seconds,
                 max_future_seconds=max_future_seconds,
             )
             event = RoastEvent(

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -151,7 +151,11 @@ def test_detector_adapter_maps_confirmed_output_to_first_crack_event() -> None:
 
     assert event is not None
     assert event.kind == "first_crack_detected"
-    assert event.detected_at_monotonic_seconds == 120.42
+    # FC is backdated to the confirming-window onset (window start 120.0),
+    # not the audio-detection timestamp 120.42 (#168). The raw confirmation
+    # timestamp stays available as confirmed_at_monotonic_seconds.
+    assert event.detected_at_monotonic_seconds == 120.0
+    assert event.confirmed_at_monotonic_seconds == 120.42
     assert event.precision == "fp32"
     assert event.revision == "v0.2.0"
     assert event.confidence == 0.87
@@ -167,7 +171,8 @@ def test_detector_adapter_maps_confirmed_output_to_first_crack_event() -> None:
     assert event.detected_at_inferred is False
     assert event.payload() == {
         "source": "first_crack_detector",
-        "detected_at_monotonic_seconds": 120.42,
+        "detected_at_monotonic_seconds": 120.0,
+        "confirmed_at_monotonic_seconds": 120.42,
         "precision": "fp32",
         "revision": "v0.2.0",
         "repo_id": "syamaner/custom-first-crack",
@@ -183,7 +188,7 @@ def test_detector_adapter_maps_confirmed_output_to_first_crack_event() -> None:
     }
 
 
-def test_detector_adapter_uses_window_end_timestamp_when_output_has_no_timestamp() -> None:
+def test_detector_adapter_backdates_inferred_timestamp_to_window_onset() -> None:
     window = _audio_window(started_at_monotonic_seconds=55.25, duration_seconds=1.0)
     backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=True),))
     adapter = build_first_crack_detector_adapter(
@@ -195,7 +200,12 @@ def test_detector_adapter_uses_window_end_timestamp_when_output_has_no_timestamp
     event = adapter.process_window(window)
 
     assert event is not None
-    assert event.detected_at_monotonic_seconds == 56.25
+    # With no explicit detector timestamp, FC is backdated to the window onset
+    # (55.25) rather than the inferred window end (56.25) — recovering the
+    # window-duration slice of detector lag (#168). The window-end stays
+    # available as the raw confirmation timestamp.
+    assert event.detected_at_monotonic_seconds == 55.25
+    assert event.confirmed_at_monotonic_seconds == 56.25
     assert event.confidence is None
     assert event.detected_at_inferred is True
     assert "confidence" not in event.payload()
@@ -237,7 +247,11 @@ def test_detector_adapter_confirms_from_recent_positive_windows() -> None:
     assert second is None
     assert third is None
     assert confirmed is not None
-    assert confirmed.detected_at_monotonic_seconds == 101.0
+    # Backdated to the onset of the earliest positive window (seq 10 starts at
+    # 100.0), not its window end (101.0) and not the confirming window (#168).
+    assert confirmed.detected_at_monotonic_seconds == 100.0
+    # Raw confirmation = the confirming window's (seq 13) end timestamp.
+    assert confirmed.confirmed_at_monotonic_seconds == 110.0
     assert confirmed.window_sequence_number == 10
     assert confirmed.confirmed_by_window_sequence_number == 13
     assert confirmed.positive_window_count == 3
@@ -271,9 +285,61 @@ def test_detector_adapter_prunes_old_positive_windows_before_confirmation() -> N
     assert first is None
     assert second is None
     assert confirmed is not None
-    assert confirmed.detected_at_monotonic_seconds == 107.0
+    # Window 1 (end 101.0) is pruned outside the 5.0s confirmation span; the
+    # earliest surviving positive is window 2, backdated to its onset 106.0
+    # (not its end 107.0). Raw confirmation = window 3 end 110.0 (#168).
+    assert confirmed.detected_at_monotonic_seconds == 106.0
+    assert confirmed.confirmed_at_monotonic_seconds == 110.0
     assert confirmed.window_sequence_number == 2
     assert confirmed.confirmed_by_window_sequence_number == 3
+
+
+def test_detector_adapter_backdates_to_first_confirming_crack_window() -> None:
+    """FC reports the onset of the FIRST confirming crack window, recovering lag.
+
+    Mirrors the roast-3 finding (#168, memory fc-detector-lag): the detector
+    needs a window of cracks before it fires, so the confirmation tick lags the
+    first audible crack. Backdating to the earliest positive window's onset
+    recovers that gap deterministically. Here three positive windows span
+    200.0 -> 208.0; the reported FC is the first window's onset (200.0), while
+    the raw confirmation lands at the third window's end (209.0) — a ~9 s lag.
+    """
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.95),
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.96),
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.97),
+        )
+    )
+    adapter = build_first_crack_detector_adapter(
+        FirstCrackConfig(min_positive_windows=3, confirmation_window_seconds=20.0),
+        _resolved_detector_artifacts(),
+        backend,
+    )
+
+    assert (
+        adapter.process_window(_audio_window(sequence_number=1, started_at_monotonic_seconds=200.0))
+        is None
+    )
+    assert (
+        adapter.process_window(_audio_window(sequence_number=2, started_at_monotonic_seconds=204.0))
+        is None
+    )
+    confirmed = adapter.process_window(
+        _audio_window(sequence_number=3, started_at_monotonic_seconds=208.0)
+    )
+
+    assert confirmed is not None
+    # Reported FC = onset of the first confirming crack window (seq 1).
+    assert confirmed.detected_at_monotonic_seconds == 200.0
+    assert confirmed.window_sequence_number == 1
+    # Raw confirmation = the third window's (inferred) end timestamp.
+    assert confirmed.confirmed_at_monotonic_seconds == 209.0
+    assert confirmed.confirmed_by_window_sequence_number == 3
+    # The backdating recovers the full detector-confirmation lag.
+    assert confirmed.confirmed_at_monotonic_seconds - confirmed.detected_at_monotonic_seconds == 9.0
+    assert confirmed.payload()["detected_at_monotonic_seconds"] == 200.0
+    assert confirmed.payload()["confirmed_at_monotonic_seconds"] == 209.0
 
 
 @pytest.mark.parametrize("confidence", (-0.01, 1.01, float("nan")))

--- a/tests/test_first_crack_integration.py
+++ b/tests/test_first_crack_integration.py
@@ -188,21 +188,25 @@ def test_confirmed_detector_output_records_first_crack_event_once() -> None:
         "first_crack_detected",
     ]
     assert session.phase == "development"
+    # FC is backdated to the confirming-window onset (seq 11 starts at 536.5,
+    # elapsed 36.5), not the detector timestamp 537.25 (#168). The raw
+    # confirmation timestamp stays in the payload.
     assert session.first_crack_at_utc == datetime(
         2026,
         5,
         17,
         14,
         0,
-        37,
-        250000,
+        36,
+        500000,
         tzinfo=UTC,
     )
-    assert session.first_crack_monotonic_seconds == 37.25
-    assert first_result.event.monotonic_seconds == 37.25
+    assert session.first_crack_monotonic_seconds == 36.5
+    assert first_result.event.monotonic_seconds == 36.5
     assert first_result.event.payload == {
         "source": "first_crack_detector",
-        "detected_at_monotonic_seconds": 537.25,
+        "detected_at_monotonic_seconds": 536.5,
+        "confirmed_at_monotonic_seconds": 537.25,
         "precision": "int8",
         "revision": "v0.1.0",
         "repo_id": "syamaner/coffee-first-crack-detection",
@@ -219,7 +223,8 @@ def test_confirmed_detector_output_records_first_crack_event_once() -> None:
     assert len(first_result.session.event_timeline) == 2
     assert [window.sequence_number for window in backend.windows] == [11]
     metrics = compute_roast_metrics(session, monotonic_now=clock.monotonic_now)
-    assert metrics.development_time_seconds == 2.75
+    # Development time grows because FC is backdated earlier (#168).
+    assert metrics.development_time_seconds == 3.5
 
 
 def test_automatic_detection_does_not_require_manual_override_permission() -> None:
@@ -274,9 +279,13 @@ def test_adapter_default_timestamp_records_when_window_end_is_slightly_ahead() -
 
     assert result is not None
     assert result.event.kind == "first_crack_detected"
-    assert result.event.monotonic_seconds == 1.25
-    assert result.event.payload["detected_at_monotonic_seconds"] == 502.0
-    assert session.first_crack_monotonic_seconds == 1.25
+    # FC backdates to the window onset (501.0, elapsed 1.0), which is no longer
+    # ahead of the integration clock; the inferred window end (502.0) is kept
+    # as the raw confirmation timestamp (#168).
+    assert result.event.monotonic_seconds == 1.0
+    assert result.event.payload["detected_at_monotonic_seconds"] == 501.0
+    assert result.event.payload["confirmed_at_monotonic_seconds"] == 502.0
+    assert session.first_crack_monotonic_seconds == 1.0
 
 
 def test_explicit_future_detector_timestamp_is_rejected() -> None:

--- a/tests/test_first_crack_integration.py
+++ b/tests/test_first_crack_integration.py
@@ -361,6 +361,73 @@ def test_explicit_future_detector_timestamp_is_rejected_with_future_timeline_ena
     assert session.phase == "roasting"
 
 
+def test_mixed_explicit_then_inferred_windows_use_confirming_window_tolerance() -> None:
+    """Future tolerance keys off the CONFIRMING window, not the backdated one.
+
+    When the earliest positive window has an EXPLICIT timestamp but the
+    confirming window's timestamp is INFERRED (its window end, which can sit
+    slightly ahead of the integration clock), the future-timeline bound must be
+    the confirming window's inferred allowance. Keying it off the earliest
+    (explicit) window's flag would pick a 0.0 tolerance and wrongly reject a
+    valid backdated FC. Mirrors the cross-window mismatch in the #168 review.
+    """
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    store.record_event(session, "beans_added")
+    config = FirstCrackConfig(mode="audio", min_positive_windows=2)
+    backend = MockDetectorBackend(
+        (
+            # Earliest positive: EXPLICIT detector timestamp.
+            FirstCrackDetectorOutput(
+                confirmed=True,
+                confidence=0.95,
+                detected_at_monotonic_seconds=510.3,
+            ),
+            # Confirming window: INFERRED (no timestamp) — its window end (512.0)
+            # is 0.5s ahead of the integration clock (511.5).
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.96),
+        )
+    )
+    adapter = build_first_crack_detector_adapter(config, _resolved_detector_artifacts(), backend)
+
+    clock.monotonic_value = 511.0
+    first_result = integrate_first_crack_window_with_session(
+        config=config,
+        adapter=adapter,
+        session_store=store,
+        session=session,
+        window=_audio_window(
+            sequence_number=1,
+            started_at_monotonic_seconds=510.0,
+            duration_seconds=1.0,
+        ),
+    )
+    clock.monotonic_value = 511.5
+    second_result = integrate_first_crack_window_with_session(
+        config=config,
+        adapter=adapter,
+        session_store=store,
+        session=session,
+        window=_audio_window(
+            sequence_number=2,
+            started_at_monotonic_seconds=511.0,
+            duration_seconds=1.0,
+        ),
+    )
+
+    # The confirming window's inferred end (512.0) is ahead of the clock but
+    # within the confirming-window tolerance, so FC records — backdated to the
+    # earliest window's onset (510.0, elapsed 10.0).
+    assert first_result is None
+    assert second_result is not None
+    assert second_result.event.kind == "first_crack_detected"
+    assert second_result.event.monotonic_seconds == 10.0
+    assert second_result.event.payload["detected_at_monotonic_seconds"] == 510.0
+    assert second_result.event.payload["confirmed_at_monotonic_seconds"] == 512.0
+    assert session.phase == "development"
+
+
 def test_manual_first_crack_event_takes_precedence_over_later_detector_confirmation() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -175,7 +175,9 @@ def test_audio_runtime_processes_after_beans_added_and_records_once() -> None:
         "beans_added",
         "first_crack_detected",
     ]
-    assert session.first_crack_monotonic_seconds == 6.0
+    # FC is backdated to the confirming-window onset (seq 1 starts at 505.0,
+    # elapsed 5.0), not the detector timestamp 506.0 (#168).
+    assert session.first_crack_monotonic_seconds == 5.0
 
 
 def test_detector_paced_audio_runtime_drains_one_window_per_processing_tick() -> None:
@@ -225,7 +227,9 @@ def test_detector_paced_audio_runtime_drains_one_window_per_processing_tick() ->
     assert detected.status == "detected"
     assert pipeline.drain_limits == [1, 1]
     assert [window.sequence_number for window in backend.windows] == [1, 2]
-    assert session.first_crack_monotonic_seconds == 7.0
+    # Inferred timestamp backdates to the confirming-window onset (seq 2 starts
+    # at 506.0, elapsed 6.0), not its window end 507.0 (#168).
+    assert session.first_crack_monotonic_seconds == 6.0
 
 
 def test_audio_runtime_reports_stopped_after_pipeline_stop_returns_running_snapshot() -> None:
@@ -388,7 +392,9 @@ def test_audio_runtime_records_earliest_positive_after_confirmation() -> None:
     detected = runtime.process_available_windows(session_store=store, session=session)
 
     assert detected.status == "detected"
-    assert session.first_crack_monotonic_seconds == 4.0
+    # Backdated to the onset of the earliest positive window (seq 1 starts at
+    # 503.0, elapsed 3.0), not its window end 504.0 (#168).
+    assert session.first_crack_monotonic_seconds == 3.0
     assert session.event_timeline[-1].payload["window_sequence_number"] == 1
     assert session.event_timeline[-1].payload["confirmed_by_window_sequence_number"] == 4
     assert session.event_timeline[-1].payload["positive_window_count"] == 3
@@ -420,7 +426,9 @@ def test_detector_paced_wav_replay_preserves_source_audio_timeline() -> None:
     detected = runtime.process_available_windows(session_store=store, session=session)
 
     assert detected.status == "detected"
-    assert session.first_crack_monotonic_seconds == 5.0
+    # Backdated to the confirming-window onset (504.0, elapsed 4.0), not the
+    # inferred window end 505.0 (#168).
+    assert session.first_crack_monotonic_seconds == 4.0
 
 
 def test_audio_runtime_reports_unavailable_artifact_errors_without_crashing() -> None:


### PR DESCRIPTION
Closes #168. Sibling of #167 (T0 backdating) — same confirmation-lag pattern, applied to FC. Independent PR off `main` (does not depend on #167).

## Problem
First crack is stamped at the moment the audio detector **confirms** the crack, which lags the true onset: the detector needs N positive windows before it fires, and an inferred timestamp uses the window **END**. A late FC **compresses** measured development time and skews DTR — which the agent's post-FC control loop + drop rule depend on — and distorts the D44 corpus labels (memory `fc-detector-lag`: audio FC lags true crack ~12-21 s).

## Change
Backdate the reported first crack to the **onset of the confirming crack window** — the start of the earliest positive window still inside the confirmation span.

- `FirstCrackDetectorAdapter` now tracks each positive window's `started_at_monotonic_seconds` onset (`_PositiveWindowCandidate`). On confirmation, `process_window` reports `detected_at_monotonic_seconds = earliest positive window onset` instead of the earliest window's end.
- The **raw audio-confirmation timestamp is preserved** as `confirmed_at_monotonic_seconds` (new `FirstCrackDetectionEvent` field + payload key). The agent prompt is told the lag, so it keeps both.
- `record_first_crack_detection_snapshot` gains an optional `confirmed_at_monotonic_seconds`. The **future-timeline bound is validated against the confirmation timestamp** (the actual detector signal that can be ahead of the integration clock), not the backdated onset — so an implausible-future detector signal is **still rejected** even though the recorded event is backdated. The onset is also re-validated (cannot precede `beans_added`).

Existing FC payload keys are unchanged; `confirmed_at_monotonic_seconds` is added alongside. JSONL/summary exports serialize the full payload, so the new field flows through with no export wiring.

## Why independent of #167
#167 touches the auto-T0 path in `session.py`; this touches the FC detector adapter (`detector.py`) + the FC record method. No shared edits — built off clean `origin/main` in a separate worktree.

## Consumer note (roastpilot-agent)
The agent accepts FC from MCP detection. For accurate development-time/DTR it should honour MCP's **reported (backdated)** FC `monotonic_seconds`/`recorded_at_utc`, with `confirmed_at_monotonic_seconds` in the payload preserving the raw confirmation moment (the prompt is told the lag). Same shape as #167's T0 backdating. The future-rejection contract is unchanged from the consumer's side — backdated timestamps are never in the future.

## Tests
- `test_detector_adapter_backdates_to_first_confirming_crack_window`: three positive windows span 200.0→208.0 → reported FC = first window onset (200.0); raw confirmation = third window end (209.0); the 9 s lag is recovered.
- `test_detector_adapter_backdates_inferred_timestamp_to_window_onset`: inferred timestamp reports window onset (55.25), not window end (56.25).
- The two `explicit_future_detector_timestamp_is_rejected` tests still pass — the future guard now keys off the confirmation timestamp.
- Updated detector/integration/runtime tests for the onset-backdated timestamps + new payload key.

## Gate (local)
- `ruff check .` — All checks passed!
- `ruff format --check .` — 35 files already formatted
- `pyright` — 0 errors, 0 warnings, 0 informations
- `pytest` — 406 passed
- New/changed `detector.py` + `session.py` lines are covered (the only uncovered lines are pre-existing ONNX-runtime backend paths). Whole-package `--cov` total is 89.61% (baseline on clean `main` is 89.60% — this PR does not regress it; the local `fail_under` is not the CI gate, `codecov/patch` is, and the patch is covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)