### PR TITLE
0.1.9: FC confidence observability (#175) + roast audio capture (#176, mono + multi-device)

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.syamaner/coffee-roaster-mcp",
   "title": "RoastPilot",
   "description": "RoastPilot controls coffee roasting sessions through local stdio MCP tools and exports logs.",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "websiteUrl": "https://github.com/syamaner/coffee-roaster-mcp#readme",
   "repository": {
     "url": "https://github.com/syamaner/coffee-roaster-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "coffee-roaster-mcp",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "runtimeHint": "uvx",
       "packageArguments": [
         {

--- a/src/coffee_roaster_mcp/__init__.py
+++ b/src/coffee_roaster_mcp/__init__.py
@@ -1,3 +1,3 @@
 """RoastPilot MCP server package."""
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -167,7 +167,7 @@ def build_audio_capture_pipeline(
     queue_limit: int = DEFAULT_AUDIO_WINDOW_QUEUE_LIMIT,
     idle_sleep_seconds: float = DEFAULT_AUDIO_IDLE_SLEEP_SECONDS,
     monotonic_now: Callable[[], float] | None = None,
-    recorder: RoastAudioRecorder | None = None,
+    recorder: RoastRecorder | None = None,
 ) -> AudioCapturePipeline:
     """Create an audio capture pipeline from configured audio input settings.
 
@@ -447,24 +447,316 @@ class RecorderMilestonesProvider(Protocol):
         ...
 
 
+class RoastRecorder(Protocol):
+    """Recorder interface driven by the capture pipeline.
+
+    The pipeline calls ``begin`` once at capture start, ``write_samples`` for
+    every block of detector samples (the teed stream), and ``close`` once at
+    stop or fault. Single-device and multi-device recorders both satisfy it.
+    """
+
+    def begin(self) -> None:
+        """Open writers and capture the recording-start time."""
+        ...
+
+    def write_samples(self, samples: Sequence[float]) -> None:
+        """Append the teed detector samples to the detector-device WAV."""
+        ...
+
+    def close(self) -> None:
+        """Flush, finalize every WAV, and write the sidecar."""
+        ...
+
+
+def device_label_to_filename(label: str) -> str:
+    """Derive a filesystem-safe WAV stem fragment from a device label.
+
+    Lower-cases the label and replaces every run of non-alphanumeric characters
+    with a single hyphen, so ``"USB PnP"`` becomes ``"usb-pnp"`` and the WAV is
+    ``roast.usb-pnp.wav``. An empty result falls back to ``"device"``.
+
+    Args:
+        label: Device-name substring from `recording.devices`.
+
+    Returns:
+        A hyphenated, lower-cased label fragment safe for a filename.
+    """
+    slug_chars = [char.lower() if char.isalnum() else "-" for char in label]
+    slug = "".join(slug_chars).strip("-")
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    return slug or "device"
+
+
+class _WavStreamWriter:
+    """Buffered 16-bit mono PCM WAV writer for one recording stream.
+
+    Writes are buffered in memory and flushed to disk in blocks so the calling
+    thread is not stalled by a per-sample syscall. One writer owns one WAV file
+    and is driven by a single thread (the detector capture worker for the teed
+    stream, or that stream's own daemon thread for an independent device).
+    """
+
+    def __init__(
+        self,
+        *,
+        wav_path: Path,
+        device_label: str | None,
+        sample_rate: int,
+        flush_sample_threshold: int,
+    ) -> None:
+        """Configure one WAV stream writer.
+
+        Args:
+            wav_path: Destination WAV path. Parent directories are created.
+            device_label: Configured device selector for this stream, or `None`
+                for the system-default detector device.
+            sample_rate: WAV sample rate in Hz.
+            flush_sample_threshold: Buffered sample count that triggers a flush.
+
+        Raises:
+            AudioCaptureError: If sample_rate or the flush threshold is invalid.
+        """
+        if sample_rate <= 0:
+            raise AudioCaptureError("recording sample_rate must be > 0.")
+        if flush_sample_threshold < 1:
+            raise AudioCaptureError("recording flush_sample_threshold must be >= 1.")
+        self._wav_path = Path(wav_path)
+        self._device_label = device_label
+        self._sample_rate = sample_rate
+        self._flush_sample_threshold = flush_sample_threshold
+        self._wav: wave.Wave_write | None = None
+        self._pending: list[float] = []
+        self._frames_written = 0
+        self._closed = False
+
+    @property
+    def wav_path(self) -> Path:
+        """Return the destination WAV path."""
+        return self._wav_path
+
+    @property
+    def device_label(self) -> str | None:
+        """Return the configured device selector for this stream."""
+        return self._device_label
+
+    @property
+    def sample_rate(self) -> int:
+        """Return the WAV sample rate in Hz."""
+        return self._sample_rate
+
+    @property
+    def frames_written(self) -> int:
+        """Return the number of audio frames written to the WAV so far."""
+        return self._frames_written
+
+    @property
+    def is_open(self) -> bool:
+        """Return whether the WAV writer is currently open."""
+        return self._wav is not None
+
+    def begin(self) -> None:
+        """Open the WAV writer.
+
+        Raises:
+            AudioCaptureError: If the WAV file cannot be opened.
+        """
+        if self._wav is not None or self._closed:
+            return
+        self._wav_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            wav_file = wave.open(  # noqa: SIM115 - writer owns the handle until close().
+                str(self._wav_path), "wb"
+            )
+        except (OSError, wave.Error) as exc:
+            raise AudioCaptureError(
+                f"Could not open roast recording WAV {self._wav_path}: {exc}"
+            ) from exc
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(_RECORDER_SAMPLE_WIDTH_BYTES)
+        wav_file.setframerate(self._sample_rate)
+        self._wav = wav_file
+
+    def write_samples(self, samples: Sequence[float]) -> None:
+        """Append mono float samples to the buffer, flushing on threshold."""
+        if self._wav is None or self._closed or not samples:
+            return
+        self._pending.extend(float(sample) for sample in samples)
+        if len(self._pending) >= self._flush_sample_threshold:
+            self._flush()
+
+    def close(self) -> None:
+        """Flush remaining samples and finalize the WAV. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._wav is None:
+            return
+        try:
+            self._flush()
+        finally:
+            with suppress(Exception):
+                self._wav.close()
+            self._wav = None
+
+    def sidecar_entry(self) -> dict[str, object]:
+        """Return this stream's descriptor for the recording sidecar JSON."""
+        return {
+            "device": self._device_label,
+            "wav_filename": self._wav_path.name,
+            "sample_rate": self._sample_rate,
+            "channels": 1,
+            "sample_width_bytes": _RECORDER_SAMPLE_WIDTH_BYTES,
+            "frame_count": self._frames_written,
+            "duration_seconds": round(self._frames_written / self._sample_rate, 6),
+        }
+
+    def _flush(self) -> None:
+        if self._wav is None or not self._pending:
+            return
+        frames = bytearray()
+        for sample in self._pending:
+            clamped = -1.0 if sample < -1.0 else (1.0 if sample > 1.0 else sample)
+            frames += struct.pack("<h", int(round(clamped * _RECORDER_PCM16_MAX)))
+        self._wav.writeframes(bytes(frames))
+        self._frames_written += len(self._pending)
+        self._pending.clear()
+
+
+def _write_recording_sidecar(
+    *,
+    sidecar_path: Path,
+    session_id: str,
+    started_monotonic_seconds: float | None,
+    streams: Sequence[_WavStreamWriter],
+    milestones_provider: RecorderMilestonesProvider | None,
+) -> None:
+    """Write the per-roast recording sidecar JSON listing every WAV stream."""
+    milestones: Mapping[str, float | None] = {}
+    if milestones_provider is not None:
+        with suppress(Exception):
+            milestones = milestones_provider()
+    stream_entries = [stream.sidecar_entry() for stream in streams]
+    sidecar: dict[str, object] = {
+        "schema_version": 2,
+        "session_id": session_id,
+        "recording_started_monotonic_seconds": started_monotonic_seconds,
+        "milestones": {key: milestones.get(key) for key in milestones},
+        "streams": stream_entries,
+    }
+    if stream_entries:
+        # Back-compat convenience: surface the FIRST (detector) stream's fields at
+        # the top level so v1 sidecar consumers keep reading without the `streams`
+        # list. The detector stream is always index 0.
+        primary = stream_entries[0]
+        sidecar["wav_filename"] = primary["wav_filename"]
+        sidecar["sample_rate"] = primary["sample_rate"]
+        sidecar["channels"] = primary["channels"]
+        sidecar["sample_width_bytes"] = primary["sample_width_bytes"]
+        sidecar["frame_count"] = primary["frame_count"]
+        sidecar["duration_seconds"] = primary["duration_seconds"]
+    sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+    with sidecar_path.open("w", encoding="utf-8") as output:
+        json.dump(sidecar, output, sort_keys=True, indent=2)
+        output.write("\n")
+
+
+class _IndependentCaptureStream:
+    """Capture one additional device on its own thread into its own WAV.
+
+    Unlike the detector's teed stream, this opens a SEPARATE `MicrophoneAudioInput`
+    (its own PortAudio stream) and reads it in its own daemon thread. The stream
+    runs on an independent clock — it is NOT sample-locked to the detector or to
+    any other independent stream — which is acceptable for FC training data
+    (operator decision, option A). A read/open error on this stream is logged and
+    drops only this stream: detection and every other WAV keep running.
+    """
+
+    def __init__(
+        self,
+        *,
+        writer: _WavStreamWriter,
+        audio_input: AudioInput,
+        read_sample_count: int,
+        idle_sleep_seconds: float,
+    ) -> None:
+        """Configure one independent capture stream.
+
+        Args:
+            writer: WAV writer for this device's samples.
+            audio_input: Freshly-opened audio input for this device.
+            read_sample_count: Samples to request per read.
+            idle_sleep_seconds: Sleep when a read returns no samples.
+        """
+        self._writer = writer
+        self._audio_input = audio_input
+        self._read_sample_count = max(1, read_sample_count)
+        self._idle_sleep_seconds = max(0.0, idle_sleep_seconds)
+        self._stop_requested = Event()
+        self._thread: Thread | None = None
+
+    @property
+    def writer(self) -> _WavStreamWriter:
+        """Return this stream's WAV writer."""
+        return self._writer
+
+    def start(self) -> None:
+        """Open the WAV and spawn the capture thread."""
+        self._writer.begin()
+        self._stop_requested.clear()
+        thread = Thread(
+            target=self._run,
+            name=f"coffee-roaster-recording-{self._writer.wav_path.stem}",
+            daemon=True,
+        )
+        self._thread = thread
+        thread.start()
+
+    def stop(self, *, timeout_seconds: float = 1.0) -> None:
+        """Signal the capture thread to stop and join it briefly."""
+        self._stop_requested.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=timeout_seconds)
+
+    def _run(self) -> None:
+        try:
+            while not self._stop_requested.is_set():
+                samples = self._audio_input.read_samples(self._read_sample_count)
+                if not samples:
+                    time.sleep(self._idle_sleep_seconds)
+                    continue
+                self._writer.write_samples(samples)
+        except Exception as exc:  # noqa: BLE001 - one stream failing must not kill others.
+            _LOGGER.warning(
+                "Independent recording stream %s failed; dropping it: %s",
+                self._writer.wav_path.name,
+                exc,
+            )
+        finally:
+            # Close the audio input on the same thread that owns its reads, so its
+            # native PortAudio ring buffer is never freed mid-read (the same
+            # discipline the detector capture loop uses).
+            _close_audio_input_if_supported(self._audio_input)
+
+
 class RoastAudioRecorder:
-    """Tee the detector's mono capture stream into one per-roast WAV (#176, v1).
+    """Tee the detector's mono capture stream into one per-roast WAV (#176).
 
     This recorder is owned by the MCP audio pipeline, which already owns the
     audio device for detection. It does NOT open a second stream: the capture
     loop hands it the same float samples the detector consumes (the verified
     non-disturbing tee point), so there is no extra device contention.
 
-    v1 captures the detector's single mono stream into ONE WAV plus a session
-    sidecar JSON. True multi-channel / 2-mic capture (open the device at 2
-    channels into 2 WAVs) is a documented follow-on and is intentionally not
-    built here.
+    This is the single-stream recorder (the `recording.devices` unset fallback,
+    and the teed-only case). Multi-device capture (option A) is handled by
+    :class:`MultiDeviceRoastRecorder`, which composes this teed stream with extra
+    independently-captured device streams.
 
     Writes are buffered in memory and flushed to disk in blocks so the capture
     worker is not stalled by a per-sample syscall; the actual disk write still
-    happens on the capture thread, which is acceptable for the v1 mono stream on
-    the Pi-CPU budget (D27) but is the first thing to move to a dedicated writer
-    thread if multi-channel capture is added later.
+    happens on the capture thread, which is acceptable for the mono stream on the
+    Pi-CPU budget (D27).
 
     The recorder is not internally locked: the capture pipeline drives all of
     ``begin``, ``write_samples``, and ``close`` from its single worker thread, so
@@ -478,17 +770,20 @@ class RoastAudioRecorder:
         sidecar_path: Path,
         sample_rate: int,
         session_id: str,
+        device_label: str | None = None,
         milestones_provider: RecorderMilestonesProvider | None = None,
         monotonic_now: Callable[[], float] | None = None,
         flush_sample_threshold: int = 16_000,
     ) -> None:
-        """Configure a per-roast audio recorder.
+        """Configure a per-roast single-stream audio recorder.
 
         Args:
             wav_path: Destination WAV path. Parent directories are created.
             sidecar_path: Destination sidecar JSON path written at close.
             sample_rate: WAV sample rate in Hz.
             session_id: Roast session identifier recorded in the sidecar.
+            device_label: Configured detector device selector, recorded in the
+                sidecar stream descriptor.
             milestones_provider: Optional callable returning roast milestone
                 offsets in recording-relative seconds, evaluated at close.
             monotonic_now: Optional monotonic clock supplier for tests.
@@ -498,27 +793,23 @@ class RoastAudioRecorder:
         Raises:
             AudioCaptureError: If sample_rate or the flush threshold is invalid.
         """
-        if sample_rate <= 0:
-            raise AudioCaptureError("recording sample_rate must be > 0.")
-        if flush_sample_threshold < 1:
-            raise AudioCaptureError("recording flush_sample_threshold must be >= 1.")
-        self._wav_path = Path(wav_path)
         self._sidecar_path = Path(sidecar_path)
-        self._sample_rate = sample_rate
         self._session_id = session_id
         self._milestones_provider = milestones_provider
         self._monotonic_now = monotonic_now or time.monotonic
-        self._flush_sample_threshold = flush_sample_threshold
-        self._wav: wave.Wave_write | None = None
-        self._pending: list[float] = []
-        self._frames_written = 0
+        self._writer = _WavStreamWriter(
+            wav_path=wav_path,
+            device_label=device_label,
+            sample_rate=sample_rate,
+            flush_sample_threshold=flush_sample_threshold,
+        )
         self._started_monotonic_seconds: float | None = None
         self._closed = False
 
     @property
     def wav_path(self) -> Path:
         """Return the destination WAV path."""
-        return self._wav_path
+        return self._writer.wav_path
 
     @property
     def sidecar_path(self) -> Path:
@@ -528,12 +819,12 @@ class RoastAudioRecorder:
     @property
     def sample_rate(self) -> int:
         """Return the WAV sample rate in Hz."""
-        return self._sample_rate
+        return self._writer.sample_rate
 
     @property
     def frames_written(self) -> int:
         """Return the number of audio frames written to the WAV so far."""
-        return self._frames_written
+        return self._writer.frames_written
 
     @property
     def started_monotonic_seconds(self) -> float | None:
@@ -542,78 +833,368 @@ class RoastAudioRecorder:
 
     def begin(self) -> None:
         """Open the WAV writer and capture the recording-start monotonic time."""
-        if self._wav is not None or self._closed:
+        if self._writer.is_open or self._closed:
             return
         self._started_monotonic_seconds = self._monotonic_now()
-        self._wav_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            wav_file = wave.open(  # noqa: SIM115 - recorder owns the handle until close().
-                str(self._wav_path), "wb"
-            )
-        except (OSError, wave.Error) as exc:
-            raise AudioCaptureError(
-                f"Could not open roast recording WAV {self._wav_path}: {exc}"
-            ) from exc
-        wav_file.setnchannels(1)
-        wav_file.setsampwidth(_RECORDER_SAMPLE_WIDTH_BYTES)
-        wav_file.setframerate(self._sample_rate)
-        self._wav = wav_file
+        self._writer.begin()
 
     def write_samples(self, samples: Sequence[float]) -> None:
         """Append the detector's mono float samples to the recording buffer."""
-        if self._wav is None or self._closed or not samples:
-            return
-        self._pending.extend(float(sample) for sample in samples)
-        if len(self._pending) >= self._flush_sample_threshold:
-            self._flush_locked()
+        self._writer.write_samples(samples)
 
     def close(self) -> None:
         """Flush remaining samples, finalize the WAV, and write the sidecar JSON."""
         if self._closed:
             return
         self._closed = True
-        if self._wav is None:
+        if self._started_monotonic_seconds is None:
+            # begin() was never called: nothing to finalize and no sidecar.
             return
-        try:
-            self._flush_locked()
-        finally:
-            with suppress(Exception):
-                self._wav.close()
-            self._wav = None
-        self._write_sidecar()
+        self._writer.close()
+        _write_recording_sidecar(
+            sidecar_path=self._sidecar_path,
+            session_id=self._session_id,
+            started_monotonic_seconds=self._started_monotonic_seconds,
+            streams=(self._writer,),
+            milestones_provider=self._milestones_provider,
+        )
 
-    def _flush_locked(self) -> None:
-        if self._wav is None or not self._pending:
+
+@dataclass(frozen=True)
+class AdditionalRecordingDevice:
+    """One additional, independently-captured recording device (#176 option A).
+
+    Attributes:
+        device_label: Device-name substring (matched like `audio.input_device`).
+        wav_path: Destination WAV path for this device's independent stream.
+        sample_rate: Capture/WAV sample rate in Hz for this device.
+    """
+
+    device_label: str
+    wav_path: Path
+    sample_rate: int
+
+
+#: Factory that opens a fresh audio input for an independent recording device.
+#: Injected in tests so multi-device capture is exercised without PortAudio.
+AdditionalAudioInputFactory = Callable[[AdditionalRecordingDevice], AudioInput]
+
+
+def _build_additional_microphone_input(device: AdditionalRecordingDevice) -> AudioInput:
+    """Open a fresh mono microphone input for an additional recording device."""
+    return MicrophoneAudioInput(
+        AudioCaptureSettings(
+            input_device=device.device_label,
+            sample_rate=device.sample_rate,
+        )
+    )
+
+
+class MultiDeviceRoastRecorder:
+    """Record several independent USB-mic streams per roast — one WAV each (#176).
+
+    Option A (operator decision): instead of an aggregate device or JACK, each
+    configured device is captured as its OWN stream. By convention the FIRST
+    device is the FC detector's device, so its WAV is TEED from the existing
+    detector capture stream (no second open, no contention) exactly like
+    :class:`RoastAudioRecorder`. Each ADDITIONAL device is opened as its own
+    independent :class:`MicrophoneAudioInput` running in its own daemon thread,
+    written to its own WAV.
+
+    The streams run on INDEPENDENT clocks — they are NOT sample-locked to each
+    other or to the detector — and may drift over a long roast. That is expected
+    and acceptable for FC training data; the per-stream WAVs are labelled and
+    each carries its own sample rate in the sidecar, and the recording-start
+    monotonic timestamp anchors them to the roast clock for offline alignment.
+
+    Fail-soft per stream: opening or reading an additional device that errors
+    logs and drops only THAT stream; detection (the teed stream) and every other
+    additional WAV keep recording. The teed stream shares the detector capture
+    worker, so it cannot contend with itself.
+
+    The pipeline drives ``begin``/``write_samples``/``close`` from its single
+    worker thread; only the additional streams add threads, and each owns its own
+    writer, so no two threads write the same WAV.
+    """
+
+    def __init__(
+        self,
+        *,
+        detector_wav_path: Path,
+        detector_device_label: str | None,
+        sidecar_path: Path,
+        sample_rate: int,
+        session_id: str,
+        additional_devices: Sequence[AdditionalRecordingDevice] = (),
+        milestones_provider: RecorderMilestonesProvider | None = None,
+        monotonic_now: Callable[[], float] | None = None,
+        flush_sample_threshold: int = 16_000,
+        additional_input_factory: AdditionalAudioInputFactory | None = None,
+        additional_read_seconds: float = 0.25,
+        idle_sleep_seconds: float = DEFAULT_AUDIO_IDLE_SLEEP_SECONDS,
+        stop_timeout_seconds: float = 1.0,
+    ) -> None:
+        """Configure a multi-device per-roast recorder.
+
+        Args:
+            detector_wav_path: WAV path for the teed detector-device stream.
+            detector_device_label: Detector device selector for the sidecar.
+            sidecar_path: Destination sidecar JSON path written at close.
+            sample_rate: WAV sample rate for the teed detector stream.
+            session_id: Roast session identifier recorded in the sidecar.
+            additional_devices: Independently-captured devices (one WAV each).
+            milestones_provider: Optional roast-milestone offsets supplier.
+            monotonic_now: Optional monotonic clock supplier for tests.
+            flush_sample_threshold: Buffered sample count that triggers a flush.
+            additional_input_factory: Opens a fresh input per additional device;
+                defaults to the real microphone input. Injected in tests.
+            additional_read_seconds: Read-block duration for additional streams.
+            idle_sleep_seconds: Sleep when an additional read returns no samples.
+            stop_timeout_seconds: Per-stream join timeout at close.
+
+        Raises:
+            AudioCaptureError: If a sample rate or the flush threshold is invalid.
+        """
+        self._sidecar_path = Path(sidecar_path)
+        self._session_id = session_id
+        self._milestones_provider = milestones_provider
+        self._monotonic_now = monotonic_now or time.monotonic
+        self._stop_timeout_seconds = stop_timeout_seconds
+        self._started_monotonic_seconds: float | None = None
+        self._closed = False
+        self._detector_writer = _WavStreamWriter(
+            wav_path=detector_wav_path,
+            device_label=detector_device_label,
+            sample_rate=sample_rate,
+            flush_sample_threshold=flush_sample_threshold,
+        )
+        factory = additional_input_factory or _build_additional_microphone_input
+        self._additional_streams: list[_IndependentCaptureStream] = []
+        for device in additional_devices:
+            writer = _WavStreamWriter(
+                wav_path=device.wav_path,
+                device_label=device.device_label,
+                sample_rate=device.sample_rate,
+                flush_sample_threshold=flush_sample_threshold,
+            )
+            self._additional_streams.append(
+                _IndependentCaptureStream(
+                    writer=writer,
+                    audio_input=_LazyAdditionalAudioInput(device, factory),
+                    read_sample_count=max(1, round(device.sample_rate * additional_read_seconds)),
+                    idle_sleep_seconds=idle_sleep_seconds,
+                )
+            )
+
+    @property
+    def wav_path(self) -> Path:
+        """Return the teed detector-stream WAV path."""
+        return self._detector_writer.wav_path
+
+    @property
+    def sidecar_path(self) -> Path:
+        """Return the destination sidecar JSON path."""
+        return self._sidecar_path
+
+    @property
+    def started_monotonic_seconds(self) -> float | None:
+        """Return the absolute monotonic timestamp captured at recording start."""
+        return self._started_monotonic_seconds
+
+    @property
+    def additional_wav_paths(self) -> tuple[Path, ...]:
+        """Return the WAV paths for the independently-captured devices."""
+        return tuple(stream.writer.wav_path for stream in self._additional_streams)
+
+    def begin(self) -> None:
+        """Open the teed WAV and start every independent capture stream.
+
+        Starting an additional stream that fails to open drops only that stream;
+        the teed detector stream and the other additional streams continue.
+        """
+        if self._closed or self._started_monotonic_seconds is not None:
             return
-        frames = bytearray()
-        for sample in self._pending:
-            clamped = -1.0 if sample < -1.0 else (1.0 if sample > 1.0 else sample)
-            frames += struct.pack("<h", int(round(clamped * _RECORDER_PCM16_MAX)))
-        self._wav.writeframes(bytes(frames))
-        self._frames_written += len(self._pending)
-        self._pending.clear()
+        self._started_monotonic_seconds = self._monotonic_now()
+        self._detector_writer.begin()
+        for stream in self._additional_streams:
+            try:
+                stream.start()
+            except Exception as exc:  # noqa: BLE001 - one stream must not block the others.
+                _LOGGER.warning(
+                    "Could not start independent recording stream %s; dropping it: %s",
+                    stream.writer.wav_path.name,
+                    exc,
+                )
 
-    def _write_sidecar(self) -> None:
-        milestones: Mapping[str, float | None] = {}
-        if self._milestones_provider is not None:
+    def write_samples(self, samples: Sequence[float]) -> None:
+        """Append the teed detector samples to the detector-device WAV."""
+        self._detector_writer.write_samples(samples)
+
+    def close(self) -> None:
+        """Stop additional streams, finalize every WAV, and write the sidecar."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._started_monotonic_seconds is None:
+            return
+        for stream in self._additional_streams:
             with suppress(Exception):
-                milestones = self._milestones_provider()
-        sidecar: dict[str, object] = {
-            "schema_version": 1,
-            "session_id": self._session_id,
-            "wav_filename": self._wav_path.name,
-            "sample_rate": self._sample_rate,
-            "channels": 1,
-            "sample_width_bytes": _RECORDER_SAMPLE_WIDTH_BYTES,
-            "frame_count": self._frames_written,
-            "duration_seconds": round(self._frames_written / self._sample_rate, 6),
-            "recording_started_monotonic_seconds": self._started_monotonic_seconds,
-            "milestones": {key: milestones.get(key) for key in milestones},
-        }
-        self._sidecar_path.parent.mkdir(parents=True, exist_ok=True)
-        with self._sidecar_path.open("w", encoding="utf-8") as output:
-            json.dump(sidecar, output, sort_keys=True, indent=2)
-            output.write("\n")
+                stream.stop(timeout_seconds=self._stop_timeout_seconds)
+        self._detector_writer.close()
+        for stream in self._additional_streams:
+            with suppress(Exception):
+                stream.writer.close()
+        streams = [self._detector_writer, *(s.writer for s in self._additional_streams)]
+        _write_recording_sidecar(
+            sidecar_path=self._sidecar_path,
+            session_id=self._session_id,
+            started_monotonic_seconds=self._started_monotonic_seconds,
+            streams=streams,
+            milestones_provider=self._milestones_provider,
+        )
+
+
+@dataclass(frozen=True)
+class IndependentCaptureResult:
+    """Outcome of one device in an independent multi-device capture.
+
+    Attributes:
+        device_label: Configured device-name substring.
+        wav_path: WAV file written for this device.
+        sample_rate: Capture/WAV sample rate in Hz.
+        frame_count: Frames written for this device.
+    """
+
+    device_label: str
+    wav_path: Path
+    sample_rate: int
+    frame_count: int
+
+
+def capture_devices_independently(
+    devices: Sequence[AdditionalRecordingDevice],
+    *,
+    record_seconds: float,
+    sidecar_path: Path,
+    session_id: str,
+    input_factory: AdditionalAudioInputFactory | None = None,
+    sleep: Callable[[float], None] | None = None,
+    flush_sample_threshold: int | None = None,
+    read_seconds: float = 0.1,
+    idle_sleep_seconds: float = DEFAULT_AUDIO_IDLE_SLEEP_SECONDS,
+    stop_timeout_seconds: float = 1.0,
+) -> list[IndependentCaptureResult]:
+    """Capture every device as its own independent stream for `record_seconds`.
+
+    Each device is opened on its own daemon thread (no teeing, no detector), one
+    WAV each, and a recording sidecar listing them is written. A device that
+    fails to open/read is dropped (logged on its thread) and reports a zero-frame
+    result; the others keep capturing. This is the roast-free building block used
+    by the recording smoke test.
+
+    Args:
+        devices: Devices to capture independently.
+        record_seconds: How long to capture from every device.
+        sidecar_path: Sidecar JSON path written after capture.
+        session_id: Identifier recorded in the sidecar.
+        input_factory: Opens a fresh input per device; defaults to the real
+            microphone input. Injected in tests.
+        sleep: Sleep function for the capture window; defaults to `time.sleep`.
+        flush_sample_threshold: Buffer flush threshold; defaults to one read
+            block per device.
+        read_seconds: Per-read block duration.
+        idle_sleep_seconds: Sleep when a read returns no samples.
+        stop_timeout_seconds: Per-stream join timeout.
+
+    Returns:
+        One :class:`IndependentCaptureResult` per device, in input order.
+    """
+    factory = input_factory or _build_additional_microphone_input
+    sleep_fn = sleep or time.sleep
+    writers = [
+        _WavStreamWriter(
+            wav_path=device.wav_path,
+            device_label=device.device_label,
+            sample_rate=device.sample_rate,
+            flush_sample_threshold=(
+                flush_sample_threshold
+                if flush_sample_threshold is not None
+                else max(1, round(device.sample_rate * read_seconds))
+            ),
+        )
+        for device in devices
+    ]
+    streams = [
+        _IndependentCaptureStream(
+            writer=writer,
+            audio_input=_LazyAdditionalAudioInput(device, factory),
+            read_sample_count=max(1, round(device.sample_rate * read_seconds)),
+            idle_sleep_seconds=idle_sleep_seconds,
+        )
+        for device, writer in zip(devices, writers, strict=True)
+    ]
+    for stream in streams:
+        stream.start()
+    sleep_fn(record_seconds)
+    for stream in streams:
+        with suppress(Exception):
+            stream.stop(timeout_seconds=stop_timeout_seconds)
+    for writer in writers:
+        with suppress(Exception):
+            writer.close()
+    _write_recording_sidecar(
+        sidecar_path=sidecar_path,
+        session_id=session_id,
+        started_monotonic_seconds=None,
+        streams=writers,
+        milestones_provider=None,
+    )
+    return [
+        IndependentCaptureResult(
+            device_label=device.device_label,
+            wav_path=writer.wav_path,
+            sample_rate=device.sample_rate,
+            frame_count=writer.frames_written,
+        )
+        for device, writer in zip(devices, writers, strict=True)
+    ]
+
+
+class _LazyAdditionalAudioInput:
+    """Open an additional device's audio input lazily on its capture thread.
+
+    The factory call happens inside the capture thread's first ``read_samples``
+    so a slow or failing device open does not block ``begin`` (and thus the
+    roast start) on the caller thread; an open error is raised on the stream's
+    own thread, where it is caught and drops only that stream.
+    """
+
+    def __init__(
+        self,
+        device: AdditionalRecordingDevice,
+        factory: AdditionalAudioInputFactory,
+    ) -> None:
+        """Wrap one additional device with a lazily-opened input.
+
+        Args:
+            device: The additional recording device to open.
+            factory: Factory that opens a fresh input for the device.
+        """
+        self._device = device
+        self._factory = factory
+        self._input: AudioInput | None = None
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        """Open the input on first call, then read up to `sample_count` samples."""
+        if self._input is None:
+            self._input = self._factory(self._device)
+        return self._input.read_samples(sample_count)
+
+    def close(self) -> None:
+        """Close the underlying input if it was opened."""
+        if self._input is not None:
+            _close_audio_input_if_supported(self._input)
+            self._input = None
 
 
 class AudioCapturePipeline:
@@ -631,7 +1212,7 @@ class AudioCapturePipeline:
         settings: AudioCaptureSettings,
         audio_input: AudioInput,
         monotonic_now: Callable[[], float] | None = None,
-        recorder: RoastAudioRecorder | None = None,
+        recorder: RoastRecorder | None = None,
     ) -> None:
         """Initialize an audio capture pipeline.
 

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import importlib
+import json
 import logging
 import math
 import struct
 import time
 import wave
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -166,8 +167,24 @@ def build_audio_capture_pipeline(
     queue_limit: int = DEFAULT_AUDIO_WINDOW_QUEUE_LIMIT,
     idle_sleep_seconds: float = DEFAULT_AUDIO_IDLE_SLEEP_SECONDS,
     monotonic_now: Callable[[], float] | None = None,
+    recorder: RoastAudioRecorder | None = None,
 ) -> AudioCapturePipeline:
-    """Create an audio capture pipeline from configured audio input settings."""
+    """Create an audio capture pipeline from configured audio input settings.
+
+    Args:
+        config: Audio capture configuration.
+        input_factory: Optional configured-input factory override.
+        window_seconds: Optional detector window override.
+        queue_limit: Detector window queue limit.
+        idle_sleep_seconds: Idle sleep when no samples are available.
+        monotonic_now: Optional monotonic clock supplier for tests.
+        recorder: Optional roast audio recorder teed onto the detector stream
+            (#176). Detector-paced WAV replay never records, since it has no live
+            capture stream to tee.
+
+    Returns:
+        A configured capture pipeline.
+    """
     resolved_input_factory = input_factory or build_configured_audio_input
     settings = audio_capture_settings_from_config(
         config,
@@ -187,6 +204,7 @@ def build_audio_capture_pipeline(
         settings=settings,
         audio_input=resolved_input_factory(settings),
         monotonic_now=monotonic_now,
+        recorder=recorder,
     )
 
 
@@ -413,6 +431,191 @@ class MicrophoneAudioInput:
         self.close()
 
 
+#: 16-bit signed PCM is the recorder's on-disk format: it is the Label-Studio /
+#: training-corpus convention reused from coffee-first-crack-detection, keeps the
+#: WAV roughly half the size of 32-bit float, and the detector samples are already
+#: in the [-1, 1] float range so the conversion is a single multiply per sample.
+_RECORDER_SAMPLE_WIDTH_BYTES = 2
+_RECORDER_PCM16_MAX = 32767
+
+
+class RecorderMilestonesProvider(Protocol):
+    """Supplies roast milestone offsets for the recording sidecar at close."""
+
+    def __call__(self) -> Mapping[str, float | None]:
+        """Return milestone name to recording-relative seconds (or `None`)."""
+        ...
+
+
+class RoastAudioRecorder:
+    """Tee the detector's mono capture stream into one per-roast WAV (#176, v1).
+
+    This recorder is owned by the MCP audio pipeline, which already owns the
+    audio device for detection. It does NOT open a second stream: the capture
+    loop hands it the same float samples the detector consumes (the verified
+    non-disturbing tee point), so there is no extra device contention.
+
+    v1 captures the detector's single mono stream into ONE WAV plus a session
+    sidecar JSON. True multi-channel / 2-mic capture (open the device at 2
+    channels into 2 WAVs) is a documented follow-on and is intentionally not
+    built here.
+
+    Writes are buffered in memory and flushed to disk in blocks so the capture
+    worker is not stalled by a per-sample syscall; the actual disk write still
+    happens on the capture thread, which is acceptable for the v1 mono stream on
+    the Pi-CPU budget (D27) but is the first thing to move to a dedicated writer
+    thread if multi-channel capture is added later.
+
+    The recorder is not internally locked: the capture pipeline drives all of
+    ``begin``, ``write_samples``, and ``close`` from its single worker thread, so
+    no two of them run concurrently.
+    """
+
+    def __init__(
+        self,
+        *,
+        wav_path: Path,
+        sidecar_path: Path,
+        sample_rate: int,
+        session_id: str,
+        milestones_provider: RecorderMilestonesProvider | None = None,
+        monotonic_now: Callable[[], float] | None = None,
+        flush_sample_threshold: int = 16_000,
+    ) -> None:
+        """Configure a per-roast audio recorder.
+
+        Args:
+            wav_path: Destination WAV path. Parent directories are created.
+            sidecar_path: Destination sidecar JSON path written at close.
+            sample_rate: WAV sample rate in Hz.
+            session_id: Roast session identifier recorded in the sidecar.
+            milestones_provider: Optional callable returning roast milestone
+                offsets in recording-relative seconds, evaluated at close.
+            monotonic_now: Optional monotonic clock supplier for tests.
+            flush_sample_threshold: Buffered sample count that triggers a disk
+                flush. Larger values reduce syscalls at the cost of memory.
+
+        Raises:
+            AudioCaptureError: If sample_rate or the flush threshold is invalid.
+        """
+        if sample_rate <= 0:
+            raise AudioCaptureError("recording sample_rate must be > 0.")
+        if flush_sample_threshold < 1:
+            raise AudioCaptureError("recording flush_sample_threshold must be >= 1.")
+        self._wav_path = Path(wav_path)
+        self._sidecar_path = Path(sidecar_path)
+        self._sample_rate = sample_rate
+        self._session_id = session_id
+        self._milestones_provider = milestones_provider
+        self._monotonic_now = monotonic_now or time.monotonic
+        self._flush_sample_threshold = flush_sample_threshold
+        self._wav: wave.Wave_write | None = None
+        self._pending: list[float] = []
+        self._frames_written = 0
+        self._started_monotonic_seconds: float | None = None
+        self._closed = False
+
+    @property
+    def wav_path(self) -> Path:
+        """Return the destination WAV path."""
+        return self._wav_path
+
+    @property
+    def sidecar_path(self) -> Path:
+        """Return the destination sidecar JSON path."""
+        return self._sidecar_path
+
+    @property
+    def sample_rate(self) -> int:
+        """Return the WAV sample rate in Hz."""
+        return self._sample_rate
+
+    @property
+    def frames_written(self) -> int:
+        """Return the number of audio frames written to the WAV so far."""
+        return self._frames_written
+
+    @property
+    def started_monotonic_seconds(self) -> float | None:
+        """Return the absolute monotonic timestamp captured at recording start."""
+        return self._started_monotonic_seconds
+
+    def begin(self) -> None:
+        """Open the WAV writer and capture the recording-start monotonic time."""
+        if self._wav is not None or self._closed:
+            return
+        self._started_monotonic_seconds = self._monotonic_now()
+        self._wav_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            wav_file = wave.open(  # noqa: SIM115 - recorder owns the handle until close().
+                str(self._wav_path), "wb"
+            )
+        except (OSError, wave.Error) as exc:
+            raise AudioCaptureError(
+                f"Could not open roast recording WAV {self._wav_path}: {exc}"
+            ) from exc
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(_RECORDER_SAMPLE_WIDTH_BYTES)
+        wav_file.setframerate(self._sample_rate)
+        self._wav = wav_file
+
+    def write_samples(self, samples: Sequence[float]) -> None:
+        """Append the detector's mono float samples to the recording buffer."""
+        if self._wav is None or self._closed or not samples:
+            return
+        self._pending.extend(float(sample) for sample in samples)
+        if len(self._pending) >= self._flush_sample_threshold:
+            self._flush_locked()
+
+    def close(self) -> None:
+        """Flush remaining samples, finalize the WAV, and write the sidecar JSON."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._wav is None:
+            return
+        try:
+            self._flush_locked()
+        finally:
+            with suppress(Exception):
+                self._wav.close()
+            self._wav = None
+        self._write_sidecar()
+
+    def _flush_locked(self) -> None:
+        if self._wav is None or not self._pending:
+            return
+        frames = bytearray()
+        for sample in self._pending:
+            clamped = -1.0 if sample < -1.0 else (1.0 if sample > 1.0 else sample)
+            frames += struct.pack("<h", int(round(clamped * _RECORDER_PCM16_MAX)))
+        self._wav.writeframes(bytes(frames))
+        self._frames_written += len(self._pending)
+        self._pending.clear()
+
+    def _write_sidecar(self) -> None:
+        milestones: Mapping[str, float | None] = {}
+        if self._milestones_provider is not None:
+            with suppress(Exception):
+                milestones = self._milestones_provider()
+        sidecar: dict[str, object] = {
+            "schema_version": 1,
+            "session_id": self._session_id,
+            "wav_filename": self._wav_path.name,
+            "sample_rate": self._sample_rate,
+            "channels": 1,
+            "sample_width_bytes": _RECORDER_SAMPLE_WIDTH_BYTES,
+            "frame_count": self._frames_written,
+            "duration_seconds": round(self._frames_written / self._sample_rate, 6),
+            "recording_started_monotonic_seconds": self._started_monotonic_seconds,
+            "milestones": {key: milestones.get(key) for key in milestones},
+        }
+        self._sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._sidecar_path.open("w", encoding="utf-8") as output:
+            json.dump(sidecar, output, sort_keys=True, indent=2)
+            output.write("\n")
+
+
 class AudioCapturePipeline:
     """Background audio capture pipeline that emits detector windows.
 
@@ -428,6 +631,7 @@ class AudioCapturePipeline:
         settings: AudioCaptureSettings,
         audio_input: AudioInput,
         monotonic_now: Callable[[], float] | None = None,
+        recorder: RoastAudioRecorder | None = None,
     ) -> None:
         """Initialize an audio capture pipeline.
 
@@ -435,11 +639,15 @@ class AudioCapturePipeline:
             settings: Validated audio capture settings.
             audio_input: Configured readable audio source.
             monotonic_now: Optional monotonic clock supplier for tests.
+            recorder: Optional roast audio recorder (#176). When supplied, the
+                capture worker tees the same float samples the detector consumes
+                into a per-roast WAV without opening a second device stream.
         """
         _validate_settings(settings)
         self._settings = settings
         self._audio_input = audio_input
         self._monotonic_now = monotonic_now or time.monotonic
+        self._recorder = recorder
         self._windows: Queue[AudioWindow] = Queue(maxsize=settings.queue_limit)
         self._sample_buffer: list[float] = []
         self._stop_requested = Event()
@@ -549,6 +757,8 @@ class AudioCapturePipeline:
             )
 
     def _run_capture_loop(self) -> None:
+        if self._recorder is not None:
+            self._recorder.begin()
         try:
             while not self._stop_requested.is_set():
                 samples = self._read_next_samples()
@@ -556,6 +766,17 @@ class AudioCapturePipeline:
                     time.sleep(self._settings.idle_sleep_seconds)
                     continue
                 self._sample_buffer.extend(samples)
+                # Tee the SAME samples the detector consumes into the recording
+                # WAV right after the buffer extend (#176). This is the verified
+                # non-disturbing tee point: the detector still windows the buffer
+                # below, untouched. Recording failures must never kill detection,
+                # so a recorder error is logged and capture continues.
+                if self._recorder is not None:
+                    try:
+                        self._recorder.write_samples(samples)
+                    except Exception as exc:  # noqa: BLE001 - recording is best effort.
+                        _LOGGER.warning("Roast audio recording write failed; continuing: %s", exc)
+                        self._recorder = None
                 self._emit_complete_windows()
         except Exception as exc:  # noqa: BLE001 - worker stores error for caller inspection.
             with self._state_lock:
@@ -567,6 +788,9 @@ class AudioCapturePipeline:
             # freed while a read is in flight, which would otherwise segfault the
             # process at end of roast (worker mid-read while the caller closes).
             _close_audio_input_if_supported(self._audio_input)
+            if self._recorder is not None:
+                with suppress(Exception):
+                    self._recorder.close()
 
     def _read_next_samples(self) -> tuple[float, ...]:
         needed_samples = self._settings.window_sample_count - len(self._sample_buffer)

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -455,6 +455,11 @@ class RoastRecorder(Protocol):
     stop or fault. Single-device and multi-device recorders both satisfy it.
     """
 
+    @property
+    def started_monotonic_seconds(self) -> float | None:
+        """Return the absolute monotonic instant captured at recording start."""
+        ...
+
     def begin(self) -> None:
         """Open writers and capture the recording-start time."""
         ...
@@ -1338,8 +1343,16 @@ class AudioCapturePipeline:
             )
 
     def _run_capture_loop(self) -> None:
+        # Recording is strictly best-effort: a recorder error (including a
+        # recording-START failure here) must NEVER kill detection. begin() runs
+        # outside the main try below, so it gets its own fail-soft guard: on
+        # failure the recorder is dropped and capture/detection continue.
         if self._recorder is not None:
-            self._recorder.begin()
+            try:
+                self._recorder.begin()
+            except Exception as exc:  # noqa: BLE001 - recording is best effort.
+                _LOGGER.warning("Roast audio recording start failed; continuing: %s", exc)
+                self._disable_recorder()
         try:
             while not self._stop_requested.is_set():
                 samples = self._read_next_samples()
@@ -1357,7 +1370,10 @@ class AudioCapturePipeline:
                         self._recorder.write_samples(samples)
                     except Exception as exc:  # noqa: BLE001 - recording is best effort.
                         _LOGGER.warning("Roast audio recording write failed; continuing: %s", exc)
-                        self._recorder = None
+                        # Finalize what was captured (flush the WAV + write the
+                        # sidecar) BEFORE dropping the recorder, so the partial
+                        # recording is not leaked or lost.
+                        self._disable_recorder()
                 self._emit_complete_windows()
         except Exception as exc:  # noqa: BLE001 - worker stores error for caller inspection.
             with self._state_lock:
@@ -1372,6 +1388,20 @@ class AudioCapturePipeline:
             if self._recorder is not None:
                 with suppress(Exception):
                     self._recorder.close()
+
+    def _disable_recorder(self) -> None:
+        """Finalize and drop the recorder after a best-effort recording failure.
+
+        Closes the recorder first so a partial recording is flushed and its
+        sidecar written, then clears the reference so the capture worker performs
+        no further recording work. Closing is itself suppressed: the recorder is
+        already in a failure path and must not propagate into detection.
+        """
+        recorder = self._recorder
+        self._recorder = None
+        if recorder is not None:
+            with suppress(Exception):
+                recorder.close()
 
     def _read_next_samples(self) -> tuple[float, ...]:
         needed_samples = self._settings.window_sample_count - len(self._sample_buffer)

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -534,6 +534,10 @@ class _WavStreamWriter:
         self._pending: list[float] = []
         self._frames_written = 0
         self._closed = False
+        # Serialises write_samples / close so the capture worker and a stop-caller
+        # fallback finalisation (#176 hardware bug 2) never touch the wave handle
+        # concurrently.
+        self._lock = Lock()
 
     @property
     def wav_path(self) -> Path:
@@ -563,46 +567,55 @@ class _WavStreamWriter:
     def begin(self) -> None:
         """Open the WAV writer.
 
+        The WAV header (sample rate / channels / width) is committed by the
+        stdlib ``wave`` module at ``close()``, so a stream that captures no frames
+        — e.g. the teed detector stream while the AST model loads (#176 hardware
+        bug 2) — still finalises as a valid 0-frame WAV as long as close() runs
+        (which the capture worker and stop-caller fallback both guarantee).
+
         Raises:
             AudioCaptureError: If the WAV file cannot be opened.
         """
-        if self._wav is not None or self._closed:
-            return
-        self._wav_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            wav_file = wave.open(  # noqa: SIM115 - writer owns the handle until close().
-                str(self._wav_path), "wb"
-            )
-        except (OSError, wave.Error) as exc:
-            raise AudioCaptureError(
-                f"Could not open roast recording WAV {self._wav_path}: {exc}"
-            ) from exc
-        wav_file.setnchannels(1)
-        wav_file.setsampwidth(_RECORDER_SAMPLE_WIDTH_BYTES)
-        wav_file.setframerate(self._sample_rate)
-        self._wav = wav_file
+        with self._lock:
+            if self._wav is not None or self._closed:
+                return
+            self._wav_path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                wav_file = wave.open(  # noqa: SIM115 - writer owns the handle until close().
+                    str(self._wav_path), "wb"
+                )
+                wav_file.setnchannels(1)
+                wav_file.setsampwidth(_RECORDER_SAMPLE_WIDTH_BYTES)
+                wav_file.setframerate(self._sample_rate)
+            except (OSError, wave.Error) as exc:
+                raise AudioCaptureError(
+                    f"Could not open roast recording WAV {self._wav_path}: {exc}"
+                ) from exc
+            self._wav = wav_file
 
     def write_samples(self, samples: Sequence[float]) -> None:
         """Append mono float samples to the buffer, flushing on threshold."""
-        if self._wav is None or self._closed or not samples:
-            return
-        self._pending.extend(float(sample) for sample in samples)
-        if len(self._pending) >= self._flush_sample_threshold:
-            self._flush()
+        with self._lock:
+            if self._wav is None or self._closed or not samples:
+                return
+            self._pending.extend(float(sample) for sample in samples)
+            if len(self._pending) >= self._flush_sample_threshold:
+                self._flush_locked()
 
     def close(self) -> None:
-        """Flush remaining samples and finalize the WAV. Idempotent."""
-        if self._closed:
-            return
-        self._closed = True
-        if self._wav is None:
-            return
-        try:
-            self._flush()
-        finally:
-            with suppress(Exception):
-                self._wav.close()
-            self._wav = None
+        """Flush remaining samples and finalize the WAV. Idempotent + thread-safe."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            if self._wav is None:
+                return
+            try:
+                self._flush_locked()
+            finally:
+                with suppress(Exception):
+                    self._wav.close()
+                self._wav = None
 
     def sidecar_entry(self) -> dict[str, object]:
         """Return this stream's descriptor for the recording sidecar JSON."""
@@ -616,7 +629,7 @@ class _WavStreamWriter:
             "duration_seconds": round(self._frames_written / self._sample_rate, 6),
         }
 
-    def _flush(self) -> None:
+    def _flush_locked(self) -> None:
         if self._wav is None or not self._pending:
             return
         frames = bytearray()
@@ -873,6 +886,9 @@ class RoastAudioRecorder:
         )
         self._started_monotonic_seconds: float | None = None
         self._closed = False
+        # Guards the one-shot close so a worker finally-close and a stop-caller
+        # fallback close (#176 hardware bug 2) can't both finalise/write sidecars.
+        self._close_lock = Lock()
 
     @property
     def wav_path(self) -> Path:
@@ -911,24 +927,30 @@ class RoastAudioRecorder:
         self._writer.write_samples(samples)
 
     def close(self) -> None:
-        """Flush remaining samples, finalize the WAV, and write the sidecar JSON."""
-        if self._closed:
-            return
-        self._closed = True
-        if self._started_monotonic_seconds is None:
-            # begin() was never called: nothing to finalize and no sidecar.
-            return
-        self._writer.close()
-        _write_recording_sidecar(
-            sidecar_path=self._sidecar_path,
-            session_id=self._session_id,
-            started_monotonic_seconds=self._started_monotonic_seconds,
-            streams=(self._writer,),
-            milestones_provider=self._milestones_provider,
-        )
-        if self._annotation_session is not None:
-            with suppress(Exception):
-                _write_annotation_session(self._annotation_session, (self._writer,))
+        """Flush remaining samples, finalize the WAV, and write the sidecar JSON.
+
+        Idempotent and thread-safe: a worker finally-close and a stop-caller
+        fallback close (#176 hardware bug 2) race here, and only the first
+        finalises and writes the sidecars.
+        """
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+            if self._started_monotonic_seconds is None:
+                # begin() was never called: nothing to finalize and no sidecar.
+                return
+            self._writer.close()
+            _write_recording_sidecar(
+                sidecar_path=self._sidecar_path,
+                session_id=self._session_id,
+                started_monotonic_seconds=self._started_monotonic_seconds,
+                streams=(self._writer,),
+                milestones_provider=self._milestones_provider,
+            )
+            if self._annotation_session is not None:
+                with suppress(Exception):
+                    _write_annotation_session(self._annotation_session, (self._writer,))
 
 
 @dataclass(frozen=True)
@@ -1038,6 +1060,9 @@ class MultiDeviceRoastRecorder:
         self._stop_timeout_seconds = stop_timeout_seconds
         self._started_monotonic_seconds: float | None = None
         self._closed = False
+        # Guards the one-shot close (#176 hardware bug 2): a worker finally-close
+        # and a stop-caller fallback close must not both finalise/write sidecars.
+        self._close_lock = Lock()
         self._detector_writer = _WavStreamWriter(
             wav_path=detector_wav_path,
             device_label=detector_device_label,
@@ -1107,30 +1132,35 @@ class MultiDeviceRoastRecorder:
         self._detector_writer.write_samples(samples)
 
     def close(self) -> None:
-        """Stop additional streams, finalize every WAV, and write the sidecar."""
-        if self._closed:
-            return
-        self._closed = True
-        if self._started_monotonic_seconds is None:
-            return
-        for stream in self._additional_streams:
-            with suppress(Exception):
-                stream.stop(timeout_seconds=self._stop_timeout_seconds)
-        self._detector_writer.close()
-        for stream in self._additional_streams:
-            with suppress(Exception):
-                stream.writer.close()
-        streams = [self._detector_writer, *(s.writer for s in self._additional_streams)]
-        _write_recording_sidecar(
-            sidecar_path=self._sidecar_path,
-            session_id=self._session_id,
-            started_monotonic_seconds=self._started_monotonic_seconds,
-            streams=streams,
-            milestones_provider=self._milestones_provider,
-        )
-        if self._annotation_session is not None:
-            with suppress(Exception):
-                _write_annotation_session(self._annotation_session, streams)
+        """Stop additional streams, finalize every WAV, and write the sidecars.
+
+        Idempotent and thread-safe: a worker finally-close and a stop-caller
+        fallback close (#176 hardware bug 2) race here, and only the first wins.
+        """
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+            if self._started_monotonic_seconds is None:
+                return
+            for stream in self._additional_streams:
+                with suppress(Exception):
+                    stream.stop(timeout_seconds=self._stop_timeout_seconds)
+            self._detector_writer.close()
+            for stream in self._additional_streams:
+                with suppress(Exception):
+                    stream.writer.close()
+            streams = [self._detector_writer, *(s.writer for s in self._additional_streams)]
+            _write_recording_sidecar(
+                sidecar_path=self._sidecar_path,
+                session_id=self._session_id,
+                started_monotonic_seconds=self._started_monotonic_seconds,
+                streams=streams,
+                milestones_provider=self._milestones_provider,
+            )
+            if self._annotation_session is not None:
+                with suppress(Exception):
+                    _write_annotation_session(self._annotation_session, streams)
 
 
 @dataclass(frozen=True)
@@ -1374,7 +1404,33 @@ class AudioCapturePipeline:
             # free / free under an in-flight read. (close() is idempotent anyway,
             # but correctness here does not depend on that.)
             _close_audio_input_if_supported(self._audio_input)
+        elif thread.is_alive():
+            # The worker did not exit within the join timeout — typically blocked
+            # in a read while the detector's first samples are still pending (AST
+            # model load). Its `finally` (which closes the recorder) will not run
+            # before this caller returns, and on process/lifespan shutdown the
+            # daemon worker can be killed before it ever does, leaving the WAV at
+            # 0 bytes and no sidecars (#176 hardware bug 2). Finalise the recorder
+            # HERE as a fallback: the recorder is thread-safe (its writer lock
+            # serialises this close against any in-flight worker write), and
+            # close() is idempotent, so the worker's later close() is a no-op. We
+            # do NOT touch the audio input — only the worker may free its native
+            # ring buffer.
+            self._finalize_recorder()
         return snapshot
+
+    def _finalize_recorder(self) -> None:
+        """Finalise the recorder (flush WAV + write sidecars), idempotent + safe.
+
+        Safe to call from the stop caller as a fallback when the worker thread is
+        still alive: the recorder's writer lock serialises this close against any
+        in-flight worker write, and close() is idempotent so the worker's own
+        finally-close becomes a no-op.
+        """
+        recorder = self._recorder
+        if recorder is not None:
+            with suppress(Exception):
+                recorder.close()
 
     def close(self) -> None:
         """Stop capture and close the underlying audio input when supported."""

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -666,6 +666,63 @@ def _write_recording_sidecar(
         output.write("\n")
 
 
+@dataclass(frozen=True)
+class AnnotationSessionSpec:
+    """Annotation-pipeline session descriptor for the captured WAVs (#176).
+
+    Drives the ``{origin}-roast{N}-session.json`` written alongside the recording
+    sidecar so the WAVs plug straight into the coffee-first-crack-detection
+    pipeline (``record_mics.py`` → ``propagate_annotations.py`` → ``chunk_audio``),
+    which keys on ``origin`` / ``roast_num`` and a ``mics`` list of
+    ``{mic_num, label, file}``.
+
+    Attributes:
+        path: Destination ``{origin}-roast{N}-session.json`` path.
+        origin: Bean origin slug (e.g. ``"brazil"``). Falls back to the session
+            id when ``set_recording_metadata`` was never called.
+        roast_num: 1-based roast number, or ``0`` for the no-metadata fallback.
+        mic_labels: Per-stream label in device order (index 0 = detector / mic1).
+    """
+
+    path: Path
+    origin: str
+    roast_num: int
+    mic_labels: tuple[str, ...]
+
+
+def _write_annotation_session(
+    spec: AnnotationSessionSpec,
+    streams: Sequence[_WavStreamWriter],
+) -> None:
+    """Write the ``{origin}-roast{N}-session.json`` for the annotation pipeline.
+
+    The shape matches ``record_mics.py``: ``origin`` / ``roast_num`` /
+    ``sample_rate`` / ``mics`` where each mic entry carries ``mic_num`` (1-based,
+    in device order), ``label``, and ``file`` (the WAV filename). ``mic1`` is the
+    detector/teed stream by convention.
+    """
+    mics: list[dict[str, object]] = []
+    for index, stream in enumerate(streams):
+        label = spec.mic_labels[index] if index < len(spec.mic_labels) else f"mic{index + 1}"
+        mics.append(
+            {
+                "mic_num": index + 1,
+                "label": label,
+                "file": stream.wav_path.name,
+            }
+        )
+    payload: dict[str, object] = {
+        "origin": spec.origin,
+        "roast_num": spec.roast_num,
+        "sample_rate": streams[0].sample_rate if streams else 0,
+        "mics": mics,
+    }
+    spec.path.parent.mkdir(parents=True, exist_ok=True)
+    with spec.path.open("w", encoding="utf-8") as output:
+        json.dump(payload, output, indent=2)
+        output.write("\n")
+
+
 class _IndependentCaptureStream:
     """Capture one additional device on its own thread into its own WAV.
 
@@ -777,6 +834,7 @@ class RoastAudioRecorder:
         session_id: str,
         device_label: str | None = None,
         milestones_provider: RecorderMilestonesProvider | None = None,
+        annotation_session: AnnotationSessionSpec | None = None,
         monotonic_now: Callable[[], float] | None = None,
         flush_sample_threshold: int = 16_000,
     ) -> None:
@@ -791,6 +849,10 @@ class RoastAudioRecorder:
                 sidecar stream descriptor.
             milestones_provider: Optional callable returning roast milestone
                 offsets in recording-relative seconds, evaluated at close.
+            annotation_session: Optional annotation-pipeline session descriptor
+                (#176). When set, a ``{origin}-roast{N}-session.json`` is written
+                alongside the sidecar so the WAV plugs into the FC annotation
+                pipeline.
             monotonic_now: Optional monotonic clock supplier for tests.
             flush_sample_threshold: Buffered sample count that triggers a disk
                 flush. Larger values reduce syscalls at the cost of memory.
@@ -801,6 +863,7 @@ class RoastAudioRecorder:
         self._sidecar_path = Path(sidecar_path)
         self._session_id = session_id
         self._milestones_provider = milestones_provider
+        self._annotation_session = annotation_session
         self._monotonic_now = monotonic_now or time.monotonic
         self._writer = _WavStreamWriter(
             wav_path=wav_path,
@@ -863,6 +926,9 @@ class RoastAudioRecorder:
             streams=(self._writer,),
             milestones_provider=self._milestones_provider,
         )
+        if self._annotation_session is not None:
+            with suppress(Exception):
+                _write_annotation_session(self._annotation_session, (self._writer,))
 
 
 @dataclass(frozen=True)
@@ -932,6 +998,7 @@ class MultiDeviceRoastRecorder:
         session_id: str,
         additional_devices: Sequence[AdditionalRecordingDevice] = (),
         milestones_provider: RecorderMilestonesProvider | None = None,
+        annotation_session: AnnotationSessionSpec | None = None,
         monotonic_now: Callable[[], float] | None = None,
         flush_sample_threshold: int = 16_000,
         additional_input_factory: AdditionalAudioInputFactory | None = None,
@@ -949,6 +1016,9 @@ class MultiDeviceRoastRecorder:
             session_id: Roast session identifier recorded in the sidecar.
             additional_devices: Independently-captured devices (one WAV each).
             milestones_provider: Optional roast-milestone offsets supplier.
+            annotation_session: Optional annotation-pipeline session descriptor
+                (#176). When set, a ``{origin}-roast{N}-session.json`` listing
+                every device (mic1 = detector) is written alongside the sidecar.
             monotonic_now: Optional monotonic clock supplier for tests.
             flush_sample_threshold: Buffered sample count that triggers a flush.
             additional_input_factory: Opens a fresh input per additional device;
@@ -963,6 +1033,7 @@ class MultiDeviceRoastRecorder:
         self._sidecar_path = Path(sidecar_path)
         self._session_id = session_id
         self._milestones_provider = milestones_provider
+        self._annotation_session = annotation_session
         self._monotonic_now = monotonic_now or time.monotonic
         self._stop_timeout_seconds = stop_timeout_seconds
         self._started_monotonic_seconds: float | None = None
@@ -1057,6 +1128,9 @@ class MultiDeviceRoastRecorder:
             streams=streams,
             milestones_provider=self._milestones_provider,
         )
+        if self._annotation_session is not None:
+            with suppress(Exception):
+                _write_annotation_session(self._annotation_session, streams)
 
 
 @dataclass(frozen=True)

--- a/src/coffee_roaster_mcp/cli.py
+++ b/src/coffee_roaster_mcp/cli.py
@@ -16,6 +16,12 @@ from coffee_roaster_mcp.hottop_validation import (
 from coffee_roaster_mcp.mcp_server import run_stdio_server
 from coffee_roaster_mcp.mic_check import DEFAULT_RMS_FLOOR, MicCheckOptions, run_mic_check
 from coffee_roaster_mcp.mic_check import report_to_json as mic_report_to_json
+from coffee_roaster_mcp.record_check import (
+    DEFAULT_RECORD_SECONDS,
+    RecordCheckOptions,
+    run_record_check,
+)
+from coffee_roaster_mcp.record_check import report_to_json as record_report_to_json
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -127,6 +133,29 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Optional JSON evidence file to write.",
     )
+
+    record_parser = subparsers.add_parser(
+        "record-check",
+        help="Smoke-test multi-device roast audio capture WITHOUT a roast (#176).",
+    )
+    record_parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="coffee-roaster-mcp YAML config selecting recording.devices + sample rate.",
+    )
+    record_parser.add_argument(
+        "--seconds",
+        type=float,
+        default=DEFAULT_RECORD_SECONDS,
+        help="Capture duration per device; make noise during this window.",
+    )
+    record_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Where to write the WAVs + sidecar (a temp dir is used when unset).",
+    )
     return parser
 
 
@@ -184,6 +213,32 @@ def main(argv: Sequence[str] | None = None) -> int:
         verdict = "PASS — microphone is capturing real audio" if report.passed else "FAIL"
         print(f"\n{verdict}", file=sys.stderr)
         if not report.passed:
+            return 1
+    if args.command == "record-check":
+        print(
+            f"Recording {args.seconds:.0f}s from the configured devices — "
+            "make noise (snap / speak / tap)…",
+            file=sys.stderr,
+            flush=True,
+        )
+        record_report = run_record_check(
+            RecordCheckOptions(
+                config_path=args.config,
+                record_seconds=args.seconds,
+                output_dir=args.output_dir,
+            )
+        )
+        print(record_report_to_json(record_report))
+        for stream in record_report.streams:
+            note = stream.error or ("signal OK" if stream.has_signal else "SILENT/low")
+            print(
+                f"  {stream.device}: {stream.wav_filename} "
+                f"peak {stream.peak_dbfs} dBFS rms {stream.rms_dbfs} dBFS — {note}",
+                file=sys.stderr,
+            )
+        verdict = "PASS — every device captured real audio" if record_report.passed else "FAIL"
+        print(f"\n{verdict} (files in {record_report.output_dir})", file=sys.stderr)
+        if not record_report.passed:
             return 1
     return 0
 

--- a/src/coffee_roaster_mcp/config.py
+++ b/src/coffee_roaster_mcp/config.py
@@ -114,10 +114,13 @@ class RecordingConfig:
     the audio feeds the FC training corpus. The recorder tees the same samples
     the detector consumes (no second contending stream on the audio device).
 
-    v1 captures the detector's single mono stream into ONE WAV. True
-    multi-channel / 2-mic capture (open the device at 2 channels into 2 WAVs) is
-    a documented follow-on and is intentionally not built here; the current
-    microphone input is mono and the 2-channel hardware is not connected.
+    Single-stream (default): the recorder tees the detector's mono stream into
+    ONE WAV. Multi-device (option A): set `devices` to capture several
+    independent USB-mic streams at once, one WAV per device — the FIRST device is
+    the FC detector's device (teed, no second open), and each ADDITIONAL device
+    is opened as its own independent capture stream. The additional streams are
+    independent (NOT sample-locked) clocks; drift is acceptable for FC training
+    data (operator decision, research-confirmed: no aggregate, no JACK).
 
     Attributes:
         enabled: Whether roast audio recording is active at all. When false, no
@@ -128,19 +131,25 @@ class RecordingConfig:
             session writes to `export_location/<session_id>/`. Defaults to a
             gitignored captures directory when unset.
         sample_rate: Optional WAV sample rate in Hz. Defaults to the detector
-            `audio.sample_rate` when unset, since v1 tees the detector stream.
-        device: Optional capture device identifier reserved for the
-            multi-channel follow-on. v1 captures the detector's existing mono
-            stream and does not open this device, so it is forward-compat only.
-        channels: Optional channel-to-mic map reserved for the multi-channel
-            follow-on. v1 captures one mono channel, so this is forward-compat
-            only.
+            `audio.sample_rate` when unset. Applies to every recorded stream.
+        devices: Optional list of capture device-name substrings (matched the
+            same way as `audio.input_device`). The FIRST entry is the detector's
+            device and is TEED from the existing detector stream (no second open,
+            no contention); each ADDITIONAL entry is opened as its own
+            independent capture stream into its own WAV. When unset, the recorder
+            falls back to single-stream behaviour (tee the detector only).
+        device: Deprecated single-device hint retained for forward-compat. Use
+            `devices`; this field is no longer read by the recorder.
+        channels: Optional channel-to-mic map reserved for a future true
+            multi-channel (single-device, 2-channel) follow-on; not read in
+            option A, which uses independent per-device streams.
     """
 
     enabled: bool = False
     autocapture: bool = False
     export_location: Path | None = None
     sample_rate: int | None = None
+    devices: tuple[str, ...] | None = None
     device: str | None = None
     channels: tuple[int, ...] | None = None
 
@@ -390,6 +399,7 @@ def _recording_from_mapping(raw: Mapping[str, Any]) -> RecordingConfig:
             "sample_rate",
             label="recording.sample_rate",
         ),
+        devices=_optional_string_list(raw.get("devices"), label="recording.devices"),
         device=_optional_string(raw, "device", label="recording.device"),
         channels=_optional_channels(raw.get("channels"), label="recording.channels"),
     )
@@ -606,6 +616,11 @@ def _apply_env_overrides(config: AppConfig, environ: Mapping[str, str]) -> AppCo
                 else _parse_positive_integer(sample_rate, "COFFEE_RECORDING_SAMPLE_RATE")
             ),
         )
+    if "COFFEE_RECORDING_DEVICES" in environ:
+        recording = replace(
+            recording,
+            devices=_parse_devices_csv(environ["COFFEE_RECORDING_DEVICES"]),
+        )
     if "COFFEE_AUTO_T0_DROP_THRESHOLD_C" in environ:
         session = replace(
             config.session,
@@ -685,6 +700,11 @@ def _boolean(
     raise ConfigError(f"{error_key} must be a boolean.")
 
 
+def _parse_devices_csv(value: str) -> tuple[str, ...] | None:
+    items = tuple(part.strip() for part in value.split(",") if part.strip())
+    return items or None
+
+
 def _parse_boolean(value: str, key: str) -> bool:
     lowered = value.strip().lower()
     if lowered in {"1", "true", "yes", "on"}:
@@ -720,6 +740,23 @@ def _optional_positive_integer(
     if value is None:
         return None
     return _parse_positive_integer(value, error_key)
+
+
+def _optional_string_list(value: object, *, label: str) -> tuple[str, ...] | None:
+    if value is None:
+        return None
+    if not isinstance(value, (list, tuple)):
+        raise ConfigError(f"{label} must be a list of strings or null.")
+    raw_items = cast(list[object] | tuple[object, ...], value)
+    items: list[str] = []
+    for item in raw_items:
+        if not isinstance(item, str):
+            raise ConfigError(f"{label} values must be strings.")
+        normalized = item.strip()
+        if not normalized:
+            raise ConfigError(f"{label} values must not be empty.")
+        items.append(normalized)
+    return tuple(items)
 
 
 def _optional_channels(value: object, *, label: str) -> tuple[int, ...] | None:

--- a/src/coffee_roaster_mcp/config.py
+++ b/src/coffee_roaster_mcp/config.py
@@ -106,6 +106,46 @@ class LoggingConfig:
 
 
 @dataclass(frozen=True)
+class RecordingConfig:
+    """Roast audio recording configuration (#176, v1: capture-only).
+
+    Records the detector's existing mono capture stream to a per-roast WAV plus
+    a session sidecar JSON, so the first-crack model can be diagnosed offline and
+    the audio feeds the FC training corpus. The recorder tees the same samples
+    the detector consumes (no second contending stream on the audio device).
+
+    v1 captures the detector's single mono stream into ONE WAV. True
+    multi-channel / 2-mic capture (open the device at 2 channels into 2 WAVs) is
+    a documented follow-on and is intentionally not built here; the current
+    microphone input is mono and the 2-channel hardware is not connected.
+
+    Attributes:
+        enabled: Whether roast audio recording is active at all. When false, no
+            WAV or sidecar is written and the detector stream is untouched.
+        autocapture: Whether capture starts automatically with each roast,
+            requiring no MCP command. Only meaningful when `enabled` is true.
+        export_location: Base directory for per-session capture output. Each
+            session writes to `export_location/<session_id>/`. Defaults to a
+            gitignored captures directory when unset.
+        sample_rate: Optional WAV sample rate in Hz. Defaults to the detector
+            `audio.sample_rate` when unset, since v1 tees the detector stream.
+        device: Optional capture device identifier reserved for the
+            multi-channel follow-on. v1 captures the detector's existing mono
+            stream and does not open this device, so it is forward-compat only.
+        channels: Optional channel-to-mic map reserved for the multi-channel
+            follow-on. v1 captures one mono channel, so this is forward-compat
+            only.
+    """
+
+    enabled: bool = False
+    autocapture: bool = False
+    export_location: Path | None = None
+    sample_rate: int | None = None
+    device: str | None = None
+    channels: tuple[int, ...] | None = None
+
+
+@dataclass(frozen=True)
 class SessionConfig:
     """Roast session metric configuration."""
 
@@ -124,6 +164,7 @@ class AppConfig:
     first_crack: FirstCrackConfig = field(default_factory=FirstCrackConfig)
     audio: AudioConfig = field(default_factory=AudioConfig)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
+    recording: RecordingConfig = field(default_factory=RecordingConfig)
     session: SessionConfig = field(default_factory=SessionConfig)
     source_path: Path | None = None
 
@@ -200,6 +241,7 @@ def _config_from_mapping(raw_config: Mapping[str, Any], source_path: Path | None
         first_crack=_first_crack_from_mapping(_section(raw_config, "first_crack")),
         audio=_audio_from_mapping(_section(raw_config, "audio")),
         logging=_logging_from_mapping(_section(raw_config, "logging")),
+        recording=_recording_from_mapping(_section(raw_config, "recording")),
         session=_session_from_mapping(_section(raw_config, "session")),
         source_path=source_path,
     )
@@ -334,6 +376,25 @@ def _logging_from_mapping(raw: Mapping[str, Any]) -> LoggingConfig:
     )
 
 
+def _recording_from_mapping(raw: Mapping[str, Any]) -> RecordingConfig:
+    return RecordingConfig(
+        enabled=_boolean(raw, "enabled", False, label="recording.enabled"),
+        autocapture=_boolean(raw, "autocapture", False, label="recording.autocapture"),
+        export_location=_optional_path(
+            raw,
+            "export_location",
+            label="recording.export_location",
+        ),
+        sample_rate=_optional_positive_integer(
+            raw,
+            "sample_rate",
+            label="recording.sample_rate",
+        ),
+        device=_optional_string(raw, "device", label="recording.device"),
+        channels=_optional_channels(raw.get("channels"), label="recording.channels"),
+    )
+
+
 def _session_from_mapping(raw: Mapping[str, Any]) -> SessionConfig:
     return SessionConfig(
         auto_t0_detection_enabled=_boolean(
@@ -368,6 +429,7 @@ def _apply_env_overrides(config: AppConfig, environ: Mapping[str, str]) -> AppCo
     first_crack = config.first_crack
     audio = config.audio
     logging = config.logging
+    recording = config.recording
 
     if "COFFEE_ROASTER_DRIVER" in environ:
         roaster = replace(
@@ -514,6 +576,36 @@ def _apply_env_overrides(config: AppConfig, environ: Mapping[str, str]) -> AppCo
             logging,
             log_dir=Path(_required_string(environ["COFFEE_ROAST_LOG_DIR"], "COFFEE_ROAST_LOG_DIR")),
         )
+
+    if "COFFEE_RECORDING_ENABLED" in environ:
+        recording = replace(
+            recording,
+            enabled=_parse_boolean(environ["COFFEE_RECORDING_ENABLED"], "COFFEE_RECORDING_ENABLED"),
+        )
+    if "COFFEE_RECORDING_AUTOCAPTURE" in environ:
+        recording = replace(
+            recording,
+            autocapture=_parse_boolean(
+                environ["COFFEE_RECORDING_AUTOCAPTURE"],
+                "COFFEE_RECORDING_AUTOCAPTURE",
+            ),
+        )
+    if "COFFEE_RECORDING_EXPORT_LOCATION" in environ:
+        export_location = _none_if_empty(environ["COFFEE_RECORDING_EXPORT_LOCATION"])
+        recording = replace(
+            recording,
+            export_location=Path(export_location) if export_location is not None else None,
+        )
+    if "COFFEE_RECORDING_SAMPLE_RATE" in environ:
+        sample_rate = _none_if_empty(environ["COFFEE_RECORDING_SAMPLE_RATE"])
+        recording = replace(
+            recording,
+            sample_rate=(
+                None
+                if sample_rate is None
+                else _parse_positive_integer(sample_rate, "COFFEE_RECORDING_SAMPLE_RATE")
+            ),
+        )
     if "COFFEE_AUTO_T0_DROP_THRESHOLD_C" in environ:
         session = replace(
             config.session,
@@ -531,6 +623,7 @@ def _apply_env_overrides(config: AppConfig, environ: Mapping[str, str]) -> AppCo
         first_crack=first_crack,
         audio=audio,
         logging=logging,
+        recording=recording,
         session=session,
     )
 
@@ -592,6 +685,15 @@ def _boolean(
     raise ConfigError(f"{error_key} must be a boolean.")
 
 
+def _parse_boolean(value: str, key: str) -> bool:
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+    raise ConfigError(f"{key} must be a boolean.")
+
+
 def _integer(raw: Mapping[str, Any], key: str, default: int, label: str | None = None) -> int:
     error_key = label or key
     value = raw.get(key, default)
@@ -606,6 +708,30 @@ def _positive_integer(
 ) -> int:
     error_key = label or key
     return _parse_positive_integer(raw.get(key, default), error_key)
+
+
+def _optional_positive_integer(
+    raw: Mapping[str, Any],
+    key: str,
+    label: str | None = None,
+) -> int | None:
+    error_key = label or key
+    value = raw.get(key)
+    if value is None:
+        return None
+    return _parse_positive_integer(value, error_key)
+
+
+def _optional_channels(value: object, *, label: str) -> tuple[int, ...] | None:
+    if value is None:
+        return None
+    if not isinstance(value, (list, tuple)):
+        raise ConfigError(f"{label} must be a list of integers or null.")
+    raw_channels = cast(list[object] | tuple[object, ...], value)
+    channels = tuple(_parse_integer(item, label) for item in raw_channels)
+    if any(channel < 0 for channel in channels):
+        raise ConfigError(f"{label} values must be non-negative integers.")
+    return channels
 
 
 def _parse_integer(value: object, key: str) -> int:

--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -174,6 +174,40 @@ class FirstCrackDetectionEvent:
         return payload
 
 
+FirstCrackWindowStatus = Literal["listening", "candidate", "confirmed"]
+
+
+@dataclass(frozen=True)
+class FirstCrackWindowObservation:
+    """Per-window first-crack inference observability for one processed window.
+
+    This is observability-only metadata recorded for every audio window the
+    detector processes during a roast (#175). It never changes detection
+    thresholds, the confirmation rule, or control behavior.
+
+    Attributes:
+        window_sequence_number: Source audio window sequence number.
+        confidence: Model confidence for this window, or `None` when the backend
+            reported no confidence.
+        positive_window_count: Positive detector windows currently inside the
+            confirmation span after this window was processed.
+        confirmed: Whether this window completed the confirmation rule.
+        fc_status: Per-window status — `listening` when the window was not
+            positive, `candidate` when it was positive but confirmation has not
+            yet been reached, and `confirmed` when this window confirmed first
+            crack.
+        event: Confirmed first-crack event when this window confirmed, else
+            `None`.
+    """
+
+    window_sequence_number: int
+    confidence: float | None
+    positive_window_count: int
+    confirmed: bool
+    fc_status: FirstCrackWindowStatus
+    event: FirstCrackDetectionEvent | None
+
+
 @dataclass(frozen=True)
 class _PositiveWindowCandidate:
     event: FirstCrackDetectionEvent
@@ -193,16 +227,68 @@ class FirstCrackDetectorAdapter:
     )
 
     def process_window(self, window: AudioWindow) -> FirstCrackDetectionEvent | None:
-        """Process one audio window and return a confirmed event candidate if present."""
+        """Process one audio window and return a confirmed event candidate if present.
+
+        Args:
+            window: Audio window to run detection for.
+
+        Returns:
+            The confirmed first-crack event candidate when this window completes
+            the confirmation rule, otherwise `None`.
+        """
+        return self.process_window_observed(window).event
+
+    def process_window_observed(self, window: AudioWindow) -> FirstCrackWindowObservation:
+        """Process one audio window and return per-window observability metadata.
+
+        This is the observability-aware entry point (#175): it always reports the
+        window's confidence, rolling positive-window count, status, and the
+        confirmed event when this window confirms. `process_window` delegates to
+        it, so detection thresholds and the confirmation rule are unchanged.
+
+        Args:
+            window: Audio window to run detection for.
+
+        Returns:
+            Per-window observation including the confirmed event when present.
+
+        Raises:
+            FirstCrackDetectorError: If the backend output or confidence is invalid.
+        """
         output = self.backend.detect(window)
         if type(output.confirmed) is not bool:
             raise FirstCrackDetectorError("detector output confirmed must be a boolean.")
         _validate_confirmation_config(self.config)
+        confidence = _validate_optional_confidence(output.confidence)
         self._prune_positive_candidates(window.started_at_monotonic_seconds)
         if not output.confirmed:
-            return None
+            return FirstCrackWindowObservation(
+                window_sequence_number=window.sequence_number,
+                confidence=confidence,
+                positive_window_count=len(self._positive_candidates),
+                confirmed=False,
+                fc_status="listening",
+                event=None,
+            )
 
-        confidence = _validate_optional_confidence(output.confidence)
+        event = self._record_positive_window(window, output, confidence)
+        confirmed = event is not None
+        return FirstCrackWindowObservation(
+            window_sequence_number=window.sequence_number,
+            confidence=confidence,
+            positive_window_count=len(self._positive_candidates),
+            confirmed=confirmed,
+            fc_status="confirmed" if confirmed else "candidate",
+            event=event,
+        )
+
+    def _record_positive_window(
+        self,
+        window: AudioWindow,
+        output: FirstCrackDetectorOutput,
+        confidence: float | None,
+    ) -> FirstCrackDetectionEvent | None:
+        """Accumulate one positive window and return a confirmed event if reached."""
         detected_at_monotonic_seconds = _detection_timestamp(window, output)
         window_onset_monotonic_seconds = round(window.started_at_monotonic_seconds, 6)
         candidate = FirstCrackDetectionEvent(
@@ -458,7 +544,16 @@ def integrate_first_crack_window_with_session(
     if not session.active or session.phase != "roasting":
         return None
 
-    detection_event = adapter.process_window(window)
+    observation = adapter.process_window_observed(window)
+    session_store.record_first_crack_window_observation(
+        session,
+        window_sequence_number=observation.window_sequence_number,
+        confidence=observation.confidence,
+        positive_window_count=observation.positive_window_count,
+        confirmed=observation.confirmed,
+        fc_status=observation.fc_status,
+    )
+    detection_event = observation.event
     if detection_event is None:
         return None
 

--- a/src/coffee_roaster_mcp/exports.py
+++ b/src/coffee_roaster_mcp/exports.py
@@ -175,6 +175,7 @@ def _write_summary_json(
         ror_min_sample_seconds=ror_min_sample_seconds,
     )
     first_crack_model = _summary_first_crack_model(session)
+    first_crack_detection = _summary_first_crack_detection(session)
     payload: dict[str, Any] = {
         "session_id": session.id,
         "active": session.active,
@@ -197,6 +198,7 @@ def _write_summary_json(
         "development_time_percent": metrics.development_percent,
         "roaster_driver": roaster_driver,
         "first_crack_model": first_crack_model,
+        "first_crack_detection": first_crack_detection,
         "metrics": {
             "roast_elapsed_seconds": metrics.roast_elapsed_seconds,
             "development_time_seconds": metrics.development_time_seconds,
@@ -240,6 +242,29 @@ def _summary_first_crack_model(session: RoastSession) -> dict[str, EventPayloadV
         "confirmation_window_seconds": _number_payload_value(
             payload.get("confirmation_window_seconds")
         ),
+    }
+
+
+def _summary_first_crack_detection(session: RoastSession) -> dict[str, EventPayloadValue]:
+    """Return the first-crack inference picture for the summary export (#175).
+
+    Unlike `first_crack_model` (which is empty when the model never confirmed),
+    these aggregates are always present, so a miss is diagnosable: it records the
+    max confidence ever seen, the total window count, the highest positive-window
+    count reached, and whether the audio model confirmed first crack. A no-fire
+    roast then reads as "peaked at 0.55, never reached the threshold."
+
+    Args:
+        session: Session snapshot to summarize.
+
+    Returns:
+        First-crack detection aggregates for the summary export.
+    """
+    return {
+        "model_confirmed": session.fc_model_confirmed,
+        "max_confidence": session.fc_max_confidence,
+        "window_count": session.fc_window_count,
+        "max_positive_window_count": session.fc_max_positive_window_count,
     }
 
 

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -395,9 +395,22 @@ def build_session_recorder(
     sample_rate = recording.sample_rate or config.audio.sample_rate
     devices = recording.devices or ()
 
-    def milestones() -> dict[str, float | None]:
-        return recording_relative_milestones(session)
+    # The milestones closure needs the recorder's start instant to rebase the
+    # session-elapsed milestone times onto the recording clock, but the recorder
+    # is built below. Capture it in a one-slot holder the closure reads at close.
+    recorder_holder: list[RoastRecorder] = []
 
+    def milestones() -> dict[str, float | None]:
+        recorder = recorder_holder[0] if recorder_holder else None
+        recording_started_monotonic = (
+            recorder.started_monotonic_seconds if recorder is not None else None
+        )
+        return recording_relative_milestones(
+            session,
+            recording_started_monotonic_seconds=recording_started_monotonic,
+        )
+
+    recorder: RoastRecorder
     if len(devices) >= 2:
         detector_label = devices[0]
         detector_wav = session_dir / f"roast.{device_label_to_filename(detector_label)}.wav"
@@ -409,7 +422,7 @@ def build_session_recorder(
             )
             for label in devices[1:]
         ]
-        return MultiDeviceRoastRecorder(
+        recorder = MultiDeviceRoastRecorder(
             detector_wav_path=detector_wav,
             detector_device_label=detector_label,
             sidecar_path=sidecar_path,
@@ -418,42 +431,68 @@ def build_session_recorder(
             additional_devices=additional,
             milestones_provider=milestones,
         )
+    else:
+        # Single-stream: tee the detector only. A lone configured device labels
+        # the WAV; otherwise the default roast.wav name is kept.
+        detector_label = devices[0] if devices else None
+        recorder = RoastAudioRecorder(
+            wav_path=session_dir / "roast.wav",
+            sidecar_path=sidecar_path,
+            sample_rate=sample_rate,
+            session_id=session.id,
+            device_label=detector_label,
+            milestones_provider=milestones,
+        )
+    recorder_holder.append(recorder)
+    return recorder
 
-    # Single-stream: tee the detector only. A lone configured device labels the
-    # WAV; otherwise the default roast.wav name is kept.
-    detector_label = devices[0] if devices else None
-    return RoastAudioRecorder(
-        wav_path=session_dir / "roast.wav",
-        sidecar_path=sidecar_path,
-        sample_rate=sample_rate,
-        session_id=session.id,
-        device_label=detector_label,
-        milestones_provider=milestones,
-    )
 
+def recording_relative_milestones(
+    session: RoastSession,
+    *,
+    recording_started_monotonic_seconds: float | None,
+) -> dict[str, float | None]:
+    """Return roast milestones in RECORDING-relative seconds for the sidecar.
 
-def recording_relative_milestones(session: RoastSession) -> dict[str, float | None]:
-    """Return roast milestones in recording-relative seconds for the sidecar.
+    The session stores each milestone as elapsed seconds from the SESSION start
+    (`session.monotonic_start`). The recorder starts slightly later, at its own
+    `started_monotonic_seconds` (an absolute monotonic instant). To express a
+    milestone relative to the RECORDING start — what the operator needs to align
+    the WAV to T0 / first crack for offline annotation — subtract the recording
+    start, converted into the same session-elapsed domain:
 
-    The session stores milestones as elapsed seconds from its own start, while
-    the recorder's clock starts when capture begins. Both share the process
-    monotonic clock, so a milestone's recording-relative offset is its absolute
-    monotonic time (`session.monotonic_start + elapsed`) minus the recording
-    start. Recording starts very slightly after the session, so the offset is
-    effectively the session-elapsed value; it is returned verbatim because the
-    sub-tick skew is below the detector window and the recorder owns the
-    absolute recording-start timestamp separately in the sidecar.
+        recording_start_session_elapsed =
+            recording_started_monotonic_seconds - session.monotonic_start
+        milestone_recording_relative =
+            milestone_session_elapsed - recording_start_session_elapsed
+
+    Both the milestone and the recording start are exact in the shared monotonic
+    clock, so the subtraction is exact (no sub-tick fudge). When the recording
+    start is unknown (recorder never began), the raw session-elapsed value is
+    returned unchanged.
 
     Args:
         session: Live roast session.
+        recording_started_monotonic_seconds: The recorder's absolute monotonic
+            start instant, or `None` if recording never started.
 
     Returns:
         Mapping of milestone name to recording-relative seconds, or `None` when
         the milestone has not fired.
     """
+    if recording_started_monotonic_seconds is None:
+        offset = 0.0
+    else:
+        offset = recording_started_monotonic_seconds - session.monotonic_start
+
+    def _rebase(value: float | None) -> float | None:
+        if value is None:
+            return None
+        return round(value - offset, 6)
+
     return {
-        "beans_added": session.beans_added_monotonic_seconds,
-        "first_crack": session.first_crack_monotonic_seconds,
+        "beans_added": _rebase(session.beans_added_monotonic_seconds),
+        "first_crack": _rebase(session.first_crack_monotonic_seconds),
     }
 
 

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -13,6 +13,7 @@ from coffee_roaster_mcp.audio import (
     AudioCapturePipeline,
     AudioCaptureSnapshot,
     AudioWindow,
+    RoastAudioRecorder,
     build_audio_capture_pipeline,
 )
 from coffee_roaster_mcp.config import AppConfig, AudioConfig, FirstCrackConfig
@@ -105,7 +106,7 @@ class FirstCrackSessionRuntime:
             stop_timeout_seconds: Maximum seconds to wait for capture shutdown.
         """
         self._config = config
-        self._audio_pipeline_factory = audio_pipeline_factory or _build_audio_pipeline
+        self._audio_pipeline_factory = audio_pipeline_factory or self._build_default_audio_pipeline
         self._detector_adapter_factory = (
             detector_adapter_factory or _build_released_detector_adapter
         )
@@ -118,6 +119,14 @@ class FirstCrackSessionRuntime:
         self._reason: str | None = _initial_reason(config.first_crack)
         self._processed_window_count = 0
         self._last_capture_snapshot: AudioCaptureSnapshot | None = None
+        #: Recorder for the session currently being started (#176). Set while the
+        #: default pipeline factory runs so the teed WAV is wired into the real
+        #: capture pipeline; injected test factories ignore it.
+        self._pending_recorder: RoastAudioRecorder | None = None
+
+    def _build_default_audio_pipeline(self, config: AudioConfig) -> AudioCapturePipeline:
+        """Build the real capture pipeline, teeing the pending session recorder."""
+        return build_audio_capture_pipeline(config, recorder=self._pending_recorder)
 
     def start_for_session(self, session: RoastSession) -> FirstCrackRuntimeSnapshot:
         """Start or prepare first-crack detection for a roast session."""
@@ -134,6 +143,8 @@ class FirstCrackSessionRuntime:
 
             self._status = "pending"
             self._reason = "Audio first-crack detection is prepared for this session."
+            recorder = build_session_recorder(self._config, session)
+            self._pending_recorder = recorder
             try:
                 adapter = self._detector_adapter_factory(self._config.first_crack)
                 pipeline = self._audio_pipeline_factory(self._config.audio)
@@ -159,6 +170,10 @@ class FirstCrackSessionRuntime:
                 self._adapter = None
                 self._pipeline = None
                 return self.snapshot()
+            finally:
+                # The recorder is consumed by the pipeline factory; clear the
+                # session-scoped handle so it never leaks into the next start.
+                self._pending_recorder = None
 
             self._adapter = adapter
             self._pipeline = pipeline
@@ -330,8 +345,72 @@ def build_first_crack_session_runtime(
     )
 
 
-def _build_audio_pipeline(config: AudioConfig) -> AudioCapturePipeline:
-    return build_audio_capture_pipeline(config)
+#: Default per-roast capture root when `recording.export_location` is unset.
+#: This lives under the configured log dir, which is gitignored, so large WAVs
+#: are never committed (#176 privacy/storage).
+_DEFAULT_RECORDING_SUBDIR = "captures"
+
+
+def build_session_recorder(
+    config: AppConfig,
+    session: RoastSession,
+) -> RoastAudioRecorder | None:
+    """Build a per-roast audio recorder for one session, or `None` when disabled.
+
+    v1 only autocaptures: recording is wired when both `recording.enabled` and
+    `recording.autocapture` are true, so capture begins with the roast and needs
+    no MCP command. The recorder tees the detector's existing mono stream into a
+    single WAV plus a sidecar JSON under `export_location/<session_id>/`.
+
+    Args:
+        config: Application configuration.
+        session: Live roast session that owns the recording. Its milestone
+            timestamps are read at close to compute recording-relative offsets.
+
+    Returns:
+        A configured recorder, or `None` when recording is disabled or capture
+        is not autostarted for this roast.
+    """
+    recording = config.recording
+    if not recording.enabled or not recording.autocapture:
+        return None
+    export_location = recording.export_location or (
+        config.logging.log_dir / _DEFAULT_RECORDING_SUBDIR
+    )
+    session_dir = export_location / session.id
+    sample_rate = recording.sample_rate or config.audio.sample_rate
+    return RoastAudioRecorder(
+        wav_path=session_dir / "roast.wav",
+        sidecar_path=session_dir / "roast.recording.json",
+        sample_rate=sample_rate,
+        session_id=session.id,
+        milestones_provider=lambda: recording_relative_milestones(session),
+    )
+
+
+def recording_relative_milestones(session: RoastSession) -> dict[str, float | None]:
+    """Return roast milestones in recording-relative seconds for the sidecar.
+
+    The session stores milestones as elapsed seconds from its own start, while
+    the recorder's clock starts when capture begins. Both share the process
+    monotonic clock, so a milestone's recording-relative offset is its absolute
+    monotonic time (`session.monotonic_start + elapsed`) minus the recording
+    start. Recording starts very slightly after the session, so the offset is
+    effectively the session-elapsed value; it is returned verbatim because the
+    sub-tick skew is below the detector window and the recorder owns the
+    absolute recording-start timestamp separately in the sidecar.
+
+    Args:
+        session: Live roast session.
+
+    Returns:
+        Mapping of milestone name to recording-relative seconds, or `None` when
+        the milestone has not fired.
+    """
+    return {
+        "beans_added": session.beans_added_monotonic_seconds,
+        "first_crack": session.first_crack_monotonic_seconds,
+    }
 
 
 def _build_released_detector_adapter(config: FirstCrackConfig) -> FirstCrackDetectorAdapter:

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -9,12 +9,16 @@ from typing import Literal, Protocol
 
 from coffee_roaster_mcp.artifacts import ArtifactResolutionError
 from coffee_roaster_mcp.audio import (
+    AdditionalRecordingDevice,
     AudioCaptureError,
     AudioCapturePipeline,
     AudioCaptureSnapshot,
     AudioWindow,
+    MultiDeviceRoastRecorder,
     RoastAudioRecorder,
+    RoastRecorder,
     build_audio_capture_pipeline,
+    device_label_to_filename,
 )
 from coffee_roaster_mcp.config import AppConfig, AudioConfig, FirstCrackConfig
 from coffee_roaster_mcp.detector import (
@@ -122,7 +126,7 @@ class FirstCrackSessionRuntime:
         #: Recorder for the session currently being started (#176). Set while the
         #: default pipeline factory runs so the teed WAV is wired into the real
         #: capture pipeline; injected test factories ignore it.
-        self._pending_recorder: RoastAudioRecorder | None = None
+        self._pending_recorder: RoastRecorder | None = None
 
     def _build_default_audio_pipeline(self, config: AudioConfig) -> AudioCapturePipeline:
         """Build the real capture pipeline, teeing the pending session recorder."""
@@ -354,13 +358,22 @@ _DEFAULT_RECORDING_SUBDIR = "captures"
 def build_session_recorder(
     config: AppConfig,
     session: RoastSession,
-) -> RoastAudioRecorder | None:
+) -> RoastRecorder | None:
     """Build a per-roast audio recorder for one session, or `None` when disabled.
 
-    v1 only autocaptures: recording is wired when both `recording.enabled` and
-    `recording.autocapture` are true, so capture begins with the roast and needs
-    no MCP command. The recorder tees the detector's existing mono stream into a
-    single WAV plus a sidecar JSON under `export_location/<session_id>/`.
+    Recording is wired when both `recording.enabled` and `recording.autocapture`
+    are true, so capture begins with the roast and needs no MCP command. Output
+    lands under `export_location/<session_id>/`.
+
+    Dispatch on `recording.devices`:
+
+    - Unset, empty, or a single device: a single-stream
+      :class:`RoastAudioRecorder` that tees the detector's existing mono stream
+      into one WAV (the original behaviour).
+    - Two or more devices: a :class:`MultiDeviceRoastRecorder` — the FIRST device
+      is the detector's device (teed, no second open) and each ADDITIONAL device
+      is captured as its own independent stream into its own WAV (option A). WAV
+      filenames are derived from the device labels.
 
     Args:
         config: Application configuration.
@@ -378,13 +391,44 @@ def build_session_recorder(
         config.logging.log_dir / _DEFAULT_RECORDING_SUBDIR
     )
     session_dir = export_location / session.id
+    sidecar_path = session_dir / "roast.recording.json"
     sample_rate = recording.sample_rate or config.audio.sample_rate
+    devices = recording.devices or ()
+
+    def milestones() -> dict[str, float | None]:
+        return recording_relative_milestones(session)
+
+    if len(devices) >= 2:
+        detector_label = devices[0]
+        detector_wav = session_dir / f"roast.{device_label_to_filename(detector_label)}.wav"
+        additional = [
+            AdditionalRecordingDevice(
+                device_label=label,
+                wav_path=session_dir / f"roast.{device_label_to_filename(label)}.wav",
+                sample_rate=sample_rate,
+            )
+            for label in devices[1:]
+        ]
+        return MultiDeviceRoastRecorder(
+            detector_wav_path=detector_wav,
+            detector_device_label=detector_label,
+            sidecar_path=sidecar_path,
+            sample_rate=sample_rate,
+            session_id=session.id,
+            additional_devices=additional,
+            milestones_provider=milestones,
+        )
+
+    # Single-stream: tee the detector only. A lone configured device labels the
+    # WAV; otherwise the default roast.wav name is kept.
+    detector_label = devices[0] if devices else None
     return RoastAudioRecorder(
         wav_path=session_dir / "roast.wav",
-        sidecar_path=session_dir / "roast.recording.json",
+        sidecar_path=sidecar_path,
         sample_rate=sample_rate,
         session_id=session.id,
-        milestones_provider=lambda: recording_relative_milestones(session),
+        device_label=detector_label,
+        milestones_provider=milestones,
     )
 
 

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,6 +30,8 @@ from coffee_roaster_mcp.detector import (
     integrate_first_crack_window_with_session,
 )
 from coffee_roaster_mcp.session import RoastSession, RoastSessionStore, SessionLifecycleError
+
+_LOGGER = logging.getLogger(__name__)
 
 FirstCrackRuntimeState = Literal[
     "disabled",
@@ -132,15 +135,26 @@ class FirstCrackSessionRuntime:
         #: by ``set_recording_metadata`` before the roast; consumed when the
         #: recorder is built at session start. None falls back to session_id / 0.
         self._recording_metadata: RecordingMetadata | None = None
+        #: Whether the recorder for the active session was already built (#176). If
+        #: ``set_recording_metadata`` arrives after this, the WAV names are already
+        #: fixed and the late metadata is rejected with a clear warning.
+        self._recorder_built_for_session = False
 
     def set_recording_metadata(self, *, origin: str, roast_num: int) -> RecordingMetadata:
-        """Store annotation-pipeline metadata for the next/current recording.
+        """Store annotation-pipeline metadata for the next roast's recording.
 
-        Called before a roast so the captured WAVs are named
-        ``mic{N}-{origin}-roast{N}.wav`` and a ``{origin}-roast{N}-session.json``
-        is written for the coffee-first-crack-detection annotation pipeline. If
-        never called, recording falls back to the session id as origin and roast
-        number ``0`` so capture never breaks.
+        Call this BEFORE ``start_roast_session``. The recorder reads it when it
+        creates the WAVs, naming them ``mic{N}-{origin}-roast{N}.wav`` and writing
+        a ``{origin}-roast{N}-session.json`` for the coffee-first-crack-detection
+        annotation pipeline. If never called, recording falls back to the session
+        id as origin and roast number ``0`` so capture never breaks.
+
+        Ordering matters: the recorder is built at session start, so metadata set
+        AFTER the roast has started cannot rename the already-open WAVs. Calling
+        it late is therefore non-silent — it logs a clear warning and the late
+        metadata is NOT applied (renaming nothing while relabelling the session
+        JSON would point the JSON at the wrong WAV files). The stored value is
+        still returned so the agent can detect the mismatch.
 
         Args:
             origin: Bean origin slug (e.g. ``"brazil"``).
@@ -158,6 +172,15 @@ class FirstCrackSessionRuntime:
         if roast_num < 0:
             raise ValueError("roast_num must be >= 0.")
         with self._lock:
+            if self._recorder_built_for_session:
+                _LOGGER.warning(
+                    "set_recording_metadata(origin=%r, roast_num=%d) arrived AFTER the "
+                    "roast recorder was built; the WAV names are already fixed for the "
+                    "active session and this metadata will NOT be applied. Call "
+                    "set_recording_metadata BEFORE start_roast_session.",
+                    normalized_origin,
+                    roast_num,
+                )
             self._recording_metadata = RecordingMetadata(
                 origin=normalized_origin,
                 roast_num=roast_num,
@@ -189,6 +212,9 @@ class FirstCrackSessionRuntime:
                 metadata=self._recording_metadata,
             )
             self._pending_recorder = recorder
+            # Once the recorder exists the WAV names are fixed; a later
+            # set_recording_metadata for this session is rejected with a warning.
+            self._recorder_built_for_session = recorder is not None
             try:
                 adapter = self._detector_adapter_factory(self._config.first_crack)
                 pipeline = self._audio_pipeline_factory(self._config.audio)
@@ -371,6 +397,8 @@ class FirstCrackSessionRuntime:
             finally:
                 self._pipeline = None
                 self._adapter = None
+        # The session is over: the next roast may set fresh recording metadata.
+        self._recorder_built_for_session = False
         if self._status == "pending":
             self._reason = f"Audio first-crack detection stopped before confirmation: {reason}."
 
@@ -475,7 +503,13 @@ def build_session_recorder(
     )
     session_dir = export_location / session.id
     sidecar_path = session_dir / "roast.recording.json"
-    sample_rate = recording.sample_rate or config.audio.sample_rate
+    # The teed mic1 stream IS the FC detector's stream, so its WAV header must use
+    # the detector's TRUE capture rate (audio.sample_rate), not recording.sample_rate
+    # (#176 hardware bug 1: a 16 kHz teed stream mislabelled at 44.1 kHz played
+    # ~2.75x too fast). Only the independently-opened additional streams use
+    # recording.sample_rate (defaulting to the detector rate when unset).
+    detector_sample_rate = config.audio.sample_rate
+    additional_sample_rate = recording.sample_rate or config.audio.sample_rate
     devices = recording.devices or ()
 
     origin = _normalize_origin_slug(metadata.origin if metadata is not None else session.id)
@@ -520,7 +554,7 @@ def build_session_recorder(
             AdditionalRecordingDevice(
                 device_label=label,
                 wav_path=_mic_wav(index + 2),
-                sample_rate=sample_rate,
+                sample_rate=additional_sample_rate,
             )
             for index, label in enumerate(devices[1:])
         ]
@@ -528,7 +562,7 @@ def build_session_recorder(
             detector_wav_path=_mic_wav(1),
             detector_device_label=detector_label,
             sidecar_path=sidecar_path,
-            sample_rate=sample_rate,
+            sample_rate=detector_sample_rate,
             session_id=session.id,
             additional_devices=additional,
             milestones_provider=milestones,
@@ -547,7 +581,7 @@ def build_session_recorder(
         recorder = RoastAudioRecorder(
             wav_path=_mic_wav(1),
             sidecar_path=sidecar_path,
-            sample_rate=sample_rate,
+            sample_rate=detector_sample_rate,
             session_id=session.id,
             device_label=detector_label,
             milestones_provider=milestones,

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from threading import RLock
 from typing import Literal, Protocol
 
 from coffee_roaster_mcp.artifacts import ArtifactResolutionError
 from coffee_roaster_mcp.audio import (
     AdditionalRecordingDevice,
+    AnnotationSessionSpec,
     AudioCaptureError,
     AudioCapturePipeline,
     AudioCaptureSnapshot,
@@ -18,7 +20,6 @@ from coffee_roaster_mcp.audio import (
     RoastAudioRecorder,
     RoastRecorder,
     build_audio_capture_pipeline,
-    device_label_to_filename,
 )
 from coffee_roaster_mcp.config import AppConfig, AudioConfig, FirstCrackConfig
 from coffee_roaster_mcp.detector import (
@@ -127,6 +128,41 @@ class FirstCrackSessionRuntime:
         #: default pipeline factory runs so the teed WAV is wired into the real
         #: capture pipeline; injected test factories ignore it.
         self._pending_recorder: RoastRecorder | None = None
+        #: Annotation-pipeline metadata for the next/current recording (#176). Set
+        #: by ``set_recording_metadata`` before the roast; consumed when the
+        #: recorder is built at session start. None falls back to session_id / 0.
+        self._recording_metadata: RecordingMetadata | None = None
+
+    def set_recording_metadata(self, *, origin: str, roast_num: int) -> RecordingMetadata:
+        """Store annotation-pipeline metadata for the next/current recording.
+
+        Called before a roast so the captured WAVs are named
+        ``mic{N}-{origin}-roast{N}.wav`` and a ``{origin}-roast{N}-session.json``
+        is written for the coffee-first-crack-detection annotation pipeline. If
+        never called, recording falls back to the session id as origin and roast
+        number ``0`` so capture never breaks.
+
+        Args:
+            origin: Bean origin slug (e.g. ``"brazil"``).
+            roast_num: 1-based roast number.
+
+        Returns:
+            The stored :class:`RecordingMetadata`.
+
+        Raises:
+            ValueError: If origin is blank or roast_num is negative.
+        """
+        normalized_origin = origin.strip()
+        if not normalized_origin:
+            raise ValueError("origin must not be blank.")
+        if roast_num < 0:
+            raise ValueError("roast_num must be >= 0.")
+        with self._lock:
+            self._recording_metadata = RecordingMetadata(
+                origin=normalized_origin,
+                roast_num=roast_num,
+            )
+            return self._recording_metadata
 
     def _build_default_audio_pipeline(self, config: AudioConfig) -> AudioCapturePipeline:
         """Build the real capture pipeline, teeing the pending session recorder."""
@@ -147,7 +183,11 @@ class FirstCrackSessionRuntime:
 
             self._status = "pending"
             self._reason = "Audio first-crack detection is prepared for this session."
-            recorder = build_session_recorder(self._config, session)
+            recorder = build_session_recorder(
+                self._config,
+                session,
+                metadata=self._recording_metadata,
+            )
             self._pending_recorder = recorder
             try:
                 adapter = self._detector_adapter_factory(self._config.first_crack)
@@ -355,9 +395,42 @@ def build_first_crack_session_runtime(
 _DEFAULT_RECORDING_SUBDIR = "captures"
 
 
+@dataclass(frozen=True)
+class RecordingMetadata:
+    """Annotation-pipeline metadata for a recording session (#176).
+
+    Set by the ``set_recording_metadata`` MCP tool before a roast so the captured
+    WAVs are named and described for the coffee-first-crack-detection annotation
+    pipeline.
+
+    Attributes:
+        origin: Bean origin slug (e.g. ``"brazil"``).
+        roast_num: 1-based roast number.
+    """
+
+    origin: str
+    roast_num: int
+
+
+def _normalize_origin_slug(origin: str) -> str:
+    """Coerce an origin into the ``[a-z0-9-]+`` slug the FC pipeline expects.
+
+    Lower-cases, replaces every run of disallowed characters with a hyphen, and
+    trims leading/trailing hyphens. An empty result falls back to ``"roast"`` so
+    a filename is always producible.
+    """
+    chars = [char.lower() if char.isalnum() else "-" for char in origin]
+    slug = "".join(chars).strip("-")
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    return slug or "roast"
+
+
 def build_session_recorder(
     config: AppConfig,
     session: RoastSession,
+    *,
+    metadata: RecordingMetadata | None = None,
 ) -> RoastRecorder | None:
     """Build a per-roast audio recorder for one session, or `None` when disabled.
 
@@ -365,20 +438,30 @@ def build_session_recorder(
     are true, so capture begins with the roast and needs no MCP command. Output
     lands under `export_location/<session_id>/`.
 
+    Annotation-pipeline naming (#176): WAVs are named
+    ``mic{N}-{origin}-roast{N}.wav`` (N = 1-based device order, mic1 = the
+    detector/teed device) and a ``{origin}-roast{N}-session.json`` is written
+    alongside the recording sidecar, so the output plugs straight into
+    coffee-first-crack-detection's ``propagate_annotations`` / ``chunk_audio``.
+    When `metadata` is omitted the fallback origin is the session id and the
+    roast number is ``0``, so capture never breaks.
+
     Dispatch on `recording.devices`:
 
     - Unset, empty, or a single device: a single-stream
       :class:`RoastAudioRecorder` that tees the detector's existing mono stream
-      into one WAV (the original behaviour).
+      into one WAV (mic1).
     - Two or more devices: a :class:`MultiDeviceRoastRecorder` — the FIRST device
-      is the detector's device (teed, no second open) and each ADDITIONAL device
-      is captured as its own independent stream into its own WAV (option A). WAV
-      filenames are derived from the device labels.
+      is the detector's device (teed, no second open, mic1) and each ADDITIONAL
+      device is captured as its own independent stream into its own WAV (option
+      A, mic2..N).
 
     Args:
         config: Application configuration.
         session: Live roast session that owns the recording. Its milestone
             timestamps are read at close to compute recording-relative offsets.
+        metadata: Optional annotation-pipeline metadata (origin + roast number).
+            Falls back to ``origin=session.id`` and ``roast_num=0`` when omitted.
 
     Returns:
         A configured recorder, or `None` when recording is disabled or capture
@@ -395,6 +478,13 @@ def build_session_recorder(
     sample_rate = recording.sample_rate or config.audio.sample_rate
     devices = recording.devices or ()
 
+    origin = _normalize_origin_slug(metadata.origin if metadata is not None else session.id)
+    roast_num = metadata.roast_num if metadata is not None else 0
+    annotation_path = session_dir / f"{origin}-roast{roast_num}-session.json"
+
+    def _mic_wav(mic_num: int) -> Path:
+        return session_dir / f"mic{mic_num}-{origin}-roast{roast_num}.wav"
+
     # The milestones closure needs the recorder's start instant to rebase the
     # session-elapsed milestone times onto the recording clock, but the recorder
     # is built below. Capture it in a one-slot holder the closure reads at close.
@@ -410,38 +500,58 @@ def build_session_recorder(
             recording_started_monotonic_seconds=recording_started_monotonic,
         )
 
+    # Per-device labels for the annotation session JSON, in device order. The
+    # detector is mic1; additional devices use their configured label, else mic{N}.
+    mic_labels = tuple(
+        devices[index] if index < len(devices) else f"mic{index + 1}"
+        for index in range(max(1, len(devices)))
+    )
+
     recorder: RoastRecorder
     if len(devices) >= 2:
         detector_label = devices[0]
-        detector_wav = session_dir / f"roast.{device_label_to_filename(detector_label)}.wav"
+        annotation_session = AnnotationSessionSpec(
+            path=annotation_path,
+            origin=origin,
+            roast_num=roast_num,
+            mic_labels=mic_labels,
+        )
         additional = [
             AdditionalRecordingDevice(
                 device_label=label,
-                wav_path=session_dir / f"roast.{device_label_to_filename(label)}.wav",
+                wav_path=_mic_wav(index + 2),
                 sample_rate=sample_rate,
             )
-            for label in devices[1:]
+            for index, label in enumerate(devices[1:])
         ]
         recorder = MultiDeviceRoastRecorder(
-            detector_wav_path=detector_wav,
+            detector_wav_path=_mic_wav(1),
             detector_device_label=detector_label,
             sidecar_path=sidecar_path,
             sample_rate=sample_rate,
             session_id=session.id,
             additional_devices=additional,
             milestones_provider=milestones,
+            annotation_session=annotation_session,
         )
     else:
-        # Single-stream: tee the detector only. A lone configured device labels
-        # the WAV; otherwise the default roast.wav name is kept.
+        # Single-stream: tee the detector only (mic1). A lone configured device
+        # supplies the mic1 label; otherwise the default mic1 label is used.
         detector_label = devices[0] if devices else None
+        annotation_session = AnnotationSessionSpec(
+            path=annotation_path,
+            origin=origin,
+            roast_num=roast_num,
+            mic_labels=(mic_labels[0],),
+        )
         recorder = RoastAudioRecorder(
-            wav_path=session_dir / "roast.wav",
+            wav_path=_mic_wav(1),
             sidecar_path=sidecar_path,
             sample_rate=sample_rate,
             session_id=session.id,
             device_label=detector_label,
             milestones_provider=milestones,
+            annotation_session=annotation_session,
         )
     recorder_holder.append(recorder)
     return recorder

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -393,6 +393,19 @@ class EventCommandResult:
 
 
 @dataclass(frozen=True)
+class SetRecordingMetadataResult:
+    """Result for storing annotation-pipeline recording metadata (#176).
+
+    Attributes:
+        origin: Stored bean origin slug used to name the captured WAVs.
+        roast_num: Stored 1-based roast number used to name the captured WAVs.
+    """
+
+    origin: str
+    roast_num: int
+
+
+@dataclass(frozen=True)
 class ExportRoastLogResult:
     """Result for one snapshot roast-log export."""
 
@@ -521,6 +534,7 @@ def create_mcp_server(
                 "stop_cooling",
                 "export_roast_log",
                 "emergency_stop",
+                "set_recording_metadata",
             ),
             started_at_utc=server_context.started_at_utc.isoformat(),
         )
@@ -777,6 +791,38 @@ def create_mcp_server(
             reason="emergency stop",
         )
         return _serialize_event_result(snapshot=snapshot, event=event)
+
+    @mcp.tool()
+    def set_recording_metadata(  # pyright: ignore[reportUntypedFunctionDecorator, reportUnusedFunction]
+        ctx: Context[ServerSession, ServerContext],
+        origin: str,
+        roast_num: int,
+    ) -> SetRecordingMetadataResult:
+        """Store bean origin + roast number for the next roast's audio recording.
+
+        Call this BEFORE starting the roast. The recorder reads it when it creates
+        the WAVs, naming them ``mic{N}-{origin}-roast{N}.wav`` and writing a
+        ``{origin}-roast{N}-session.json`` so the captured audio plugs straight
+        into the coffee-first-crack-detection annotation pipeline. This is purely
+        additive metadata: it sends no hardware command. If never called,
+        recording falls back to the session id as origin and roast number 0.
+
+        Args:
+            origin: Bean origin slug (e.g. ``"brazil"``).
+            roast_num: 1-based roast number.
+
+        Returns:
+            The stored origin and roast number.
+
+        Raises:
+            ValueError: If origin is blank or roast_num is negative.
+        """
+        server_context = ctx.request_context.lifespan_context
+        stored = server_context.first_crack_runtime.set_recording_metadata(
+            origin=origin,
+            roast_num=roast_num,
+        )
+        return SetRecordingMetadataResult(origin=stored.origin, roast_num=stored.roast_num)
 
     return mcp
 

--- a/src/coffee_roaster_mcp/record_check.py
+++ b/src/coffee_roaster_mcp/record_check.py
@@ -1,0 +1,315 @@
+"""Roast-free multi-device recording smoke test (#176, option A).
+
+The multi-device recorder only runs inside a roast (the detector owns the teed
+stream; the additional devices are opened by the recorder). That makes it hard
+to validate real capture on a laptop without starting a roast. This module
+closes that gap: it opens EVERY configured `recording.devices` entry as its own
+independent capture stream, records a few seconds to a temp directory, writes the
+WAVs plus the recording sidecar, and reports each WAV's peak / RMS dBFS so a
+silent or dead mic is obvious (a flat floor means the device opened but delivered
+silence — muted, OS-permission-blocked, or grabbed by another process).
+
+Unlike a real roast, the smoke test captures the FIRST (detector) device
+independently too, because there is no detector loop to tee. It reuses the same
+capture primitives as the roast path (`_WavStreamWriter`,
+`_IndependentCaptureStream`, the configured `MicrophoneAudioInput`), so a pass
+here exercises the real device-open + read path. It is injectable end to end so
+the logic is unit-tested without hardware; the decisive proof is the operator's
+real run on their MacBook.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import math
+import struct
+import wave
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from tempfile import mkdtemp
+from typing import cast
+
+from coffee_roaster_mcp.audio import (
+    AdditionalAudioInputFactory,
+    AdditionalRecordingDevice,
+    capture_devices_independently,
+    device_label_to_filename,
+)
+from coffee_roaster_mcp.config import load_config
+
+#: Default smoke-test capture duration.
+DEFAULT_RECORD_SECONDS = 5.0
+#: dBFS at or above which a stream is treated as carrying real signal (not
+#: silence). -50 dBFS is comfortably above a quiet room floor but well below
+#: speech / a snap; a muted or blocked device sits at or below it.
+DEFAULT_SIGNAL_FLOOR_DBFS = -50.0
+_READ_SECONDS = 0.1
+
+
+@dataclass(frozen=True)
+class RecordCheckStreamResult:
+    """Per-device result of the recording smoke test.
+
+    Attributes:
+        device: Configured device-name substring.
+        wav_filename: WAV file written for this device.
+        sample_rate: Capture/WAV sample rate in Hz.
+        frame_count: Frames written for this device.
+        duration_seconds: Recorded duration in seconds.
+        peak_dbfs: Peak amplitude in dBFS (`-inf` for pure silence).
+        rms_dbfs: RMS level in dBFS (`-inf` for pure silence).
+        has_signal: Whether `peak_dbfs` cleared the signal floor.
+        error: Capture/open error for this device, if any (the stream is dropped
+            but the others continue).
+    """
+
+    device: str
+    wav_filename: str
+    sample_rate: int
+    frame_count: int
+    duration_seconds: float
+    peak_dbfs: float
+    rms_dbfs: float
+    has_signal: bool
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class RecordCheckReport:
+    """Result of a multi-device recording smoke test.
+
+    Attributes:
+        output_dir: Directory the WAVs and sidecar were written to.
+        sidecar_filename: Recording sidecar JSON filename.
+        record_seconds: Requested capture duration.
+        signal_floor_dbfs: dBFS floor used to decide `has_signal`.
+        streams: Per-device results.
+        error: Top-level error (e.g. no devices configured), if any.
+        passed: Every configured stream captured real signal above the floor.
+    """
+
+    output_dir: Path
+    sidecar_filename: str
+    record_seconds: float
+    signal_floor_dbfs: float
+    streams: list[RecordCheckStreamResult] = field(
+        default_factory=lambda: cast(list[RecordCheckStreamResult], [])
+    )
+    error: str | None = None
+    passed: bool = False
+
+
+@dataclass(frozen=True)
+class RecordCheckOptions:
+    """Options for the recording smoke test.
+
+    Attributes:
+        config_path: Optional coffee-roaster-mcp YAML config path; its
+            `recording.devices` (or `audio.input_device` fallback) selects the
+            devices and `recording.sample_rate` (or `audio.sample_rate`) the rate.
+        record_seconds: How long to capture from each device.
+        signal_floor_dbfs: dBFS floor above which a stream counts as real signal.
+        output_dir: Optional output directory; a temp directory is used when unset.
+    """
+
+    config_path: Path | None = None
+    record_seconds: float = DEFAULT_RECORD_SECONDS
+    signal_floor_dbfs: float = DEFAULT_SIGNAL_FLOOR_DBFS
+    output_dir: Path | None = None
+
+
+def _amplitude_to_dbfs(amplitude: float) -> float:
+    """Convert a 0..1 amplitude to dBFS (`-inf` at zero)."""
+    if amplitude <= 0.0:
+        return -math.inf
+    return round(20.0 * math.log10(min(1.0, amplitude)), 2)
+
+
+def _read_wav_levels(path: Path) -> tuple[float, float]:
+    """Return `(peak_dbfs, rms_dbfs)` for a 16-bit mono PCM WAV."""
+    with wave.open(str(path), "rb") as wav_file:
+        frame_count = wav_file.getnframes()
+        raw = wav_file.readframes(frame_count)
+    if not raw:
+        return -math.inf, -math.inf
+    peak = 0.0
+    sum_squares = 0.0
+    count = 0
+    for (value,) in struct.iter_unpack("<h", raw):
+        amplitude = abs(value) / 32768.0
+        peak = max(peak, amplitude)
+        sum_squares += amplitude * amplitude
+        count += 1
+    rms = math.sqrt(sum_squares / count) if count else 0.0
+    return _amplitude_to_dbfs(peak), _amplitude_to_dbfs(rms)
+
+
+def run_record_check(
+    options: RecordCheckOptions,
+    *,
+    additional_input_factory: AdditionalAudioInputFactory | None = None,
+    sleep: Callable[[float], None] | None = None,
+) -> RecordCheckReport:
+    """Record a few seconds from every configured device and report levels.
+
+    Args:
+        options: Smoke-test options (config, duration, floor, output dir).
+        additional_input_factory: Opens a fresh input per device; defaults to the
+            real configured microphone input. Injected in tests.
+        sleep: Sleep function for the capture window; defaults to `time.sleep`.
+            Injected in tests to avoid real waits.
+
+    Returns:
+        A :class:`RecordCheckReport`. Never raises for capture/config problems —
+        they are recorded in ``error`` / per-stream ``error`` with
+        ``passed=False``.
+    """
+    config = load_config(path=options.config_path)
+    recording = config.recording
+    sample_rate = recording.sample_rate or config.audio.sample_rate
+    devices = list(recording.devices or ())
+    if not devices and config.audio.input_device is not None:
+        # Fall back to the single detector device so the smoke test still works
+        # before `recording.devices` is configured.
+        devices = [config.audio.input_device]
+
+    output_dir = options.output_dir or Path(mkdtemp(prefix="roast-record-check-"))
+    sidecar_path = output_dir / "record-check.json"
+
+    if not devices:
+        return RecordCheckReport(
+            output_dir=output_dir,
+            sidecar_filename=sidecar_path.name,
+            record_seconds=options.record_seconds,
+            signal_floor_dbfs=options.signal_floor_dbfs,
+            error=(
+                "No devices configured: set recording.devices (or audio.input_device) "
+                "to smoke-test capture."
+            ),
+        )
+
+    specs = [
+        AdditionalRecordingDevice(
+            device_label=label,
+            wav_path=output_dir / f"record-check.{device_label_to_filename(label)}.wav",
+            sample_rate=sample_rate,
+        )
+        for label in devices
+    ]
+    captures = capture_devices_independently(
+        specs,
+        record_seconds=options.record_seconds,
+        sidecar_path=sidecar_path,
+        session_id="record-check",
+        input_factory=additional_input_factory,
+        sleep=sleep,
+        read_seconds=_READ_SECONDS,
+    )
+
+    results: list[RecordCheckStreamResult] = []
+    for capture in captures:
+        peak_dbfs = -math.inf
+        rms_dbfs = -math.inf
+        error: str | None = None
+        if capture.wav_path.exists():
+            try:
+                peak_dbfs, rms_dbfs = _read_wav_levels(capture.wav_path)
+            except (OSError, wave.Error) as exc:
+                error = f"Could not read back {capture.wav_path.name}: {exc}"
+        else:
+            error = "No WAV was written (device open/read failed)."
+        if capture.frame_count == 0 and error is None:
+            error = "Captured no audio frames (silent or failed stream)."
+        has_signal = peak_dbfs >= options.signal_floor_dbfs
+        results.append(
+            RecordCheckStreamResult(
+                device=capture.device_label,
+                wav_filename=capture.wav_path.name,
+                sample_rate=capture.sample_rate,
+                frame_count=capture.frame_count,
+                duration_seconds=round(capture.frame_count / capture.sample_rate, 6),
+                peak_dbfs=peak_dbfs,
+                rms_dbfs=rms_dbfs,
+                has_signal=has_signal,
+                error=error,
+            )
+        )
+
+    passed = bool(results) and all(r.has_signal and r.error is None for r in results)
+    return RecordCheckReport(
+        output_dir=output_dir,
+        sidecar_filename=sidecar_path.name,
+        record_seconds=options.record_seconds,
+        signal_floor_dbfs=options.signal_floor_dbfs,
+        streams=results,
+        passed=passed,
+    )
+
+
+def _json_safe(value: object) -> object:
+    """Recursively make a value JSON-safe.
+
+    Paths become strings and non-finite floats (e.g. `-inf` dBFS for pure
+    silence) become the strings ``"-inf"`` / ``"inf"`` / ``"nan"`` so the JSON
+    stays valid.
+    """
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, float) and not math.isfinite(value):
+        if math.isnan(value):
+            return "nan"
+        return "-inf" if value < 0 else "inf"
+    if isinstance(value, dict):
+        return {key: _json_safe(item) for key, item in cast(dict[object, object], value).items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in cast(list[object], value)]
+    return value
+
+
+def report_to_json(report: RecordCheckReport) -> str:
+    """Serialize a :class:`RecordCheckReport` to pretty JSON.
+
+    `-inf` dBFS (pure silence) is rendered as the string ``"-inf"`` so the JSON
+    stays valid.
+    """
+    payload = _json_safe(dataclasses.asdict(report))
+    return json.dumps(payload, indent=2)
+
+
+def main() -> int:  # pragma: no cover - thin CLI wiring exercised via cli.py.
+    """Run the recording smoke test from `python -m coffee_roaster_mcp.record_check`."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m coffee_roaster_mcp.record_check",
+        description="Smoke-test multi-device roast audio capture without a roast.",
+    )
+    parser.add_argument("--config", type=Path, default=None, help="coffee-roaster-mcp YAML config.")
+    parser.add_argument(
+        "--seconds",
+        type=float,
+        default=DEFAULT_RECORD_SECONDS,
+        help="Capture duration per device.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Where to write the WAVs + sidecar (a temp dir is used when unset).",
+    )
+    args = parser.parse_args()
+    report = run_record_check(
+        RecordCheckOptions(
+            config_path=args.config,
+            record_seconds=args.seconds,
+            output_dir=args.output_dir,
+        )
+    )
+    print(report_to_json(report))
+    return 0 if report.passed else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - module entrypoint.
+    raise SystemExit(main())

--- a/src/coffee_roaster_mcp/record_check.py
+++ b/src/coffee_roaster_mcp/record_check.py
@@ -34,6 +34,7 @@ from typing import cast
 from coffee_roaster_mcp.audio import (
     AdditionalAudioInputFactory,
     AdditionalRecordingDevice,
+    AudioCaptureError,
     capture_devices_independently,
     device_label_to_filename,
 )
@@ -198,15 +199,27 @@ def run_record_check(
         )
         for label in devices
     ]
-    captures = capture_devices_independently(
-        specs,
-        record_seconds=options.record_seconds,
-        sidecar_path=sidecar_path,
-        session_id="record-check",
-        input_factory=additional_input_factory,
-        sleep=sleep,
-        read_seconds=_READ_SECONDS,
-    )
+    try:
+        captures = capture_devices_independently(
+            specs,
+            record_seconds=options.record_seconds,
+            sidecar_path=sidecar_path,
+            session_id="record-check",
+            input_factory=additional_input_factory,
+            sleep=sleep,
+            read_seconds=_READ_SECONDS,
+        )
+    except (AudioCaptureError, OSError, wave.Error) as exc:
+        # The docstring promises never to raise for capture problems: a WAV
+        # open/write or sidecar I/O error becomes a report so the CLI exits
+        # cleanly (non-zero) with diagnostics instead of crashing.
+        return RecordCheckReport(
+            output_dir=output_dir,
+            sidecar_filename=sidecar_path.name,
+            record_seconds=options.record_seconds,
+            signal_floor_dbfs=options.signal_floor_dbfs,
+            error=f"Recording failed: {exc}",
+        )
 
     results: list[RecordCheckStreamResult] = []
     for capture in captures:

--- a/src/coffee_roaster_mcp/session.py
+++ b/src/coffee_roaster_mcp/session.py
@@ -334,6 +334,15 @@ class RoastSession:
         log_writer: Append-only log writer reference when available.
         last_logged_telemetry_monotonic_seconds: Latest telemetry timestamp
             written to the append-only JSONL log.
+        fc_window_count: Number of audio windows the first-crack detector
+            processed during this session (#175 observability).
+        fc_max_confidence: Highest per-window first-crack confidence seen so
+            far, or `None` when no window reported a confidence.
+        fc_max_positive_window_count: Highest rolling positive-window count the
+            detector reached, even when confirmation was never met.
+        fc_model_confirmed: Whether the audio model confirmed first crack for
+            this session (false when first crack was operator-marked or never
+            fired).
         stopped_at_utc: Wall-clock UTC stop time once the session is stopped.
         monotonic_stop: Monotonic clock value captured when the session stops.
     """
@@ -365,6 +374,10 @@ class RoastSession:
     telemetry_buffer: deque[TelemetrySample] = field(default_factory=_telemetry_buffer_default)
     log_writer: LogWriterReference | None = None
     last_logged_telemetry_monotonic_seconds: float | None = None
+    fc_window_count: int = 0
+    fc_max_confidence: float | None = None
+    fc_max_positive_window_count: int = 0
+    fc_model_confirmed: bool = False
     stopped_at_utc: datetime | None = None
     monotonic_stop: float | None = None
     pending_driver_command_token: str | None = None
@@ -1677,6 +1690,65 @@ class RoastSessionStore:
         _apply_event_timestamp(session, event)
         return event
 
+    def record_first_crack_window_observation(
+        self,
+        session: RoastSession,
+        *,
+        window_sequence_number: int,
+        confidence: float | None,
+        positive_window_count: int,
+        confirmed: bool,
+        fc_status: Literal["listening", "candidate", "confirmed"],
+    ) -> None:
+        """Record one per-window first-crack inference observation (#175).
+
+        This is observability-only: it appends an `fc_window` row to the durable
+        roast log and updates the session's first-crack inference aggregates. It
+        never records a timeline event or changes control behavior. The
+        confirmed first-crack timeline event is still recorded separately by
+        `record_first_crack_detection_snapshot`.
+
+        Args:
+            session: Latest active session that owns the observation.
+            window_sequence_number: Source audio window sequence number.
+            confidence: Per-window model confidence, or `None` when the backend
+                reported no confidence.
+            positive_window_count: Rolling positive-window count inside the
+                confirmation span after this window was processed.
+            confirmed: Whether this window confirmed first crack.
+            fc_status: Per-window status (`listening`, `candidate`, `confirmed`).
+
+        Raises:
+            SessionLifecycleError: If the session is not the latest active session.
+        """
+        with self._lock:
+            self._assert_latest_active_session(session)
+            recorded_at_utc = self._utc_now()
+            monotonic_seconds = session.elapsed_monotonic_seconds(self._monotonic_now)
+            session.fc_window_count += 1
+            if confidence is not None and (
+                session.fc_max_confidence is None or confidence > session.fc_max_confidence
+            ):
+                session.fc_max_confidence = confidence
+            if positive_window_count > session.fc_max_positive_window_count:
+                session.fc_max_positive_window_count = positive_window_count
+            if confirmed:
+                session.fc_model_confirmed = True
+            _append_jsonl_log_row(
+                session,
+                {
+                    "session_id": session.id,
+                    "type": "fc_window",
+                    "recorded_at_utc": recorded_at_utc.isoformat(),
+                    "monotonic_seconds": monotonic_seconds,
+                    "window_sequence_number": window_sequence_number,
+                    "confidence": confidence,
+                    "positive_window_count": positive_window_count,
+                    "confirmed": confirmed,
+                    "fc_status": fc_status,
+                },
+            )
+
     def record_first_crack_detection_snapshot(
         self,
         session: RoastSession,
@@ -2325,6 +2397,10 @@ def _copy_session_for_read(session: RoastSession) -> RoastSession:
         telemetry_buffer=deque(session.telemetry_buffer),
         log_writer=session.log_writer,
         last_logged_telemetry_monotonic_seconds=(session.last_logged_telemetry_monotonic_seconds),
+        fc_window_count=session.fc_window_count,
+        fc_max_confidence=session.fc_max_confidence,
+        fc_max_positive_window_count=session.fc_max_positive_window_count,
+        fc_model_confirmed=session.fc_model_confirmed,
         stopped_at_utc=session.stopped_at_utc,
         monotonic_stop=session.monotonic_stop,
         pending_driver_command_token=session.pending_driver_command_token,

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -958,3 +958,176 @@ def test_pipeline_recorder_write_failure_does_not_kill_detection(tmp_path: Path)
     assert snapshot.emitted_window_count == 1
     assert snapshot.latest_error is None
     assert pipeline.drain_windows()[0].samples == (0.0, 1.0, 2.0, 3.0)
+
+
+def test_device_label_to_filename_slug() -> None:
+    from coffee_roaster_mcp.audio import device_label_to_filename
+
+    assert device_label_to_filename("USB PnP") == "usb-pnp"
+    assert device_label_to_filename("ATR2100x-USB") == "atr2100x-usb"
+    assert device_label_to_filename("  !!  ") == "device"
+    assert device_label_to_filename("A  B__C") == "a-b-c"
+
+
+class _BoundedInput:
+    """Yields a fixed number of constant-amplitude reads, then end-of-stream."""
+
+    def __init__(self, amplitude: float, reads: int) -> None:
+        self._amplitude = amplitude
+        self._reads = reads
+        self.closed = False
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        if self._reads <= 0:
+            return ()
+        self._reads -= 1
+        return (self._amplitude,) * sample_count
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_multi_device_recorder_writes_two_wavs(tmp_path: Path) -> None:
+    import json
+    import time
+
+    from coffee_roaster_mcp.audio import AdditionalRecordingDevice, MultiDeviceRoastRecorder
+
+    inputs: dict[str, _BoundedInput] = {}
+
+    def factory(device: AdditionalRecordingDevice) -> _BoundedInput:
+        created = _BoundedInput(amplitude=0.5, reads=4)
+        inputs[device.device_label] = created
+        return created
+
+    recorder = MultiDeviceRoastRecorder(
+        detector_wav_path=tmp_path / "roast.usb-pnp.wav",
+        detector_device_label="USB PnP",
+        sidecar_path=tmp_path / "roast.recording.json",
+        sample_rate=4,
+        session_id="s",
+        additional_devices=[
+            AdditionalRecordingDevice("ATR2100x", tmp_path / "roast.atr2100x.wav", 4),
+        ],
+        milestones_provider=lambda: {"beans_added": 1.0, "first_crack": 9.0},
+        additional_input_factory=factory,
+        additional_read_seconds=0.25,
+        idle_sleep_seconds=0.001,
+        stop_timeout_seconds=2.0,
+    )
+
+    recorder.begin()
+    recorder.write_samples((0.25,) * 8)  # teed detector samples → detector WAV only
+    # Let the independent ATR2100x stream drain its bounded input, then close
+    # (close() joins the capture thread and finalizes every WAV).
+    time.sleep(0.1)
+    recorder.close()
+
+    # Two WAVs: the teed detector stream + the independent additional stream.
+    detector_values, _, _ = _read_wav_samples(tmp_path / "roast.usb-pnp.wav")
+    additional_values, _, _ = _read_wav_samples(tmp_path / "roast.atr2100x.wav")
+    assert detector_values == (round(0.25 * 32767),) * 8  # teed samples only
+    assert len(additional_values) > 0
+    assert all(value == round(0.5 * 32767) for value in additional_values)  # independent capture
+    # The additional device was opened fresh and closed on its own thread.
+    assert inputs["ATR2100x"].closed is True
+
+    sidecar = json.loads((tmp_path / "roast.recording.json").read_text(encoding="utf-8"))
+    assert sidecar["schema_version"] == 2
+    devices = [stream["device"] for stream in sidecar["streams"]]
+    assert devices == ["USB PnP", "ATR2100x"]
+    # Per-stream sample rate + the detector stream surfaced at top level (back-compat).
+    assert all(stream["sample_rate"] == 4 for stream in sidecar["streams"])
+    assert sidecar["wav_filename"] == "roast.usb-pnp.wav"
+    assert sidecar["milestones"] == {"beans_added": 1.0, "first_crack": 9.0}
+    assert recorder.additional_wav_paths == (tmp_path / "roast.atr2100x.wav",)
+
+
+def test_multi_device_recorder_drops_only_failing_stream(tmp_path: Path) -> None:
+    import json
+    import time
+
+    from coffee_roaster_mcp.audio import AdditionalRecordingDevice, MultiDeviceRoastRecorder
+
+    class FailingInput:
+        def read_samples(self, sample_count: int) -> Sequence[float]:
+            raise RuntimeError("device unplugged")
+
+        def close(self) -> None:
+            return None
+
+    good = _BoundedInput(amplitude=0.5, reads=4)
+
+    def factory(device: AdditionalRecordingDevice) -> AudioInput:
+        return FailingInput() if device.device_label == "BAD" else good
+
+    recorder = MultiDeviceRoastRecorder(
+        detector_wav_path=tmp_path / "roast.usb-pnp.wav",
+        detector_device_label="USB PnP",
+        sidecar_path=tmp_path / "roast.recording.json",
+        sample_rate=4,
+        session_id="s",
+        additional_devices=[
+            AdditionalRecordingDevice("BAD", tmp_path / "roast.bad.wav", 4),
+            AdditionalRecordingDevice("GOOD", tmp_path / "roast.good.wav", 4),
+        ],
+        additional_input_factory=factory,
+        additional_read_seconds=0.25,
+        idle_sleep_seconds=0.001,
+        stop_timeout_seconds=2.0,
+    )
+
+    recorder.begin()
+    recorder.write_samples((0.25,) * 8)
+    # Let both independent streams run (one fails immediately, one captures),
+    # then close — which joins every thread and finalizes the surviving WAVs.
+    time.sleep(0.1)
+    recorder.close()
+
+    # The detector (teed) WAV and the good additional WAV survived the failing one.
+    detector_values, _, _ = _read_wav_samples(tmp_path / "roast.usb-pnp.wav")
+    good_values, _, _ = _read_wav_samples(tmp_path / "roast.good.wav")
+    assert detector_values == (round(0.25 * 32767),) * 8
+    assert len(good_values) > 0
+
+    sidecar = json.loads((tmp_path / "roast.recording.json").read_text(encoding="utf-8"))
+    # All three streams are listed; the failing one captured zero frames.
+    by_device = {stream["device"]: stream for stream in sidecar["streams"]}
+    assert by_device["BAD"]["frame_count"] == 0
+    assert by_device["GOOD"]["frame_count"] > 0
+    assert by_device["USB PnP"]["frame_count"] == 8
+
+
+def test_capture_devices_independently_writes_all(tmp_path: Path) -> None:
+    import time
+
+    from coffee_roaster_mcp.audio import (
+        AdditionalRecordingDevice,
+        capture_devices_independently,
+    )
+
+    def factory(device: AdditionalRecordingDevice) -> _BoundedInput:
+        return _BoundedInput(amplitude=0.5, reads=3)
+
+    devices = [
+        AdditionalRecordingDevice("USB PnP", tmp_path / "c.usb-pnp.wav", 4),
+        AdditionalRecordingDevice("ATR2100x", tmp_path / "c.atr2100x.wav", 4),
+    ]
+
+    results = capture_devices_independently(
+        devices,
+        record_seconds=0.05,
+        sidecar_path=tmp_path / "c.json",
+        session_id="record-check",
+        input_factory=factory,
+        sleep=time.sleep,
+        read_seconds=0.01,
+        idle_sleep_seconds=0.001,
+        stop_timeout_seconds=2.0,
+    )
+
+    assert [r.device_label for r in results] == ["USB PnP", "ATR2100x"]
+    assert all(r.frame_count > 0 for r in results)
+    assert (tmp_path / "c.usb-pnp.wav").exists()
+    assert (tmp_path / "c.atr2100x.wav").exists()
+    assert (tmp_path / "c.json").exists()

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1310,3 +1310,86 @@ def test_single_recorder_writes_annotation_session_json(tmp_path: Path) -> None:
     assert payload["mics"] == [
         {"mic_num": 1, "label": "USB PnP", "file": "mic1-ethiopia-roast3.wav"},
     ]
+
+
+def test_stop_finalises_recorder_when_worker_blocked(tmp_path: Path) -> None:
+    """Bug 2(b): if the capture worker is blocked in a read when stop() is called
+    (e.g. the detector's first samples are pending during AST model load), stop()
+    finalises the recorder itself so the WAV + sidecars are written, not lost."""
+    from threading import Event
+
+    released = Event()
+    closed = Event()
+
+    class BlockingInput:
+        """read_samples blocks until stop() releases it."""
+
+        def read_samples(self, sample_count: int) -> Sequence[float]:
+            released.wait(timeout=2.0)
+            return ()
+
+        def close(self) -> None:
+            return None
+
+    class CloseTrackingRecorder(RoastAudioRecorder):
+        def close(self) -> None:
+            closed.set()
+            super().close()
+
+    recorder = CloseTrackingRecorder(
+        wav_path=tmp_path / "mic1.wav",
+        sidecar_path=tmp_path / "roast.recording.json",
+        sample_rate=16,
+        session_id="s",
+    )
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=16,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=BlockingInput(),
+        recorder=recorder,
+    )
+
+    pipeline.start()
+    # Give the worker a moment to call begin() and block in read_samples.
+    _wait_for(lambda: recorder.started_monotonic_seconds is not None)
+    # Stop with a short join timeout while the worker is still blocked → the stop
+    # caller must finalise the recorder as a fallback.
+    pipeline.stop(timeout_seconds=0.05)
+
+    assert closed.is_set()
+    # The mic1 WAV exists and is a valid (0-frame) finalised file, not 0 bytes.
+    assert (tmp_path / "mic1.wav").exists()
+    assert (tmp_path / "mic1.wav").stat().st_size >= 44
+    # The recording sidecar was written despite zero frames.
+    assert (tmp_path / "roast.recording.json").exists()
+
+    # Release the still-blocked worker so it exits cleanly; its later close() is a
+    # no-op (idempotent), proving no double-write.
+    released.set()
+
+
+def test_wav_writer_zero_frames_finalises_valid_header(tmp_path: Path) -> None:
+    """Bug 2(a): a writer that opens but never receives frames still finalises a
+    valid WAV (correct header, 0 frames), not a 0-byte file."""
+    from coffee_roaster_mcp.audio import _WavStreamWriter
+
+    writer = _WavStreamWriter(
+        wav_path=tmp_path / "empty.wav",
+        device_label="USB PnP",
+        sample_rate=16_000,
+        flush_sample_threshold=1,
+    )
+    writer.begin()
+    writer.close()
+
+    # After close the WAV is a valid, finalised file (>=44-byte header, 0 frames),
+    # not a 0-byte file — even though no samples were ever written.
+    assert (tmp_path / "empty.wav").stat().st_size >= 44
+    with wave.open(str(tmp_path / "empty.wav"), "rb") as wav_file:
+        assert wav_file.getnframes() == 0
+        assert wav_file.getframerate() == 16_000
+        assert wav_file.getnchannels() == 1

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1217,3 +1217,96 @@ def test_capture_devices_independently_writes_all(tmp_path: Path) -> None:
     assert (tmp_path / "c.usb-pnp.wav").exists()
     assert (tmp_path / "c.atr2100x.wav").exists()
     assert (tmp_path / "c.json").exists()
+
+
+def test_multi_device_recorder_writes_annotation_session_json(tmp_path: Path) -> None:
+    """Finding: the {origin}-roast{N}-session.json matches the record_mics.py shape."""
+    import json
+    import time
+
+    from coffee_roaster_mcp.audio import (
+        AdditionalRecordingDevice,
+        AnnotationSessionSpec,
+        MultiDeviceRoastRecorder,
+    )
+
+    def factory(device: AdditionalRecordingDevice) -> _BoundedInput:
+        return _BoundedInput(amplitude=0.5, reads=4)
+
+    annotation_path = tmp_path / "brazil-roast7-session.json"
+    recorder = MultiDeviceRoastRecorder(
+        detector_wav_path=tmp_path / "mic1-brazil-roast7.wav",
+        detector_device_label="USB PnP",
+        sidecar_path=tmp_path / "roast.recording.json",
+        sample_rate=8,
+        session_id="s",
+        additional_devices=[
+            AdditionalRecordingDevice("ATR2100x", tmp_path / "mic2-brazil-roast7.wav", 8),
+        ],
+        annotation_session=AnnotationSessionSpec(
+            path=annotation_path,
+            origin="brazil",
+            roast_num=7,
+            mic_labels=("USB PnP", "ATR2100x"),
+        ),
+        additional_input_factory=factory,
+        additional_read_seconds=0.25,
+        idle_sleep_seconds=0.001,
+        stop_timeout_seconds=2.0,
+    )
+
+    recorder.begin()
+    recorder.write_samples((0.25,) * 8)
+    time.sleep(0.1)
+    recorder.close()
+
+    assert annotation_path.exists()
+    payload = json.loads(annotation_path.read_text(encoding="utf-8"))
+    # Exact record_mics.py session-JSON shape.
+    assert payload["origin"] == "brazil"
+    assert isinstance(payload["origin"], str)
+    assert payload["roast_num"] == 7
+    assert isinstance(payload["roast_num"], int)
+    assert payload["sample_rate"] == 8
+    assert payload["mics"] == [
+        {"mic_num": 1, "label": "USB PnP", "file": "mic1-brazil-roast7.wav"},
+        {"mic_num": 2, "label": "ATR2100x", "file": "mic2-brazil-roast7.wav"},
+    ]
+    for mic in payload["mics"]:
+        assert isinstance(mic["mic_num"], int)
+        assert isinstance(mic["label"], str)
+        assert isinstance(mic["file"], str)
+    # The recording sidecar (milestones / recording-relative alignment) is NOT lost.
+    assert (tmp_path / "roast.recording.json").exists()
+
+
+def test_single_recorder_writes_annotation_session_json(tmp_path: Path) -> None:
+    from coffee_roaster_mcp.audio import AnnotationSessionSpec, RoastAudioRecorder
+
+    annotation_path = tmp_path / "ethiopia-roast3-session.json"
+    recorder = RoastAudioRecorder(
+        wav_path=tmp_path / "mic1-ethiopia-roast3.wav",
+        sidecar_path=tmp_path / "roast.recording.json",
+        sample_rate=4,
+        session_id="s",
+        device_label="USB PnP",
+        annotation_session=AnnotationSessionSpec(
+            path=annotation_path,
+            origin="ethiopia",
+            roast_num=3,
+            mic_labels=("USB PnP",),
+        ),
+    )
+
+    import json
+
+    recorder.begin()
+    recorder.write_samples((0.25,) * 4)
+    recorder.close()
+
+    payload = json.loads(annotation_path.read_text(encoding="utf-8"))
+    assert payload["origin"] == "ethiopia"
+    assert payload["roast_num"] == 3
+    assert payload["mics"] == [
+        {"mic_num": 1, "label": "USB PnP", "file": "mic1-ethiopia-roast3.wav"},
+    ]

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1375,7 +1375,7 @@ def test_stop_finalises_recorder_when_worker_blocked(tmp_path: Path) -> None:
 def test_wav_writer_zero_frames_finalises_valid_header(tmp_path: Path) -> None:
     """Bug 2(a): a writer that opens but never receives frames still finalises a
     valid WAV (correct header, 0 frames), not a 0-byte file."""
-    from coffee_roaster_mcp.audio import _WavStreamWriter
+    from coffee_roaster_mcp.audio import _WavStreamWriter  # pyright: ignore[reportPrivateUsage]
 
     writer = _WavStreamWriter(
         wav_path=tmp_path / "empty.wav",

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -18,6 +18,7 @@ from coffee_roaster_mcp.audio import (
     AudioInput,
     DetectorPacedWavReplayPipeline,
     MicrophoneAudioInput,
+    RoastAudioRecorder,
     WavAudioInput,
     audio_capture_settings_from_config,
     build_audio_capture_pipeline,
@@ -779,3 +780,181 @@ def _write_pcm16_wav(
         wav_file.setsampwidth(2)
         wav_file.setframerate(sample_rate)
         wav_file.writeframes(struct.pack(f"<{len(samples)}h", *samples))
+
+
+def _read_wav_samples(path: Path) -> tuple[tuple[int, ...], int, int]:
+    with wave.open(str(path), "rb") as wav_file:
+        channels = wav_file.getnchannels()
+        sample_rate = wav_file.getframerate()
+        frame_count = wav_file.getnframes()
+        raw = wav_file.readframes(frame_count)
+    values = tuple(value[0] for value in struct.iter_unpack("<h", raw))
+    return values, channels, sample_rate
+
+
+def test_roast_recorder_writes_wav_and_sidecar(tmp_path: Path) -> None:
+    wav_path = tmp_path / "session-1" / "roast.wav"
+    sidecar_path = tmp_path / "session-1" / "roast.recording.json"
+    recorder = RoastAudioRecorder(
+        wav_path=wav_path,
+        sidecar_path=sidecar_path,
+        sample_rate=8,
+        session_id="session-1",
+        milestones_provider=lambda: {"beans_added": 1.5, "first_crack": None},
+        monotonic_now=lambda: 123.0,
+        flush_sample_threshold=2,
+    )
+
+    recorder.begin()
+    recorder.write_samples((0.0, 1.0, -1.0))
+    recorder.write_samples((0.5,))
+    recorder.close()
+
+    assert recorder.frames_written == 4
+    assert recorder.started_monotonic_seconds == 123.0
+    values, channels, sample_rate = _read_wav_samples(wav_path)
+    assert channels == 1
+    assert sample_rate == 8
+    assert values == (0, 32767, -32767, round(0.5 * 32767))
+
+    import json
+
+    sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    assert sidecar["session_id"] == "session-1"
+    assert sidecar["sample_rate"] == 8
+    assert sidecar["channels"] == 1
+    assert sidecar["frame_count"] == 4
+    assert sidecar["recording_started_monotonic_seconds"] == 123.0
+    assert sidecar["milestones"] == {"beans_added": 1.5, "first_crack": None}
+    assert sidecar["wav_filename"] == "roast.wav"
+
+
+def test_roast_recorder_clamps_out_of_range_samples(tmp_path: Path) -> None:
+    recorder = RoastAudioRecorder(
+        wav_path=tmp_path / "r.wav",
+        sidecar_path=tmp_path / "r.json",
+        sample_rate=4,
+        session_id="s",
+    )
+    recorder.begin()
+    recorder.write_samples((2.0, -2.0))
+    recorder.close()
+
+    values, _, _ = _read_wav_samples(tmp_path / "r.wav")
+    assert values == (32767, -32767)
+
+
+def test_roast_recorder_rejects_invalid_sample_rate(tmp_path: Path) -> None:
+    with pytest.raises(AudioCaptureError, match="sample_rate"):
+        RoastAudioRecorder(
+            wav_path=tmp_path / "r.wav",
+            sidecar_path=tmp_path / "r.json",
+            sample_rate=0,
+            session_id="s",
+        )
+
+
+def test_roast_recorder_close_is_idempotent_and_write_after_close_noops(
+    tmp_path: Path,
+) -> None:
+    recorder = RoastAudioRecorder(
+        wav_path=tmp_path / "r.wav",
+        sidecar_path=tmp_path / "r.json",
+        sample_rate=4,
+        session_id="s",
+    )
+    recorder.begin()
+    recorder.write_samples((0.25,))
+    recorder.close()
+    recorder.close()
+    recorder.write_samples((0.5,))
+
+    assert recorder.frames_written == 1
+
+
+def test_pipeline_tees_detector_stream_into_wav(tmp_path: Path) -> None:
+    samples = tuple(float(value) / 8.0 for value in range(8))
+    recorder = RoastAudioRecorder(
+        wav_path=tmp_path / "roast.wav",
+        sidecar_path=tmp_path / "roast.json",
+        sample_rate=4,
+        session_id="s",
+        flush_sample_threshold=1,
+    )
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=FiniteAudioInput(samples),
+        recorder=recorder,
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().emitted_window_count == 2)
+    pipeline.stop()
+
+    windows = pipeline.drain_windows()
+    # The detector still sees the unmodified float windows: teeing did not change
+    # detector behavior.
+    assert windows[0].samples == samples[:4]
+    assert windows[1].samples == samples[4:]
+    # The recorder captured the SAME samples (as 16-bit PCM).
+    values, channels, sample_rate = _read_wav_samples(tmp_path / "roast.wav")
+    assert channels == 1
+    assert sample_rate == 4
+    assert values == tuple(round(sample * 32767) for sample in samples)
+
+
+def test_pipeline_without_recorder_writes_no_wav(tmp_path: Path) -> None:
+    wav_path = tmp_path / "roast.wav"
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=FiniteAudioInput((0.0, 1.0, 2.0, 3.0)),
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().emitted_window_count == 1)
+    pipeline.stop()
+
+    assert not wav_path.exists()
+
+
+def test_pipeline_recorder_write_failure_does_not_kill_detection(tmp_path: Path) -> None:
+    class FailingRecorder(RoastAudioRecorder):
+        def write_samples(self, samples: Sequence[float]) -> None:
+            raise RuntimeError("disk full")
+
+    recorder = FailingRecorder(
+        wav_path=tmp_path / "roast.wav",
+        sidecar_path=tmp_path / "roast.json",
+        sample_rate=4,
+        session_id="s",
+    )
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=FiniteAudioInput((0.0, 1.0, 2.0, 3.0)),
+        recorder=recorder,
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().emitted_window_count == 1)
+    snapshot = pipeline.stop()
+
+    # Detection survived the recorder failure: the window was still emitted and
+    # the capture worker reported no fatal error.
+    assert snapshot.emitted_window_count == 1
+    assert snapshot.latest_error is None
+    assert pipeline.drain_windows()[0].samples == (0.0, 1.0, 2.0, 3.0)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -960,6 +960,92 @@ def test_pipeline_recorder_write_failure_does_not_kill_detection(tmp_path: Path)
     assert pipeline.drain_windows()[0].samples == (0.0, 1.0, 2.0, 3.0)
 
 
+def test_pipeline_recorder_begin_failure_does_not_kill_detection(tmp_path: Path) -> None:
+    """Finding #1: a recording-START failure must not stop capture/detection."""
+
+    class BeginFailingRecorder(RoastAudioRecorder):
+        def begin(self) -> None:
+            raise RuntimeError("could not open WAV")
+
+    recorder = BeginFailingRecorder(
+        wav_path=tmp_path / "roast.wav",
+        sidecar_path=tmp_path / "roast.json",
+        sample_rate=4,
+        session_id="s",
+    )
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=FiniteAudioInput((0.0, 1.0, 2.0, 3.0)),
+        recorder=recorder,
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().emitted_window_count == 1)
+    snapshot = pipeline.stop()
+
+    # The begin() failure dropped the recorder but detection ran to completion.
+    assert snapshot.emitted_window_count == 1
+    assert snapshot.latest_error is None
+    assert pipeline.drain_windows()[0].samples == (0.0, 1.0, 2.0, 3.0)
+    # No sidecar: recording never started.
+    assert not (tmp_path / "roast.json").exists()
+
+
+def test_pipeline_recorder_write_failure_finalizes_partial_recording(tmp_path: Path) -> None:
+    """Finding #2: a write failure flushes the WAV + writes the sidecar before drop."""
+    import json
+
+    class FailOnSecondWriteRecorder(RoastAudioRecorder):
+        def __init__(self, **kwargs: object) -> None:
+            super().__init__(**kwargs)  # type: ignore[arg-type]
+            self._writes = 0
+
+        def write_samples(self, samples: Sequence[float]) -> None:
+            self._writes += 1
+            if self._writes >= 2:
+                raise RuntimeError("disk full mid-roast")
+            super().write_samples(samples)
+
+    recorder = FailOnSecondWriteRecorder(
+        wav_path=tmp_path / "roast.wav",
+        sidecar_path=tmp_path / "roast.recording.json",
+        sample_rate=4,
+        session_id="s",
+        flush_sample_threshold=1,
+    )
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        # Two windows: the first write succeeds and is captured; the second
+        # write raises, finalizing the partial recording.
+        audio_input=FiniteAudioInput((0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)),
+        recorder=recorder,
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().emitted_window_count == 2)
+    snapshot = pipeline.stop()
+
+    # Detection unaffected.
+    assert snapshot.latest_error is None
+    # The partial recording was finalized: the first window's samples are in the
+    # WAV (not leaked) and the sidecar was written.
+    values, _, _ = _read_wav_samples(tmp_path / "roast.wav")
+    assert len(values) >= 4
+    sidecar = json.loads((tmp_path / "roast.recording.json").read_text(encoding="utf-8"))
+    assert sidecar["frame_count"] >= 4
+    assert sidecar["wav_filename"] == "roast.wav"
+
+
 def test_device_label_to_filename_slug() -> None:
     from coffee_roaster_mcp.audio import device_label_to_filename
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -497,3 +497,46 @@ def test_recording_invalid_enabled_environment_fails(tmp_path: Path) -> None:
 
     with pytest.raises(ConfigError, match="COFFEE_RECORDING_ENABLED"):
         load_config(config_path, environ={"COFFEE_RECORDING_ENABLED": "maybe"})
+
+
+def test_recording_devices_yaml_and_env(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        """
+recording:
+  enabled: true
+  autocapture: true
+  devices:
+    - USB PnP
+    - ATR2100x
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path, environ={})
+    assert config.recording.devices == ("USB PnP", "ATR2100x")
+
+    overridden = load_config(
+        config_path,
+        environ={"COFFEE_RECORDING_DEVICES": " USB PnP , ATR2100x , "},
+    )
+    assert overridden.recording.devices == ("USB PnP", "ATR2100x")
+
+    # An all-empty CSV clears the list back to None.
+    cleared = load_config(config_path, environ={"COFFEE_RECORDING_DEVICES": " , "})
+    assert cleared.recording.devices is None
+
+
+def test_recording_devices_invalid_entries_fail(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("recording:\n  devices:\n    - 5\n", encoding="utf-8")
+    with pytest.raises(ConfigError, match="recording.devices"):
+        load_config(config_path, environ={})
+
+    config_path.write_text("recording:\n  devices:\n    - '   '\n", encoding="utf-8")
+    with pytest.raises(ConfigError, match="recording.devices"):
+        load_config(config_path, environ={})
+
+    config_path.write_text("recording:\n  devices: USB PnP\n", encoding="utf-8")
+    with pytest.raises(ConfigError, match="recording.devices"):
+        load_config(config_path, environ={})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -391,3 +391,109 @@ def test_temperature_unit_error_reports_context(tmp_path: Path) -> None:
 
     with pytest.raises(ConfigError, match="roaster.temperature_unit"):
         load_config(config_path, environ={})
+
+
+def test_recording_defaults_are_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    config = load_config(environ={})
+
+    assert config.recording.enabled is False
+    assert config.recording.autocapture is False
+    assert config.recording.export_location is None
+    assert config.recording.sample_rate is None
+    assert config.recording.device is None
+    assert config.recording.channels is None
+
+
+def test_recording_yaml_config_is_parsed(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        """
+recording:
+  enabled: true
+  autocapture: "yes"
+  export_location: ~/roasts/captures
+  sample_rate: 44100
+  device: aggregate-2ch
+  channels:
+    - 0
+    - 1
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path, environ={})
+
+    assert config.recording.enabled is True
+    assert config.recording.autocapture is True
+    assert config.recording.export_location == Path("~/roasts/captures")
+    assert config.recording.sample_rate == 44_100
+    assert config.recording.device == "aggregate-2ch"
+    assert config.recording.channels == (0, 1)
+
+
+def test_recording_environment_overrides(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("recording:\n  enabled: false\n", encoding="utf-8")
+
+    config = load_config(
+        config_path,
+        environ={
+            "COFFEE_RECORDING_ENABLED": "true",
+            "COFFEE_RECORDING_AUTOCAPTURE": "1",
+            "COFFEE_RECORDING_EXPORT_LOCATION": "  /tmp/captures \n",
+            "COFFEE_RECORDING_SAMPLE_RATE": "48000",
+        },
+    )
+
+    assert config.recording.enabled is True
+    assert config.recording.autocapture is True
+    assert config.recording.export_location == Path("/tmp/captures")
+    assert config.recording.sample_rate == 48_000
+
+
+def test_recording_empty_environment_clears_optionals(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "recording:\n  export_location: ~/x\n  sample_rate: 44100\n",
+        encoding="utf-8",
+    )
+
+    config = load_config(
+        config_path,
+        environ={
+            "COFFEE_RECORDING_EXPORT_LOCATION": "   ",
+            "COFFEE_RECORDING_SAMPLE_RATE": "  ",
+        },
+    )
+
+    assert config.recording.export_location is None
+    assert config.recording.sample_rate is None
+
+
+def test_recording_invalid_sample_rate_fails(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("recording:\n  sample_rate: 0\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="recording.sample_rate"):
+        load_config(config_path, environ={})
+
+
+def test_recording_invalid_channels_fail(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("recording:\n  channels:\n    - -1\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="recording.channels"):
+        load_config(config_path, environ={})
+
+
+def test_recording_invalid_enabled_environment_fails(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("recording:\n  enabled: false\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="COFFEE_RECORDING_ENABLED"):
+        load_config(config_path, environ={"COFFEE_RECORDING_ENABLED": "maybe"})

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -13,6 +13,7 @@ from coffee_roaster_mcp.detector import (
     FirstCrackDetectorAdapter,
     FirstCrackDetectorError,
     FirstCrackDetectorOutput,
+    FirstCrackWindowObservation,
     OnnxFeatureExtractor,
     OnnxInferenceSession,
     OnnxInputInfo,
@@ -256,6 +257,84 @@ def test_detector_adapter_confirms_from_recent_positive_windows() -> None:
     assert confirmed.confirmed_by_window_sequence_number == 13
     assert confirmed.positive_window_count == 3
     assert confirmed.confidence == 0.61
+
+
+def test_process_window_observed_captures_confidence_for_non_confirming_window() -> None:
+    backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=False, confidence=0.55),))
+    adapter = build_first_crack_detector_adapter(
+        FirstCrackConfig(confidence_threshold=0.6),
+        _resolved_detector_artifacts(),
+        backend,
+    )
+
+    observation = adapter.process_window_observed(
+        _audio_window(sequence_number=21, started_at_monotonic_seconds=100.0)
+    )
+
+    assert isinstance(observation, FirstCrackWindowObservation)
+    assert observation.window_sequence_number == 21
+    # Confidence is captured even though the window never crossed the threshold,
+    # so a miss is diagnosable (#175).
+    assert observation.confidence == 0.55
+    assert observation.positive_window_count == 0
+    assert observation.confirmed is False
+    assert observation.fc_status == "listening"
+    assert observation.event is None
+
+
+def test_process_window_observed_reports_candidate_before_confirmation() -> None:
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.71),
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.83),
+        )
+    )
+    adapter = build_first_crack_detector_adapter(
+        FirstCrackConfig(
+            confidence_threshold=0.6,
+            min_positive_windows=2,
+            confirmation_window_seconds=20.0,
+        ),
+        _resolved_detector_artifacts(),
+        backend,
+    )
+
+    candidate = adapter.process_window_observed(
+        _audio_window(sequence_number=30, started_at_monotonic_seconds=100.0)
+    )
+    confirmed = adapter.process_window_observed(
+        _audio_window(sequence_number=31, started_at_monotonic_seconds=103.0)
+    )
+
+    assert candidate.confidence == 0.71
+    assert candidate.positive_window_count == 1
+    assert candidate.confirmed is False
+    assert candidate.fc_status == "candidate"
+    assert candidate.event is None
+
+    assert confirmed.confidence == 0.83
+    assert confirmed.positive_window_count == 2
+    assert confirmed.confirmed is True
+    assert confirmed.fc_status == "confirmed"
+    assert confirmed.event is not None
+    assert confirmed.event.kind == "first_crack_detected"
+
+
+def test_process_window_delegates_to_observed() -> None:
+    backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=True, confidence=0.95),))
+    adapter = build_first_crack_detector_adapter(
+        FirstCrackConfig(confidence_threshold=0.6, min_positive_windows=1),
+        _resolved_detector_artifacts(),
+        backend,
+    )
+
+    event = adapter.process_window(
+        _audio_window(sequence_number=40, started_at_monotonic_seconds=100.0)
+    )
+
+    assert event is not None
+    assert event.kind == "first_crack_detected"
+    assert event.confidence == 0.95
 
 
 def test_detector_adapter_prunes_old_positive_windows_before_confirmation() -> None:

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -9,8 +9,65 @@ from pathlib import Path
 
 import pytest
 
+from coffee_roaster_mcp.artifacts import ResolvedArtifact, ResolvedDetectorArtifacts
+from coffee_roaster_mcp.audio import AudioWindow
+from coffee_roaster_mcp.config import FirstCrackConfig
+from coffee_roaster_mcp.detector import (
+    FirstCrackDetectorOutput,
+    build_first_crack_detector_adapter,
+    integrate_first_crack_window_with_session,
+)
 from coffee_roaster_mcp.exports import export_roast_snapshot
 from coffee_roaster_mcp.session import EventPayloadValue, RoastSessionStore, TelemetrySample
+
+
+class MockDetectorBackend:
+    """Detector backend with deterministic queued outputs for export tests."""
+
+    def __init__(self, outputs: tuple[FirstCrackDetectorOutput, ...]) -> None:
+        self._outputs = list(outputs)
+        self.windows: list[AudioWindow] = []
+
+    def detect(self, window: AudioWindow) -> FirstCrackDetectorOutput:
+        """Return the next queued detector output for one window."""
+        self.windows.append(window)
+        return self._outputs.pop(0)
+
+
+def _audio_window(
+    *,
+    sequence_number: int,
+    started_at_monotonic_seconds: float,
+    duration_seconds: float = 1.0,
+) -> AudioWindow:
+    """Return a deterministic audio window for export observability tests."""
+    return AudioWindow(
+        sequence_number=sequence_number,
+        input_device="mock-audio",
+        sample_rate=4,
+        started_at_monotonic_seconds=started_at_monotonic_seconds,
+        duration_seconds=duration_seconds,
+        samples=(0.1, 0.2, 0.3, 0.4),
+    )
+
+
+def _resolved_detector_artifacts() -> ResolvedDetectorArtifacts:
+    """Return resolved detector artifacts for export observability tests."""
+    return ResolvedDetectorArtifacts(
+        onnx_model=ResolvedArtifact(
+            repo_id="syamaner/coffee-first-crack-detection",
+            revision=None,
+            filename="onnx/int8/model_quantized.onnx",
+            local_path=Path("/tmp/model.onnx"),
+        ),
+        feature_extractor_config=ResolvedArtifact(
+            repo_id="syamaner/coffee-first-crack-detection",
+            revision=None,
+            filename="onnx/int8/preprocessor_config.json",
+            local_path=Path("/tmp/preprocessor_config.json"),
+        ),
+    )
+
 
 EXPECTED_CSV_FIELDNAMES = [
     "timestamp_utc",
@@ -56,7 +113,14 @@ EXPECTED_SUMMARY_KEYS = {
     "development_time_percent",
     "roaster_driver",
     "first_crack_model",
+    "first_crack_detection",
     "metrics",
+}
+EXPECTED_FIRST_CRACK_DETECTION_KEYS = {
+    "model_confirmed",
+    "max_confidence",
+    "window_count",
+    "max_positive_window_count",
 }
 EXPECTED_SUMMARY_METRICS_KEYS = {
     "roast_elapsed_seconds",
@@ -269,6 +333,132 @@ def test_snapshot_export_summary_schema_completeness(tmp_path: Path) -> None:
     assert set(summary) == EXPECTED_SUMMARY_KEYS
     assert set(summary["metrics"]) == EXPECTED_SUMMARY_METRICS_KEYS
     assert set(summary["first_crack_model"]) == EXPECTED_FIRST_CRACK_MODEL_KEYS
+    assert set(summary["first_crack_detection"]) == EXPECTED_FIRST_CRACK_DETECTION_KEYS
+
+
+def test_per_window_fc_inference_rows_are_appended_to_roast_jsonl(tmp_path: Path) -> None:
+    """Append one fc_window row per processed window during a roast (#175)."""
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    config = FirstCrackConfig(
+        mode="audio",
+        confidence_threshold=0.6,
+        min_positive_windows=2,
+        confirmation_window_seconds=20.0,
+    )
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(confirmed=False, confidence=0.40),
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.72),
+            FirstCrackDetectorOutput(confirmed=True, confidence=0.91),
+        )
+    )
+    adapter = build_first_crack_detector_adapter(config, _resolved_detector_artifacts(), backend)
+
+    clock.monotonic_value = 110.0
+    for sequence_number, started_at in ((1, 105.0), (2, 108.0), (3, 111.0)):
+        clock.monotonic_value = started_at + 1.0
+        integrate_first_crack_window_with_session(
+            config=config,
+            adapter=adapter,
+            session_store=store,
+            session=session,
+            window=_audio_window(
+                sequence_number=sequence_number,
+                started_at_monotonic_seconds=started_at,
+            ),
+        )
+
+    export = export_roast_snapshot(session)
+    jsonl_rows = [
+        json.loads(line) for line in export.jsonl_path.read_text(encoding="utf-8").splitlines()
+    ]
+    fc_window_rows = [row for row in jsonl_rows if row["type"] == "fc_window"]
+    assert len(fc_window_rows) == 3
+    assert [row["window_sequence_number"] for row in fc_window_rows] == [1, 2, 3]
+    assert [row["confidence"] for row in fc_window_rows] == [0.40, 0.72, 0.91]
+    assert [row["fc_status"] for row in fc_window_rows] == [
+        "listening",
+        "candidate",
+        "confirmed",
+    ]
+    assert [row["positive_window_count"] for row in fc_window_rows] == [0, 1, 2]
+    assert [row["confirmed"] for row in fc_window_rows] == [False, False, True]
+    assert all(row["session_id"] == session.id for row in fc_window_rows)
+
+    summary = json.loads(export.summary_path.read_text(encoding="utf-8"))
+    assert summary["first_crack_detection"] == {
+        "model_confirmed": True,
+        "max_confidence": 0.91,
+        "window_count": 3,
+        "max_positive_window_count": 2,
+    }
+
+
+def test_summary_records_fc_picture_on_a_no_fire_roast(tmp_path: Path) -> None:
+    """A no-fire roast still records max confidence + model_confirmed=false (#175)."""
+    clock = ClockHarness()
+    store = RoastSessionStore(
+        utc_now=clock.utc_now,
+        monotonic_now=clock.monotonic_now,
+        default_log_dir=tmp_path / "roasts",
+    )
+    session = store.start_session()
+    clock.monotonic_value = 105.0
+    store.record_event(session, "beans_added")
+    config = FirstCrackConfig(
+        mode="audio",
+        confidence_threshold=0.6,
+        min_positive_windows=2,
+        confirmation_window_seconds=20.0,
+    )
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(confirmed=False, confidence=0.31),
+            FirstCrackDetectorOutput(confirmed=False, confidence=0.55),
+            FirstCrackDetectorOutput(confirmed=False, confidence=0.48),
+        )
+    )
+    adapter = build_first_crack_detector_adapter(config, _resolved_detector_artifacts(), backend)
+
+    for sequence_number, started_at in ((1, 105.0), (2, 108.0), (3, 111.0)):
+        clock.monotonic_value = started_at + 1.0
+        integrate_first_crack_window_with_session(
+            config=config,
+            adapter=adapter,
+            session_store=store,
+            session=session,
+            window=_audio_window(
+                sequence_number=sequence_number,
+                started_at_monotonic_seconds=started_at,
+            ),
+        )
+
+    # First crack is operator-marked because the model never confirmed.
+    clock.monotonic_value = 150.0
+    store.record_event(session, "first_crack_detected", payload={"source": "operator"})
+    clock.monotonic_value = 180.0
+    store.record_event(session, "beans_dropped")
+
+    export = export_roast_snapshot(session)
+    summary = json.loads(export.summary_path.read_text(encoding="utf-8"))
+    assert summary["first_crack_detection"] == {
+        "model_confirmed": False,
+        "max_confidence": 0.55,
+        "window_count": 3,
+        "max_positive_window_count": 0,
+    }
+    # The model-metadata block stays empty on a miss; the detection picture
+    # carries the diagnosable aggregates instead.
+    assert summary["first_crack_model"]["confidence"] is None
+    assert summary["first_crack_model"]["confidence_threshold"] is None
 
 
 def test_snapshot_export_uses_configured_ror_parameters(tmp_path: Path) -> None:

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -924,3 +924,203 @@ def test_normalize_origin_slug_edge_cases() -> None:
     assert _normalize_origin_slug("ETHIOPIA__yirgacheffe") == "ethiopia-yirgacheffe"
     assert _normalize_origin_slug("  !!  ") == "roast"  # empty after stripping → fallback
     assert _normalize_origin_slug("kenya-aa") == "kenya-aa"
+
+
+def test_teed_stream_wav_uses_detector_sample_rate_not_recording_rate(tmp_path: Path) -> None:
+    """Bug 1: the teed mic1 WAV header must use audio.sample_rate (the detector's
+    real capture rate), NOT recording.sample_rate."""
+    import wave
+
+    from coffee_roaster_mcp.audio import RoastAudioRecorder
+    from coffee_roaster_mcp.config import AudioConfig, RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    config = AppConfig(
+        audio=AudioConfig(sample_rate=16_000),
+        recording=RecordingConfig(
+            enabled=True,
+            autocapture=True,
+            export_location=tmp_path,
+            sample_rate=44_100,  # the WRONG rate for the teed detector stream
+        ),
+    )
+
+    recorder = build_session_recorder(config, session)
+    assert isinstance(recorder, RoastAudioRecorder)
+    # The recorder's nominal rate is the detector rate, not recording.sample_rate.
+    assert recorder.sample_rate == 16_000
+
+    recorder.begin()
+    recorder.write_samples((0.1,) * 16_000)  # 1.0 s of 16 kHz audio
+    recorder.close()
+
+    with wave.open(str(recorder.wav_path), "rb") as wav_file:
+        assert wav_file.getframerate() == 16_000  # NOT 44_100
+        frame_count = wav_file.getnframes()
+    assert frame_count == 16_000
+    # frame_count / rate gives the TRUE wall-clock duration (1.0 s), not 0.36 s.
+    assert round(frame_count / wav_file.getframerate(), 3) == 1.0
+
+
+def test_multi_device_teed_and_additional_rates_differ(tmp_path: Path) -> None:
+    """Bug 1: mic1 (teed) uses audio.sample_rate; additional streams use
+    recording.sample_rate."""
+    import time
+    import wave
+
+    from coffee_roaster_mcp.audio import (
+        AdditionalRecordingDevice,
+        AudioInput,
+        MultiDeviceRoastRecorder,
+    )
+    from coffee_roaster_mcp.config import AudioConfig, RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import RecordingMetadata, build_session_recorder
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    config = AppConfig(
+        audio=AudioConfig(sample_rate=16_000),
+        recording=RecordingConfig(
+            enabled=True,
+            autocapture=True,
+            export_location=tmp_path,
+            sample_rate=44_100,
+            devices=("USB PnP", "ATR2100x"),
+        ),
+    )
+
+    captured_rates: dict[str, int] = {}
+
+    def factory(device: AdditionalRecordingDevice) -> AudioInput:
+        # Record the rate the additional stream was configured with, then no-op
+        # the capture (no hardware in tests).
+        captured_rates[device.device_label] = device.sample_rate
+        raise RuntimeError("not opening hardware in this test")
+
+    recorder = build_session_recorder(
+        config,
+        session,
+        metadata=RecordingMetadata(origin="brazil", roast_num=7),
+    )
+    assert isinstance(recorder, MultiDeviceRoastRecorder)
+
+    # We cannot reach the private additional specs through build_session_recorder,
+    # so re-create an equivalent recorder with a capturing factory to observe the
+    # rate threaded into the additional device.
+    observed = MultiDeviceRoastRecorder(
+        detector_wav_path=tmp_path / "x" / "mic1-brazil-roast7.wav",
+        detector_device_label="USB PnP",
+        sidecar_path=tmp_path / "x" / "roast.recording.json",
+        sample_rate=16_000,  # detector rate
+        session_id="s",
+        additional_devices=[
+            AdditionalRecordingDevice(
+                "ATR2100x", tmp_path / "x" / "mic2-brazil-roast7.wav", 44_100
+            ),
+        ],
+        additional_input_factory=factory,
+        stop_timeout_seconds=2.0,
+    )
+    observed.begin()
+    time.sleep(0.05)
+    observed.close()
+
+    # The teed mic1 WAV header is the detector rate; the additional stream is the
+    # recording rate.
+    with wave.open(str(observed.wav_path), "rb") as wav_file:
+        assert wav_file.getframerate() == 16_000
+    assert captured_rates["ATR2100x"] == 44_100
+
+
+def test_zero_frame_teed_stream_still_finalises_wav_and_both_sidecars(tmp_path: Path) -> None:
+    """Bug 2: a teed stream that captures NO frames before close still produces a
+    valid finalised mic1 WAV plus both JSON sidecars."""
+    import json
+    import wave
+
+    from coffee_roaster_mcp.config import RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    recorder = build_session_recorder(
+        AppConfig(
+            recording=RecordingConfig(
+                enabled=True, autocapture=True, export_location=tmp_path, sample_rate=16_000
+            ),
+        ),
+        session,
+        metadata=None,
+    )
+    assert recorder is not None
+
+    # begin() then close() with NO write_samples in between (zero frames).
+    recorder.begin()
+    recorder.close()
+
+    session_dir = tmp_path / session.id
+    wav_path = session_dir / f"mic1-{session.id}-roast0.wav"
+    # Valid, finalised WAV (not 0 bytes) with a correct header and 0 frames.
+    assert wav_path.exists()
+    assert wav_path.stat().st_size >= 44  # WAV header is 44 bytes
+    with wave.open(str(wav_path), "rb") as wav_file:
+        assert wav_file.getnframes() == 0
+        assert wav_file.getframerate() == 16_000
+    # BOTH sidecars written.
+    annotation_path = session_dir / f"{session.id}-roast0-session.json"
+    recording_sidecar = session_dir / "roast.recording.json"
+    assert annotation_path.exists()
+    assert recording_sidecar.exists()
+    annotation = json.loads(annotation_path.read_text(encoding="utf-8"))
+    assert annotation["mics"][0]["file"] == f"mic1-{session.id}-roast0.wav"
+
+
+def test_set_recording_metadata_after_build_warns_and_is_not_applied(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Hardening: metadata set AFTER the recorder is built logs a warning and the
+    WAV names stay fixed (it is not silently applied)."""
+    import logging
+
+    from coffee_roaster_mcp.config import RecordingConfig
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(
+            first_crack=FirstCrackConfig(mode="audio", revision="v0.1.0"),
+            recording=RecordingConfig(enabled=True, autocapture=True, export_location=tmp_path),
+        ),
+        audio_pipeline_factory=lambda _config: FakeAudioPipeline(),
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config, _resolved_detector_artifacts(), MockDetectorBackend(())
+        ),
+    )
+
+    # Metadata BEFORE start: applied with no warning.
+    with caplog.at_level(logging.WARNING, logger="coffee_roaster_mcp.first_crack_runtime"):
+        runtime.set_recording_metadata(origin="early", roast_num=1)
+    assert not any("arrived AFTER" in record.message for record in caplog.records)
+
+    # Starting the roast builds the recorder for the active session.
+    runtime.start_for_session(session)
+
+    # Metadata AFTER the recorder was built now warns (non-silent).
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="coffee_roaster_mcp.first_crack_runtime"):
+        runtime.set_recording_metadata(origin="late", roast_num=99)
+    assert any("arrived AFTER" in record.message for record in caplog.records)
+
+    # A new session resets the gate: metadata is accepted again without warning.
+    runtime.stop_for_session(session.id, reason="done")
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="coffee_roaster_mcp.first_crack_runtime"):
+        runtime.set_recording_metadata(origin="next", roast_num=2)
+    assert not any("arrived AFTER" in record.message for record in caplog.records)

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -582,6 +582,7 @@ def test_build_session_recorder_disabled_returns_none() -> None:
 
 
 def test_build_session_recorder_uses_export_location_and_session_id(tmp_path: Path) -> None:
+    from coffee_roaster_mcp.audio import RoastAudioRecorder
     from coffee_roaster_mcp.config import RecordingConfig
     from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
 
@@ -599,7 +600,7 @@ def test_build_session_recorder_uses_export_location_and_session_id(tmp_path: Pa
 
     recorder = build_session_recorder(config, session)
 
-    assert recorder is not None
+    assert isinstance(recorder, RoastAudioRecorder)
     assert recorder.wav_path == tmp_path / "captures" / session.id / "roast.wav"
     assert recorder.sidecar_path == tmp_path / "captures" / session.id / "roast.recording.json"
     # sample_rate falls back to the detector audio.sample_rate.
@@ -607,6 +608,7 @@ def test_build_session_recorder_uses_export_location_and_session_id(tmp_path: Pa
 
 
 def test_build_session_recorder_defaults_export_under_log_dir(tmp_path: Path) -> None:
+    from coffee_roaster_mcp.audio import RoastAudioRecorder
     from coffee_roaster_mcp.config import LoggingConfig, RecordingConfig
     from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
 
@@ -620,7 +622,7 @@ def test_build_session_recorder_defaults_export_under_log_dir(tmp_path: Path) ->
 
     recorder = build_session_recorder(config, session)
 
-    assert recorder is not None
+    assert isinstance(recorder, RoastAudioRecorder)
     # With no export_location, captures land under the gitignored log dir.
     assert recorder.wav_path == tmp_path / "logs" / "captures" / session.id / "roast.wav"
 
@@ -694,3 +696,71 @@ def test_build_session_recorder_milestones_track_session(tmp_path: Path) -> None
         "beans_added": 12.0,
         "first_crack": 95.5,
     }
+
+
+def test_build_session_recorder_multi_device(tmp_path: Path) -> None:
+    from coffee_roaster_mcp.audio import MultiDeviceRoastRecorder
+    from coffee_roaster_mcp.config import RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    config = AppConfig(
+        recording=RecordingConfig(
+            enabled=True,
+            autocapture=True,
+            export_location=tmp_path,
+            devices=("USB PnP", "ATR2100x"),
+        ),
+    )
+
+    recorder = build_session_recorder(config, session)
+
+    assert isinstance(recorder, MultiDeviceRoastRecorder)
+    # The FIRST device is the teed detector device; additional devices get fresh
+    # streams, one WAV each, with labels derived from the device names.
+    assert recorder.wav_path == tmp_path / session.id / "roast.usb-pnp.wav"
+    assert recorder.additional_wav_paths == (tmp_path / session.id / "roast.atr2100x.wav",)
+
+
+def test_build_session_recorder_single_device_labels_wav(tmp_path: Path) -> None:
+    from coffee_roaster_mcp.audio import RoastAudioRecorder
+    from coffee_roaster_mcp.config import RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    config = AppConfig(
+        recording=RecordingConfig(
+            enabled=True,
+            autocapture=True,
+            export_location=tmp_path,
+            devices=("USB PnP",),
+        ),
+    )
+
+    recorder = build_session_recorder(config, session)
+
+    # A single configured device falls back to the v1 single-stream recorder.
+    assert isinstance(recorder, RoastAudioRecorder)
+    assert recorder.wav_path == tmp_path / session.id / "roast.wav"
+
+
+def test_build_session_recorder_no_devices_is_v1_single(tmp_path: Path) -> None:
+    from coffee_roaster_mcp.audio import RoastAudioRecorder
+    from coffee_roaster_mcp.config import RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    config = AppConfig(
+        recording=RecordingConfig(enabled=True, autocapture=True, export_location=tmp_path),
+    )
+
+    recorder = build_session_recorder(config, session)
+
+    assert isinstance(recorder, RoastAudioRecorder)
+    assert recorder.wav_path == tmp_path / session.id / "roast.wav"

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -683,8 +683,8 @@ def test_build_session_recorder_milestones_track_session(tmp_path: Path) -> None
     recorder = build_session_recorder(config, session)
     assert recorder is not None
 
-    # Before any milestone, both are None.
-    assert recording_relative_milestones(session) == {
+    # Before any milestone, both are None (recording start unknown → raw values).
+    assert recording_relative_milestones(session, recording_started_monotonic_seconds=None) == {
         "beans_added": None,
         "first_crack": None,
     }
@@ -692,10 +692,82 @@ def test_build_session_recorder_milestones_track_session(tmp_path: Path) -> None
     # The provider reads the LIVE session, so later milestones surface.
     session.beans_added_monotonic_seconds = 12.0
     session.first_crack_monotonic_seconds = 95.5
-    assert recording_relative_milestones(session) == {
+    assert recording_relative_milestones(session, recording_started_monotonic_seconds=None) == {
         "beans_added": 12.0,
         "first_crack": 95.5,
     }
+
+
+def test_recording_relative_milestones_are_rebased_to_recording_start() -> None:
+    """A milestone's sidecar value equals (milestone_session_elapsed - rec_start)."""
+    from coffee_roaster_mcp.first_crack_runtime import recording_relative_milestones
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+
+    # Session started at monotonic 500.0 (ClockHarness). Recording began 3.5 s
+    # later, at absolute monotonic 503.5 — i.e. 3.5 s into the session.
+    assert session.monotonic_start == 500.0
+    recording_started = 503.5
+    recording_start_session_elapsed = recording_started - session.monotonic_start
+
+    # Milestones in SESSION-elapsed seconds (as the session stores them).
+    session.beans_added_monotonic_seconds = 12.0
+    session.first_crack_monotonic_seconds = 95.5
+
+    milestones = recording_relative_milestones(
+        session, recording_started_monotonic_seconds=recording_started
+    )
+
+    # Each is genuinely recording-relative: session-elapsed minus the recording
+    # start (in the same session-elapsed domain).
+    assert milestones["beans_added"] == round(12.0 - recording_start_session_elapsed, 6)
+    assert milestones["first_crack"] == round(95.5 - recording_start_session_elapsed, 6)
+    assert milestones["beans_added"] == 8.5
+    assert milestones["first_crack"] == 92.0
+
+
+def test_built_recorder_writes_recording_relative_milestones(tmp_path: Path) -> None:
+    """End to end: the sidecar from build_session_recorder carries rebased milestones."""
+    import json
+
+    from coffee_roaster_mcp.config import RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    recorder = build_session_recorder(
+        AppConfig(
+            recording=RecordingConfig(
+                enabled=True,
+                autocapture=True,
+                export_location=tmp_path,
+                sample_rate=8,
+            ),
+        ),
+        session,
+    )
+    assert recorder is not None
+
+    recorder.begin()
+    recording_started = recorder.started_monotonic_seconds
+    assert recording_started is not None
+    recording_start_session_elapsed = recording_started - session.monotonic_start
+
+    # Milestones recorded (in session-elapsed seconds) after recording started.
+    session.beans_added_monotonic_seconds = 12.0
+    session.first_crack_monotonic_seconds = 95.5
+    recorder.write_samples((0.1,) * 8)
+    recorder.close()
+
+    sidecar = json.loads(
+        (tmp_path / session.id / "roast.recording.json").read_text(encoding="utf-8")
+    )
+    # The closure rebased both milestones onto the recording clock.
+    assert sidecar["milestones"]["beans_added"] == round(12.0 - recording_start_session_elapsed, 6)
+    assert sidecar["milestones"]["first_crack"] == round(95.5 - recording_start_session_elapsed, 6)
 
 
 def test_build_session_recorder_multi_device(tmp_path: Path) -> None:

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -4,6 +4,8 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 from coffee_roaster_mcp.artifacts import (
     ArtifactResolutionError,
     ResolvedArtifact,
@@ -555,3 +557,140 @@ def _resolved_detector_artifacts() -> ResolvedDetectorArtifacts:
             local_path=Path("/tmp/preprocessor_config.json"),
         ),
     )
+
+
+def test_build_session_recorder_disabled_returns_none() -> None:
+    from coffee_roaster_mcp.config import RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+
+    # Disabled entirely.
+    assert (
+        build_session_recorder(AppConfig(recording=RecordingConfig(enabled=False)), session) is None
+    )
+    # Enabled but not autocapture (v1 only wires autocapture).
+    assert (
+        build_session_recorder(
+            AppConfig(recording=RecordingConfig(enabled=True, autocapture=False)),
+            session,
+        )
+        is None
+    )
+
+
+def test_build_session_recorder_uses_export_location_and_session_id(tmp_path: Path) -> None:
+    from coffee_roaster_mcp.config import RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    config = AppConfig(
+        audio=AudioConfig(sample_rate=22_050),
+        recording=RecordingConfig(
+            enabled=True,
+            autocapture=True,
+            export_location=tmp_path / "captures",
+        ),
+    )
+
+    recorder = build_session_recorder(config, session)
+
+    assert recorder is not None
+    assert recorder.wav_path == tmp_path / "captures" / session.id / "roast.wav"
+    assert recorder.sidecar_path == tmp_path / "captures" / session.id / "roast.recording.json"
+    # sample_rate falls back to the detector audio.sample_rate.
+    assert recorder.sample_rate == 22_050
+
+
+def test_build_session_recorder_defaults_export_under_log_dir(tmp_path: Path) -> None:
+    from coffee_roaster_mcp.config import LoggingConfig, RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    config = AppConfig(
+        logging=LoggingConfig(log_dir=tmp_path / "logs"),
+        recording=RecordingConfig(enabled=True, autocapture=True),
+    )
+
+    recorder = build_session_recorder(config, session)
+
+    assert recorder is not None
+    # With no export_location, captures land under the gitignored log dir.
+    assert recorder.wav_path == tmp_path / "logs" / "captures" / session.id / "roast.wav"
+
+
+def test_default_pipeline_factory_passes_recorder(monkeypatch: pytest.MonkeyPatch) -> None:
+    import coffee_roaster_mcp.first_crack_runtime as runtime_module
+    from coffee_roaster_mcp.config import RecordingConfig
+
+    captured: dict[str, object] = {}
+
+    def fake_build_pipeline(config: AudioConfig, *, recorder: object = None) -> FakeAudioPipeline:
+        captured["recorder"] = recorder
+        return FakeAudioPipeline()
+
+    monkeypatch.setattr(runtime_module, "build_audio_capture_pipeline", fake_build_pipeline)
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(
+            first_crack=FirstCrackConfig(mode="audio", revision="v0.1.0"),
+            recording=RecordingConfig(enabled=True, autocapture=True),
+        ),
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            MockDetectorBackend(()),
+        ),
+    )
+
+    snapshot = runtime.start_for_session(session)
+
+    # The default factory built the pipeline with the session recorder teed in.
+    assert snapshot.status == "pending"
+    assert captured["recorder"] is not None
+
+
+def test_build_session_recorder_milestones_track_session(tmp_path: Path) -> None:
+    from coffee_roaster_mcp.config import RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import (
+        build_session_recorder,
+        recording_relative_milestones,
+    )
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    config = AppConfig(
+        recording=RecordingConfig(
+            enabled=True,
+            autocapture=True,
+            export_location=tmp_path,
+            sample_rate=16_000,
+        ),
+    )
+
+    recorder = build_session_recorder(config, session)
+    assert recorder is not None
+
+    # Before any milestone, both are None.
+    assert recording_relative_milestones(session) == {
+        "beans_added": None,
+        "first_crack": None,
+    }
+
+    # The provider reads the LIVE session, so later milestones surface.
+    session.beans_added_monotonic_seconds = 12.0
+    session.first_crack_monotonic_seconds = 95.5
+    assert recording_relative_milestones(session) == {
+        "beans_added": 12.0,
+        "first_crack": 95.5,
+    }

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -918,7 +918,9 @@ def test_built_recorder_no_metadata_fallback_writes_valid_files(tmp_path: Path) 
 
 
 def test_normalize_origin_slug_edge_cases() -> None:
-    from coffee_roaster_mcp.first_crack_runtime import _normalize_origin_slug
+    from coffee_roaster_mcp.first_crack_runtime import (
+        _normalize_origin_slug,  # pyright: ignore[reportPrivateUsage]
+    )
 
     assert _normalize_origin_slug("Brazil Cerrado") == "brazil-cerrado"
     assert _normalize_origin_slug("ETHIOPIA__yirgacheffe") == "ethiopia-yirgacheffe"

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -601,7 +601,8 @@ def test_build_session_recorder_uses_export_location_and_session_id(tmp_path: Pa
     recorder = build_session_recorder(config, session)
 
     assert isinstance(recorder, RoastAudioRecorder)
-    assert recorder.wav_path == tmp_path / "captures" / session.id / "roast.wav"
+    # No metadata → fallback origin=session.id, roast_num=0; mic1 WAV name.
+    assert recorder.wav_path == tmp_path / "captures" / session.id / f"mic1-{session.id}-roast0.wav"
     assert recorder.sidecar_path == tmp_path / "captures" / session.id / "roast.recording.json"
     # sample_rate falls back to the detector audio.sample_rate.
     assert recorder.sample_rate == 22_050
@@ -624,7 +625,10 @@ def test_build_session_recorder_defaults_export_under_log_dir(tmp_path: Path) ->
 
     assert isinstance(recorder, RoastAudioRecorder)
     # With no export_location, captures land under the gitignored log dir.
-    assert recorder.wav_path == tmp_path / "logs" / "captures" / session.id / "roast.wav"
+    assert (
+        recorder.wav_path
+        == tmp_path / "logs" / "captures" / session.id / f"mic1-{session.id}-roast0.wav"
+    )
 
 
 def test_default_pipeline_factory_passes_recorder(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -773,7 +777,7 @@ def test_built_recorder_writes_recording_relative_milestones(tmp_path: Path) -> 
 def test_build_session_recorder_multi_device(tmp_path: Path) -> None:
     from coffee_roaster_mcp.audio import MultiDeviceRoastRecorder
     from coffee_roaster_mcp.config import RecordingConfig
-    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+    from coffee_roaster_mcp.first_crack_runtime import RecordingMetadata, build_session_recorder
 
     clock = ClockHarness()
     store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
@@ -787,19 +791,21 @@ def test_build_session_recorder_multi_device(tmp_path: Path) -> None:
         ),
     )
 
-    recorder = build_session_recorder(config, session)
+    recorder = build_session_recorder(
+        config, session, metadata=RecordingMetadata(origin="brazil", roast_num=7)
+    )
 
     assert isinstance(recorder, MultiDeviceRoastRecorder)
-    # The FIRST device is the teed detector device; additional devices get fresh
-    # streams, one WAV each, with labels derived from the device names.
-    assert recorder.wav_path == tmp_path / session.id / "roast.usb-pnp.wav"
-    assert recorder.additional_wav_paths == (tmp_path / session.id / "roast.atr2100x.wav",)
+    # mic1 = the teed detector device; mic2 = the first additional device. WAVs
+    # are named for the annotation pipeline: mic{N}-{origin}-roast{N}.wav.
+    assert recorder.wav_path == tmp_path / session.id / "mic1-brazil-roast7.wav"
+    assert recorder.additional_wav_paths == (tmp_path / session.id / "mic2-brazil-roast7.wav",)
 
 
 def test_build_session_recorder_single_device_labels_wav(tmp_path: Path) -> None:
     from coffee_roaster_mcp.audio import RoastAudioRecorder
     from coffee_roaster_mcp.config import RecordingConfig
-    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+    from coffee_roaster_mcp.first_crack_runtime import RecordingMetadata, build_session_recorder
 
     clock = ClockHarness()
     store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
@@ -813,11 +819,13 @@ def test_build_session_recorder_single_device_labels_wav(tmp_path: Path) -> None
         ),
     )
 
-    recorder = build_session_recorder(config, session)
+    recorder = build_session_recorder(
+        config, session, metadata=RecordingMetadata(origin="ethiopia", roast_num=3)
+    )
 
-    # A single configured device falls back to the v1 single-stream recorder.
+    # A single configured device uses the single-stream recorder, mic1-named.
     assert isinstance(recorder, RoastAudioRecorder)
-    assert recorder.wav_path == tmp_path / session.id / "roast.wav"
+    assert recorder.wav_path == tmp_path / session.id / "mic1-ethiopia-roast3.wav"
 
 
 def test_build_session_recorder_no_devices_is_v1_single(tmp_path: Path) -> None:
@@ -834,5 +842,85 @@ def test_build_session_recorder_no_devices_is_v1_single(tmp_path: Path) -> None:
 
     recorder = build_session_recorder(config, session)
 
+    # No devices + no metadata → single stream, fallback origin=session.id/roast0.
     assert isinstance(recorder, RoastAudioRecorder)
-    assert recorder.wav_path == tmp_path / session.id / "roast.wav"
+    assert recorder.wav_path == tmp_path / session.id / f"mic1-{session.id}-roast0.wav"
+
+
+def test_runtime_set_recording_metadata_flows_into_built_recorder(tmp_path: Path) -> None:
+    from coffee_roaster_mcp.audio import RoastAudioRecorder
+    from coffee_roaster_mcp.config import RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    config = AppConfig(
+        recording=RecordingConfig(enabled=True, autocapture=True, export_location=tmp_path),
+    )
+    runtime = FirstCrackSessionRuntime(config=config)
+
+    # The tool stores the metadata and echoes it back.
+    stored = runtime.set_recording_metadata(origin="Brazil Cerrado", roast_num=12)
+    assert stored.origin == "Brazil Cerrado"
+    assert stored.roast_num == 12
+
+    # The recorder consumes that exact metadata object to name the WAVs.
+    recorder = build_session_recorder(config, session, metadata=stored)
+    assert isinstance(recorder, RoastAudioRecorder)
+    # Origin is slugified to [a-z0-9-]+ for the FC pipeline.
+    assert recorder.wav_path.name == "mic1-brazil-cerrado-roast12.wav"
+
+
+def test_set_recording_metadata_validates_input() -> None:
+    runtime = FirstCrackSessionRuntime(config=AppConfig())
+    with pytest.raises(ValueError, match="origin must not be blank"):
+        runtime.set_recording_metadata(origin="  ", roast_num=1)
+    with pytest.raises(ValueError, match="roast_num must be >= 0"):
+        runtime.set_recording_metadata(origin="brazil", roast_num=-1)
+
+
+def test_built_recorder_no_metadata_fallback_writes_valid_files(tmp_path: Path) -> None:
+    """Finding: the no-metadata fallback (session_id / 0) still produces valid files."""
+    import json
+
+    from coffee_roaster_mcp.config import RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    recorder = build_session_recorder(
+        AppConfig(
+            recording=RecordingConfig(
+                enabled=True, autocapture=True, export_location=tmp_path, sample_rate=8
+            ),
+        ),
+        session,
+        metadata=None,
+    )
+    assert recorder is not None
+
+    recorder.begin()
+    recorder.write_samples((0.2,) * 8)
+    recorder.close()
+
+    session_dir = tmp_path / session.id
+    annotation_path = session_dir / f"{session.id}-roast0-session.json"
+    assert annotation_path.exists()
+    payload = json.loads(annotation_path.read_text(encoding="utf-8"))
+    assert payload["origin"] == session.id  # fallback origin
+    assert payload["roast_num"] == 0  # fallback roast number
+    assert payload["mics"][0]["file"] == f"mic1-{session.id}-roast0.wav"
+    # The WAV and recording sidecar are valid too.
+    assert (session_dir / f"mic1-{session.id}-roast0.wav").exists()
+    assert (session_dir / "roast.recording.json").exists()
+
+
+def test_normalize_origin_slug_edge_cases() -> None:
+    from coffee_roaster_mcp.first_crack_runtime import _normalize_origin_slug
+
+    assert _normalize_origin_slug("Brazil Cerrado") == "brazil-cerrado"
+    assert _normalize_origin_slug("ETHIOPIA__yirgacheffe") == "ethiopia-yirgacheffe"
+    assert _normalize_origin_slug("  !!  ") == "roast"  # empty after stripping → fallback
+    assert _normalize_origin_slug("kenya-aa") == "kenya-aa"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -136,6 +136,46 @@ def test_in_process_mcp_tools_cover_mock_roast_and_export(tmp_path: Path) -> Non
     ]
 
 
+def test_set_recording_metadata_tool_stores_and_echoes(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    # The tool is registered and listed as a bootstrap-safe tool.
+    server_info = _call_tool(server, "get_server_info", ctx)
+    assert "set_recording_metadata" in server_info.available_bootstrap_tools
+
+    result = _call_tool(server, "set_recording_metadata", ctx, origin="brazil", roast_num=7)
+    assert result.origin == "brazil"
+    assert result.roast_num == 7
+
+    # The metadata reached the runtime, so the recorder it builds for a roast
+    # names the WAV for the annotation pipeline.
+    from dataclasses import replace
+
+    from coffee_roaster_mcp.audio import RoastAudioRecorder
+    from coffee_roaster_mcp.config import RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    recording_config = replace(
+        server_context.config,
+        recording=RecordingConfig(enabled=True, autocapture=True, export_location=tmp_path),
+    )
+    session = server_context.session_store.start_session()
+    metadata = server_context.first_crack_runtime.set_recording_metadata(
+        origin="brazil", roast_num=7
+    )
+    recorder = build_session_recorder(recording_config, session, metadata=metadata)
+    assert isinstance(recorder, RoastAudioRecorder)
+    assert recorder.wav_path.name == "mic1-brazil-roast7.wav"
+
+    # Invalid input is rejected.
+    with pytest.raises(ValueError, match="origin must not be blank"):
+        _call_tool(server, "set_recording_metadata", ctx, origin="  ", roast_num=1)
+
+
 def test_in_process_mcp_tools_surface_errors_and_audio_bootstrap_state(tmp_path: Path) -> None:
     config_path = tmp_path / "coffee-roaster-mcp.yaml"
     config_path.write_text(

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -210,6 +210,7 @@ async def _assert_stdio_server_tools(tmp_path: Path) -> None:
             "mark_first_crack",
             "set_fan",
             "set_heat",
+            "set_recording_metadata",
             "start_cooling",
             "start_roast_session",
             "stop_cooling",

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -94,7 +94,7 @@ _EXPECTED_T0_STATUS_KEYS = {
 
 
 def test_version_is_defined() -> None:
-    assert __version__ == "0.1.8"
+    assert __version__ == "0.1.9"
 
 
 def test_cli_parser_program_name() -> None:
@@ -107,7 +107,7 @@ def test_main_without_subcommand_prints_help(capsys: pytest.CaptureFixture[str])
     assert main([]) == 0
     output = capsys.readouterr().out
     assert "usage: coffee-roaster-mcp" in output
-    assert "{serve,hottop-validate,mic-check}" in output
+    assert "{serve,hottop-validate,mic-check,record-check}" in output
 
 
 def test_main_prints_version(capsys: pytest.CaptureFixture[str]) -> None:
@@ -147,6 +147,39 @@ def test_hottop_validate_returns_nonzero_for_unsuccessful_report(
 
     assert main(["hottop-validate", "--i-understand-this-controls-hardware"]) == 1
     assert capsys.readouterr().out == "{}\n"
+
+
+def test_record_check_cli_reports_and_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    stream = SimpleNamespace(
+        device="USB PnP",
+        wav_filename="record-check.usb-pnp.wav",
+        peak_dbfs=-6.0,
+        rms_dbfs=-12.0,
+        has_signal=False,
+        error=None,
+    )
+    report = SimpleNamespace(streams=[stream], passed=False, output_dir=tmp_path)
+
+    def fake_run_record_check(options: Any) -> Any:
+        _ = options
+        return report
+
+    def fake_record_report_to_json(record_report: Any) -> str:
+        _ = record_report
+        return "{}"
+
+    monkeypatch.setattr(cli, "run_record_check", fake_run_record_check)
+    monkeypatch.setattr(cli, "record_report_to_json", fake_record_report_to_json)
+
+    assert main(["record-check", "--seconds", "1"]) == 1
+    captured = capsys.readouterr()
+    assert "{}" in captured.out
+    assert "USB PnP" in captured.err
+    assert "FAIL" in captured.err
 
 
 def test_stdio_server_starts_and_exposes_bootstrap_tools(tmp_path: Path) -> None:

--- a/tests/test_record_check.py
+++ b/tests/test_record_check.py
@@ -4,6 +4,8 @@ import math
 from collections.abc import Sequence
 from pathlib import Path
 
+import pytest
+
 from coffee_roaster_mcp.audio import AdditionalRecordingDevice
 from coffee_roaster_mcp.record_check import (
     RecordCheckOptions,
@@ -188,3 +190,42 @@ audio:
     assert stream.frame_count == 0
     assert stream.error is not None
     assert report.passed is False
+
+
+def test_record_check_catches_capture_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Finding #3: a capture-layer error becomes a report, never a raised crash."""
+    import coffee_roaster_mcp.record_check as record_check_module
+    from coffee_roaster_mcp.audio import AudioCaptureError
+
+    config_path = _write_config(
+        tmp_path,
+        """
+recording:
+  enabled: true
+  autocapture: true
+  sample_rate: 8
+  devices:
+    - USB PnP
+audio:
+  sample_rate: 8
+""",
+    )
+
+    def boom(*_args: object, **_kwargs: object) -> object:
+        raise AudioCaptureError("WAV open failed")
+
+    monkeypatch.setattr(record_check_module, "capture_devices_independently", boom)
+
+    report = run_record_check(
+        RecordCheckOptions(config_path=config_path, record_seconds=0.0, output_dir=tmp_path / "o"),
+        additional_input_factory=lambda _device: _BoundedInput(0.5, 1),
+        sleep=lambda _: None,
+    )
+
+    assert report.error is not None
+    assert "Recording failed" in report.error
+    assert report.passed is False
+    assert report.streams == []

--- a/tests/test_record_check.py
+++ b/tests/test_record_check.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from pathlib import Path
+
+from coffee_roaster_mcp.audio import AdditionalRecordingDevice
+from coffee_roaster_mcp.record_check import (
+    RecordCheckOptions,
+    report_to_json,
+    run_record_check,
+)
+
+
+class _BoundedInput:
+    def __init__(self, amplitude: float, reads: int) -> None:
+        self._amplitude = amplitude
+        self._reads = reads
+        self.closed = False
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        if self._reads <= 0:
+            return ()
+        self._reads -= 1
+        return (self._amplitude,) * sample_count
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _write_config(tmp_path: Path, body: str) -> Path:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(body, encoding="utf-8")
+    return config_path
+
+
+def test_record_check_two_devices_one_silent(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+recording:
+  enabled: true
+  autocapture: true
+  sample_rate: 8
+  devices:
+    - USB PnP
+    - ATR2100x
+audio:
+  sample_rate: 8
+""",
+    )
+    amplitudes = {"USB PnP": 0.5, "ATR2100x": 0.0}
+
+    def factory(device: AdditionalRecordingDevice) -> _BoundedInput:
+        return _BoundedInput(amplitude=amplitudes[device.device_label], reads=4)
+
+    report = run_record_check(
+        RecordCheckOptions(
+            config_path=config_path,
+            record_seconds=0.05,
+            output_dir=tmp_path / "out",
+        ),
+        additional_input_factory=factory,
+        sleep=lambda _: None,
+    )
+
+    assert [stream.device for stream in report.streams] == ["USB PnP", "ATR2100x"]
+    # Two WAVs written.
+    assert (tmp_path / "out" / "record-check.usb-pnp.wav").exists()
+    assert (tmp_path / "out" / "record-check.atr2100x.wav").exists()
+    assert (tmp_path / "out" / "record-check.json").exists()
+    # The live device cleared the floor; the silent device did not.
+    live = next(s for s in report.streams if s.device == "USB PnP")
+    silent = next(s for s in report.streams if s.device == "ATR2100x")
+    assert live.has_signal is True
+    assert live.peak_dbfs > report.signal_floor_dbfs
+    assert silent.has_signal is False
+    assert silent.peak_dbfs == -math.inf
+    # One silent device fails the overall smoke test.
+    assert report.passed is False
+
+
+def test_record_check_all_live_passes(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+recording:
+  enabled: true
+  autocapture: true
+  sample_rate: 8
+  devices:
+    - USB PnP
+    - ATR2100x
+audio:
+  sample_rate: 8
+""",
+    )
+
+    def factory(device: AdditionalRecordingDevice) -> _BoundedInput:
+        return _BoundedInput(amplitude=0.5, reads=4)
+
+    report = run_record_check(
+        RecordCheckOptions(config_path=config_path, record_seconds=0.05, output_dir=tmp_path / "o"),
+        additional_input_factory=factory,
+        sleep=lambda _: None,
+    )
+
+    assert report.passed is True
+    assert all(stream.has_signal for stream in report.streams)
+    # report_to_json keeps -inf JSON-safe and is parseable.
+    import json
+
+    parsed = json.loads(report_to_json(report))
+    assert parsed["passed"] is True
+    assert len(parsed["streams"]) == 2
+
+
+def test_record_check_falls_back_to_audio_input_device(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+recording:
+  enabled: true
+  autocapture: true
+audio:
+  input_device: USB PnP
+  sample_rate: 8
+""",
+    )
+
+    def factory(device: AdditionalRecordingDevice) -> _BoundedInput:
+        return _BoundedInput(amplitude=0.5, reads=4)
+
+    report = run_record_check(
+        RecordCheckOptions(config_path=config_path, record_seconds=0.05, output_dir=tmp_path / "o"),
+        additional_input_factory=factory,
+        sleep=lambda _: None,
+    )
+
+    assert [stream.device for stream in report.streams] == ["USB PnP"]
+    assert report.passed is True
+
+
+def test_record_check_no_devices_errors(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        "recording:\n  enabled: true\n  autocapture: true\naudio:\n  sample_rate: 8\n",
+    )
+
+    report = run_record_check(
+        RecordCheckOptions(config_path=config_path, output_dir=tmp_path / "o"),
+        additional_input_factory=lambda _device: _BoundedInput(0.5, 1),
+        sleep=lambda _: None,
+    )
+
+    assert report.error is not None
+    assert "No devices configured" in report.error
+    assert report.passed is False
+    assert report.streams == []
+
+
+def test_record_check_silent_zero_frame_flagged(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+recording:
+  enabled: true
+  autocapture: true
+  sample_rate: 8
+  devices:
+    - DEAD
+audio:
+  sample_rate: 8
+""",
+    )
+
+    def factory(device: AdditionalRecordingDevice) -> _BoundedInput:
+        return _BoundedInput(amplitude=0.0, reads=0)  # opens but delivers nothing
+
+    report = run_record_check(
+        RecordCheckOptions(config_path=config_path, record_seconds=0.02, output_dir=tmp_path / "o"),
+        additional_input_factory=factory,
+        sleep=lambda _: None,
+    )
+
+    assert len(report.streams) == 1
+    stream = report.streams[0]
+    assert stream.frame_count == 0
+    assert stream.error is not None
+    assert report.passed is False


### PR DESCRIPTION
## 0.1.9 — FC observability + roast audio capture

### #175 — per-window FC confidence observability
The audio first-crack detector can silently miss (roast 4: "FC: listening / Mic OK" but it never fired) with **zero** confidence in the logs. Now every processed window logs a `fc_window` row (confidence, positive-window count, status) and `summary.json` carries a `first_crack_detection` block with the **max confidence even on a miss** — so a non-fire reads "peaked at 0.55, never crossed 0.6". Observability-only; detection thresholds + the confirm rule unchanged.

### #176 — config-driven roast audio capture (capture-only)
- **v1 (mono):** tee the FC detector's stream → one WAV + a recording-relative sidecar.
- **Multi-device (option A):** `recording.devices` — tee the detector's device (index 0, no second open) + open each additional device as its own independent stream / daemon thread / WAV. Cross-platform (macOS + Pi, no aggregate). Independent clocks → expected drift, **not** sample-locked (documented; fine for FC training, per the operator's research-backed decision). Fail-soft per stream.
- **`record-check` CLI:** a roast-free smoke test — records N s from every configured device, reports per-stream peak/RMS dBFS, exits non-zero on a dead mic. **Mac-validated against USB PnP + ATR2100x (two non-silent WAVs).**

### Release hygiene
Version aligned to 0.1.9 across `__init__.py` / `server.json` / the version test.

### Gates
`ruff` / `ruff format` / `pyright` (strict, 0 errors) / `pytest` all green; coverage ≥ 90 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)