### PR TITLE
fix(#162): quiet the SDK per-request INFO flood during a live roast

### DIFF
--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
@@ -780,12 +781,36 @@ def create_mcp_server(
     return mcp
 
 
+# Logger of the MCP SDK's low-level server, which logs one INFO line
+# ("Processing request of type ...") for every request it dispatches. During a
+# live roast the agent polls ``get_roast_state`` once per controller tick (~1 Hz),
+# so at INFO this single logger floods the console for the whole roast and buries
+# the operator-relevant output (phase changes, advisor recs, safety verdicts,
+# audio mic-overflow recovery). The name is stable across the SDK versions we pin;
+# it is asserted in the tests so a rename surfaces loudly rather than silently
+# re-flooding.
+SDK_REQUEST_LOGGER_NAME = "mcp.server.lowlevel.server"
+
+
+def quiet_sdk_per_request_log() -> None:
+    """Raise the MCP SDK's per-request logger above INFO.
+
+    Suppresses the routine per-request ``Processing request of type
+    CallToolRequest`` INFO line that the SDK emits once per dispatched request,
+    while leaving ``WARNING`` and above visible so faults, mic-overflow recovery,
+    and real errors still surface. This is observability-only and touches no other
+    logger (the project's own ``coffee_roaster_mcp.*`` INFO lines are unaffected).
+    """
+    logging.getLogger(SDK_REQUEST_LOGGER_NAME).setLevel(logging.WARNING)
+
+
 def run_stdio_server(config_path: str | Path | None = None) -> None:
     """Run RoastPilot over stdio transport.
 
     Args:
         config_path: Optional explicit config path.
     """
+    quiet_sdk_per_request_log()
     create_mcp_server(config_path=config_path, transport="stdio").run(transport="stdio")
 
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -793,15 +793,21 @@ SDK_REQUEST_LOGGER_NAME = "mcp.server.lowlevel.server"
 
 
 def quiet_sdk_per_request_log() -> None:
-    """Raise the MCP SDK's per-request logger above INFO.
+    """Raise the MCP SDK's per-request logger to WARNING if it is more verbose.
 
     Suppresses the routine per-request ``Processing request of type
     CallToolRequest`` INFO line that the SDK emits once per dispatched request,
     while leaving ``WARNING`` and above visible so faults, mic-overflow recovery,
     and real errors still surface. This is observability-only and touches no other
     logger (the project's own ``coffee_roaster_mcp.*`` INFO lines are unaffected).
+
+    Only raises the level: if a user or config has already set the logger to a
+    stricter level (``ERROR``/``CRITICAL``), that setting is preserved rather than
+    trampled down to ``WARNING``.
     """
-    logging.getLogger(SDK_REQUEST_LOGGER_NAME).setLevel(logging.WARNING)
+    sdk_logger = logging.getLogger(SDK_REQUEST_LOGGER_NAME)
+    if sdk_logger.getEffectiveLevel() < logging.WARNING:
+        sdk_logger.setLevel(logging.WARNING)
 
 
 def run_stdio_server(config_path: str | Path | None = None) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -55,6 +55,19 @@ def test_quiet_sdk_per_request_log_suppresses_info_keeps_warning() -> None:
         project_logger.setLevel(original_project_level)
 
 
+def test_quiet_sdk_per_request_log_only_raises_never_lowers() -> None:
+    """A stricter user/config level (e.g. ERROR) is preserved, not trampled to WARNING."""
+    sdk_logger = logging.getLogger(SDK_REQUEST_LOGGER_NAME)
+    original_sdk_level = sdk_logger.level
+    sdk_logger.setLevel(logging.ERROR)
+    try:
+        quiet_sdk_per_request_log()
+
+        assert sdk_logger.level == logging.ERROR
+    finally:
+        sdk_logger.setLevel(original_sdk_level)
+
+
 def test_in_process_mcp_tools_cover_mock_roast_and_export(tmp_path: Path) -> None:
     config_path = tmp_path / "coffee-roaster-mcp.yaml"
     config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from threading import Event, Thread
 from types import SimpleNamespace
@@ -17,11 +18,41 @@ from coffee_roaster_mcp.first_crack_runtime import (
     FirstCrackRuntimeState,
 )
 from coffee_roaster_mcp.mcp_server import (
+    SDK_REQUEST_LOGGER_NAME,
     ServerContext,
     build_server_context,
     create_mcp_server,
+    quiet_sdk_per_request_log,
 )
 from coffee_roaster_mcp.session import RoastSession, RoastSessionStore, SessionLifecycleError
+
+
+def test_sdk_request_logger_name_matches_installed_sdk() -> None:
+    """The pinned SDK logger name must match the SDK we suppress, or the guard misses."""
+    import mcp.server.lowlevel.server as sdk_server
+
+    assert sdk_server.logger.name == SDK_REQUEST_LOGGER_NAME
+
+
+def test_quiet_sdk_per_request_log_suppresses_info_keeps_warning() -> None:
+    """Quieting raises the SDK per-request logger to WARNING without touching others."""
+    sdk_logger = logging.getLogger(SDK_REQUEST_LOGGER_NAME)
+    project_logger = logging.getLogger("coffee_roaster_mcp.audio")
+    original_sdk_level = sdk_logger.level
+    original_project_level = project_logger.level
+    sdk_logger.setLevel(logging.INFO)
+    project_logger.setLevel(logging.INFO)
+    try:
+        quiet_sdk_per_request_log()
+
+        assert sdk_logger.level == logging.WARNING
+        assert sdk_logger.isEnabledFor(logging.WARNING)
+        assert not sdk_logger.isEnabledFor(logging.INFO)
+        # The project's own INFO logging (e.g. mic-overflow recovery) is untouched.
+        assert project_logger.level == logging.INFO
+    finally:
+        sdk_logger.setLevel(original_sdk_level)
+        project_logger.setLevel(original_project_level)
 
 
 def test_in_process_mcp_tools_cover_mock_roast_and_export(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

The MCP SDK's low-level server (`mcp.server.lowlevel.server`) logs one INFO line per dispatched request:

```
INFO  Processing request of type CallToolRequest   server.py:727
```

During a live roast the agent polls `get_roast_state` once per controller tick (~1 Hz), so that single SDK logger floods the console for the whole roast and buries the operator-relevant output (phase changes, advisor recs, safety verdicts, audio mic-overflow recovery).

## Change

`run_stdio_server` now raises `logging.getLogger("mcp.server.lowlevel.server")` to `WARNING` (via the `quiet_sdk_per_request_log()` helper) before calling `.run()`. `WARNING` and above stay visible so faults, mic-overflow recovery, and real errors still surface.

**Observability-only — no protocol or behaviour change.** Only the one noisy SDK logger is bumped; the project's own `coffee_roaster_mcp.*` INFO lines (including the audio mic-overflow recovery warnings) are untouched.

A test asserts the SDK logger name still matches the installed SDK, so a future SDK rename surfaces loudly (test fails) rather than silently re-flooding the console.

## Tests

- `test_sdk_request_logger_name_matches_installed_sdk` — guards the pinned logger name against an SDK rename.
- `test_quiet_sdk_per_request_log_suppresses_info_keeps_warning` — asserts INFO is suppressed, WARNING stays enabled, and a project logger is unaffected.

Full local gates green: `ruff check` / `ruff format --check` / `pyright` (0 errors) / `pytest` (full suite).

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)