### PR TITLE
chore(release): bump version to 0.1.7

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.syamaner/coffee-roaster-mcp",
   "title": "RoastPilot",
   "description": "RoastPilot controls coffee roasting sessions through local stdio MCP tools and exports logs.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "websiteUrl": "https://github.com/syamaner/coffee-roaster-mcp#readme",
   "repository": {
     "url": "https://github.com/syamaner/coffee-roaster-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "coffee-roaster-mcp",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "runtimeHint": "uvx",
       "packageArguments": [
         {

--- a/src/coffee_roaster_mcp/__init__.py
+++ b/src/coffee_roaster_mcp/__init__.py
@@ -1,3 +1,3 @@
 """RoastPilot MCP server package."""
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -94,7 +94,7 @@ _EXPECTED_T0_STATUS_KEYS = {
 
 
 def test_version_is_defined() -> None:
-    assert __version__ == "0.1.6"
+    assert __version__ == "0.1.7"
 
 
 def test_cli_parser_program_name() -> None:


### PR DESCRIPTION
Release-prep for **v0.1.7**. Ships the T0/FC detection backdating merged after v0.1.6:
- **#169** — auto-T0 backdated to the turning point (not the confirmation tick)
- **#170** — first crack backdated to the confirming-window onset (not the audio-confirmation tick)

Bumps `__version__`, `server.json` (top-level + `packages[0].version`), and the pinned version test to `0.1.7` so the `validate-release-metadata` release gate passes. After merge, tag `v0.1.7` triggers the Release workflow (publish jobs gated behind the `release` environment for operator approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)