### PR TITLE
0.1.11: full-roast recording (#181) + live mic-levels readout (#178)

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.syamaner/coffee-roaster-mcp",
   "title": "RoastPilot",
   "description": "RoastPilot controls coffee roasting sessions through local stdio MCP tools and exports logs.",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "websiteUrl": "https://github.com/syamaner/coffee-roaster-mcp#readme",
   "repository": {
     "url": "https://github.com/syamaner/coffee-roaster-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "coffee-roaster-mcp",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "runtimeHint": "uvx",
       "packageArguments": [
         {

--- a/src/coffee_roaster_mcp/__init__.py
+++ b/src/coffee_roaster_mcp/__init__.py
@@ -1,3 +1,3 @@
 """RoastPilot MCP server package."""
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -128,6 +128,13 @@ class AudioCaptureSnapshot:
         emitted_window_count: Windows successfully queued for detector consumption.
         dropped_window_count: Windows dropped because the detector queue was full.
         latest_error: Last capture error message, if the worker stopped on error.
+        peak_dbfs: Rolling peak level of the captured stream in dBFS over the most
+            recent measurement window, or ``None`` before any samples are read
+            (#178). ``-inf`` for pure silence. A live in-session mic-levels signal
+            so a mis-gained or dead mic is visible under real roasting conditions.
+        rms_dbfs: Rolling RMS level of the captured stream in dBFS over the most
+            recent measurement window, or ``None`` before any samples are read
+            (#178). ``-inf`` for pure silence.
     """
 
     running: bool
@@ -135,6 +142,84 @@ class AudioCaptureSnapshot:
     emitted_window_count: int
     dropped_window_count: int
     latest_error: str | None
+    peak_dbfs: float | None = None
+    rms_dbfs: float | None = None
+
+
+def amplitude_to_dbfs(amplitude: float) -> float:
+    """Convert a 0..1 normalized amplitude to dBFS.
+
+    Returns ``-inf`` for an amplitude at or below zero (pure silence) so a dead
+    or muted mic is unambiguous in the levels readout (#178). Amplitudes above
+    1.0 are clamped to 0 dBFS.
+
+    Args:
+        amplitude: Absolute sample amplitude in the normalized [0, 1] range.
+
+    Returns:
+        The level in dBFS, ``-inf`` at silence.
+    """
+    if amplitude <= 0.0:
+        return -math.inf
+    return round(20.0 * math.log10(min(1.0, amplitude)), 2)
+
+
+class _RollingLevelMeter:
+    """Track peak / RMS of the captured stream over a recent sample window (#178).
+
+    Fed the same float blocks the detector consumes, it keeps a bounded ring of
+    the most recent samples and reports the peak and RMS of that ring in dBFS.
+    The bound keeps the meter responsive (it reflects the live signal, not the
+    whole-roast average) and the work is vectorised in C via numpy so it never
+    stalls the capture worker on the Pi CPU budget (D27). The meter is owned and
+    driven by the single capture worker thread; reads come from the snapshot
+    under the pipeline's state lock, which sees a consistent ``(peak, rms)`` pair.
+    """
+
+    def __init__(self, *, window_sample_count: int) -> None:
+        """Configure the rolling meter.
+
+        Args:
+            window_sample_count: Maximum recent samples retained for the level
+                measurement. At least one sample is always kept.
+        """
+        self._window_sample_count = max(1, window_sample_count)
+        self._samples: np.ndarray = np.empty(0, dtype=np.float64)
+        self._has_samples = False
+        self._peak_dbfs: float | None = None
+        self._rms_dbfs: float | None = None
+
+    def observe(self, samples: Sequence[float]) -> None:
+        """Append captured samples and recompute the rolling peak / RMS."""
+        if not samples:
+            return
+        block = np.abs(np.asarray(samples, dtype=np.float64))
+        combined = np.concatenate((self._samples, block))
+        if combined.shape[0] > self._window_sample_count:
+            combined = combined[-self._window_sample_count :]
+        self._samples = combined
+        self._has_samples = True
+        peak = float(combined.max()) if combined.shape[0] else 0.0
+        rms = float(np.sqrt(np.mean(np.square(combined)))) if combined.shape[0] else 0.0
+        self._peak_dbfs = amplitude_to_dbfs(peak)
+        self._rms_dbfs = amplitude_to_dbfs(rms)
+
+    @property
+    def peak_dbfs(self) -> float | None:
+        """Return the rolling peak in dBFS, or ``None`` before any samples."""
+        return self._peak_dbfs if self._has_samples else None
+
+    @property
+    def rms_dbfs(self) -> float | None:
+        """Return the rolling RMS in dBFS, or ``None`` before any samples."""
+        return self._rms_dbfs if self._has_samples else None
+
+    def reset(self) -> None:
+        """Clear the retained samples and reported levels for a fresh run."""
+        self._samples = np.empty(0, dtype=np.float64)
+        self._has_samples = False
+        self._peak_dbfs = None
+        self._rms_dbfs = None
 
 
 def audio_capture_settings_from_config(
@@ -1355,6 +1440,12 @@ class AudioCapturePipeline:
         self._emitted_window_count = 0
         self._dropped_window_count = 0
         self._latest_error: str | None = None
+        # Live mic-levels meter (#178): a rolling peak/RMS over roughly the most
+        # recent measurement window of captured samples, fed the same blocks the
+        # detector consumes. Surfaced in the snapshot so a mis-gained / dead mic
+        # is visible under real roasting conditions, where the quiet pre-roast
+        # floor differs from the in-roast level.
+        self._level_meter = _RollingLevelMeter(window_sample_count=settings.window_sample_count)
 
     @property
     def settings(self) -> AudioCaptureSettings:
@@ -1478,6 +1569,8 @@ class AudioCapturePipeline:
                 emitted_window_count=self._emitted_window_count,
                 dropped_window_count=self._dropped_window_count,
                 latest_error=self._latest_error,
+                peak_dbfs=self._level_meter.peak_dbfs,
+                rms_dbfs=self._level_meter.rms_dbfs,
             )
 
     def _run_capture_loop(self) -> None:
@@ -1498,6 +1591,10 @@ class AudioCapturePipeline:
                     time.sleep(self._settings.idle_sleep_seconds)
                     continue
                 self._sample_buffer.extend(samples)
+                # Update the live mic-levels meter from the SAME samples the
+                # detector consumes (#178). Cheap, vectorised, and never raises;
+                # purely observational so it cannot affect detection.
+                self._level_meter.observe(samples)
                 # Tee the SAME samples the detector consumes into the recording
                 # WAV right after the buffer extend (#176). This is the verified
                 # non-disturbing tee point: the detector still windows the buffer
@@ -1583,6 +1680,7 @@ class AudioCapturePipeline:
         self._emitted_window_count = 0
         self._dropped_window_count = 0
         self._latest_error = None
+        self._level_meter.reset()
 
 
 class DetectorPacedWavReplayPipeline(AudioCapturePipeline):

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -171,9 +171,13 @@ class _RollingLevelMeter:
     the most recent samples and reports the peak and RMS of that ring in dBFS.
     The bound keeps the meter responsive (it reflects the live signal, not the
     whole-roast average) and the work is vectorised in C via numpy so it never
-    stalls the capture worker on the Pi CPU budget (D27). The meter is owned and
-    driven by the single capture worker thread; reads come from the snapshot
-    under the pipeline's state lock, which sees a consistent ``(peak, rms)`` pair.
+    stalls the capture worker on the Pi CPU budget (D27). The meter is written
+    only by the single capture worker thread, but a snapshot reader runs on
+    another thread WITHOUT holding the writer (``observe`` is outside the
+    pipeline's state lock). To keep the reader from seeing a torn pair (a peak
+    from one update with an RMS from another), the two dBFS levels are stored as
+    one ``(peak, rms)`` tuple assigned atomically; ``levels`` reads that single
+    reference, so a reader always sees a coherent pair.
     """
 
     def __init__(self, *, window_sample_count: int) -> None:
@@ -185,9 +189,10 @@ class _RollingLevelMeter:
         """
         self._window_sample_count = max(1, window_sample_count)
         self._samples: np.ndarray = np.empty(0, dtype=np.float64)
-        self._has_samples = False
-        self._peak_dbfs: float | None = None
-        self._rms_dbfs: float | None = None
+        #: The coherent ``(peak_dbfs, rms_dbfs)`` pair, or ``None`` before any
+        #: samples. Assigned as one reference so a cross-thread reader never sees
+        #: a peak and RMS from different updates.
+        self._levels: tuple[float, float] | None = None
 
     def observe(self, samples: Sequence[float]) -> None:
         """Append captured samples and recompute the rolling peak / RMS."""
@@ -198,28 +203,38 @@ class _RollingLevelMeter:
         if combined.shape[0] > self._window_sample_count:
             combined = combined[-self._window_sample_count :]
         self._samples = combined
-        self._has_samples = True
         peak = float(combined.max()) if combined.shape[0] else 0.0
         rms = float(np.sqrt(np.mean(np.square(combined)))) if combined.shape[0] else 0.0
-        self._peak_dbfs = amplitude_to_dbfs(peak)
-        self._rms_dbfs = amplitude_to_dbfs(rms)
+        # Single atomic assignment of the coherent pair (see class docstring):
+        # the reader sees both new values or both old, never a mix.
+        self._levels = (amplitude_to_dbfs(peak), amplitude_to_dbfs(rms))
+
+    @property
+    def levels(self) -> tuple[float, float] | None:
+        """Return the coherent ``(peak_dbfs, rms_dbfs)`` pair, or ``None``.
+
+        A single read of the atomically-assigned tuple, so a cross-thread reader
+        never sees a peak and RMS drawn from different updates. ``None`` before
+        any samples have been observed.
+        """
+        return self._levels
 
     @property
     def peak_dbfs(self) -> float | None:
         """Return the rolling peak in dBFS, or ``None`` before any samples."""
-        return self._peak_dbfs if self._has_samples else None
+        levels = self._levels
+        return None if levels is None else levels[0]
 
     @property
     def rms_dbfs(self) -> float | None:
         """Return the rolling RMS in dBFS, or ``None`` before any samples."""
-        return self._rms_dbfs if self._has_samples else None
+        levels = self._levels
+        return None if levels is None else levels[1]
 
     def reset(self) -> None:
         """Clear the retained samples and reported levels for a fresh run."""
         self._samples = np.empty(0, dtype=np.float64)
-        self._has_samples = False
-        self._peak_dbfs = None
-        self._rms_dbfs = None
+        self._levels = None
 
 
 def audio_capture_settings_from_config(
@@ -1562,6 +1577,11 @@ class AudioCapturePipeline:
     def snapshot(self) -> AudioCaptureSnapshot:
         """Return a thread-safe capture status snapshot."""
         thread = self._thread
+        # Read the coherent (peak, rms) pair in a single access so the snapshot
+        # never mixes a peak and RMS from different meter updates (#178). The
+        # meter is written outside _state_lock by the capture worker, so two
+        # separate property reads could tear; one tuple read cannot.
+        levels = self._level_meter.levels
         with self._state_lock:
             return AudioCaptureSnapshot(
                 running=thread is not None and thread.is_alive(),
@@ -1569,8 +1589,8 @@ class AudioCapturePipeline:
                 emitted_window_count=self._emitted_window_count,
                 dropped_window_count=self._dropped_window_count,
                 latest_error=self._latest_error,
-                peak_dbfs=self._level_meter.peak_dbfs,
-                rms_dbfs=self._level_meter.rms_dbfs,
+                peak_dbfs=None if levels is None else levels[0],
+                rms_dbfs=None if levels is None else levels[1],
             )
 
     def _run_capture_loop(self) -> None:

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -372,12 +372,22 @@ class FirstCrackSessionRuntime:
                 status = "faulted"
                 reason = f"Audio capture failed: {capture_snapshot.latest_error}"
 
+            audio_running = capture_snapshot is not None and capture_snapshot.running
+            # The mic levels are a LIVE signal: report them only while audio
+            # capture is running. After stop_for_session the stopped capture
+            # snapshot still carries the last-measured levels, but they are stale,
+            # so gate on ``audio_running`` — ``None`` reliably means "no live
+            # signal", matching the field's documented semantics (#178).
+            mic_peak_dbfs = (
+                capture_snapshot.peak_dbfs if audio_running and capture_snapshot else None
+            )
+            mic_rms_dbfs = capture_snapshot.rms_dbfs if audio_running and capture_snapshot else None
             return FirstCrackRuntimeSnapshot(
                 status=status,
                 active_session_id=self._active_session_id,
                 active=self._pipeline is not None,
                 reason=reason,
-                audio_running=False if capture_snapshot is None else capture_snapshot.running,
+                audio_running=audio_running,
                 queued_window_count=0
                 if capture_snapshot is None
                 else capture_snapshot.queued_window_count,
@@ -388,8 +398,8 @@ class FirstCrackSessionRuntime:
                 if capture_snapshot is None
                 else capture_snapshot.dropped_window_count,
                 processed_window_count=self._processed_window_count,
-                mic_peak_dbfs=None if capture_snapshot is None else capture_snapshot.peak_dbfs,
-                mic_rms_dbfs=None if capture_snapshot is None else capture_snapshot.rms_dbfs,
+                mic_peak_dbfs=mic_peak_dbfs,
+                mic_rms_dbfs=mic_rms_dbfs,
             )
 
     def _can_process_locked(self, session: RoastSession) -> bool:
@@ -687,14 +697,17 @@ def _initial_status(config: FirstCrackConfig) -> FirstCrackRuntimeState:
 
 
 def _stopped_capture_snapshot(snapshot: AudioCaptureSnapshot) -> AudioCaptureSnapshot:
+    # A stopped capture carries no LIVE mic levels: the meter's last values are
+    # stale once capture stops, so drop them (the runtime snapshot also gates the
+    # levels on ``audio_running``, so a stale value would never surface anyway).
     return AudioCaptureSnapshot(
         running=False,
         queued_window_count=snapshot.queued_window_count,
         emitted_window_count=snapshot.emitted_window_count,
         dropped_window_count=snapshot.dropped_window_count,
         latest_error=snapshot.latest_error,
-        peak_dbfs=snapshot.peak_dbfs,
-        rms_dbfs=snapshot.rms_dbfs,
+        peak_dbfs=None,
+        rms_dbfs=None,
     )
 
 

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -81,6 +81,11 @@ class FirstCrackRuntimeSnapshot:
         emitted_window_count: Windows emitted by the capture pipeline.
         dropped_window_count: Windows dropped by the capture queue.
         processed_window_count: Windows processed by this runtime.
+        mic_peak_dbfs: Live rolling peak level of the captured mic stream in dBFS
+            (#178), or ``None`` when no audio capture is running. ``-inf`` for
+            silence. Lets a mis-gained / dead mic be caught under real conditions.
+        mic_rms_dbfs: Live rolling RMS level of the captured mic stream in dBFS
+            (#178), or ``None`` when no audio capture is running.
     """
 
     status: FirstCrackRuntimeState
@@ -92,6 +97,8 @@ class FirstCrackRuntimeSnapshot:
     emitted_window_count: int = 0
     dropped_window_count: int = 0
     processed_window_count: int = 0
+    mic_peak_dbfs: float | None = None
+    mic_rms_dbfs: float | None = None
 
 
 class FirstCrackSessionRuntime:
@@ -127,6 +134,12 @@ class FirstCrackSessionRuntime:
         self._reason: str | None = _initial_reason(config.first_crack)
         self._processed_window_count = 0
         self._last_capture_snapshot: AudioCaptureSnapshot | None = None
+        #: Whether inference/draining has been stopped for this session while the
+        #: capture worker + recorder keep running (#181). Set at first-crack
+        #: detection so the runtime stops draining/detecting but the recording
+        #: spans charge→session stop (not charge→FC). The pipeline is finalised
+        #: only at ``stop_for_session`` (the real roast end).
+        self._inference_stopped = False
         #: Recorder for the session currently being started (#176). Set while the
         #: default pipeline factory runs so the teed WAV is wired into the real
         #: capture pipeline; injected test factories ignore it.
@@ -197,6 +210,7 @@ class FirstCrackSessionRuntime:
             self._stop_locked(reason="new roast session")
             self._active_session_id = session.id
             self._processed_window_count = 0
+            self._inference_stopped = False
             self._last_capture_snapshot = None
 
             if self._config.first_crack.mode != "audio":
@@ -286,7 +300,13 @@ class FirstCrackSessionRuntime:
                     if result is not None:
                         self._status = "detected"
                         self._reason = "First crack was recorded by audio detection."
-                        self._stop_locked(reason="first crack detected")
+                        # #181: stop ONLY inference/draining at first crack — keep
+                        # the capture worker + recorder running so the recording
+                        # spans charge→session stop (not charge→FC). Nothing drains
+                        # the bounded window queue after this, so it fills and drops
+                        # harmlessly while the capture worker keeps teeing to the
+                        # WAVs. The pipeline finalises at stop_for_session.
+                        self._inference_stopped = True
                         break
             except (AudioCaptureError, FirstCrackDetectorError, SessionLifecycleError) as exc:
                 self._mark_faulted_locked(f"First-crack detection failed: {exc}")
@@ -368,12 +388,18 @@ class FirstCrackSessionRuntime:
                 if capture_snapshot is None
                 else capture_snapshot.dropped_window_count,
                 processed_window_count=self._processed_window_count,
+                mic_peak_dbfs=None if capture_snapshot is None else capture_snapshot.peak_dbfs,
+                mic_rms_dbfs=None if capture_snapshot is None else capture_snapshot.rms_dbfs,
             )
 
     def _can_process_locked(self, session: RoastSession) -> bool:
         if self._config.first_crack.mode != "audio":
             return False
         if self._active_session_id != session.id:
+            return False
+        # Inference is stopped at first crack (#181) while capture keeps running;
+        # never drain/detect again until a fresh session resets the flag.
+        if self._inference_stopped:
             return False
         if self._status != "pending":
             return False
@@ -397,8 +423,10 @@ class FirstCrackSessionRuntime:
             finally:
                 self._pipeline = None
                 self._adapter = None
-        # The session is over: the next roast may set fresh recording metadata.
+        # The session is over: the next roast may set fresh recording metadata,
+        # and inference may run again from scratch (#181).
         self._recorder_built_for_session = False
+        self._inference_stopped = False
         if self._status == "pending":
             self._reason = f"Audio first-crack detection stopped before confirmation: {reason}."
 
@@ -665,6 +693,8 @@ def _stopped_capture_snapshot(snapshot: AudioCaptureSnapshot) -> AudioCaptureSna
         emitted_window_count=snapshot.emitted_window_count,
         dropped_window_count=snapshot.dropped_window_count,
         latest_error=snapshot.latest_error,
+        peak_dbfs=snapshot.peak_dbfs,
+        rms_dbfs=snapshot.rms_dbfs,
     )
 
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -284,6 +284,11 @@ class FirstCrackStatus:
         emitted_window_count: Windows emitted by the audio runtime.
         dropped_window_count: Windows dropped by the audio runtime.
         processed_window_count: Windows processed by the detector runtime.
+        mic_peak_dbfs: Live rolling peak mic level in dBFS while audio capture
+            runs (#178), or ``None`` when no capture is running. ``-inf`` for
+            silence — surfaces a mis-gained / dead mic under real conditions.
+        mic_rms_dbfs: Live rolling RMS mic level in dBFS while audio capture runs
+            (#178), or ``None`` when no capture is running.
     """
 
     mode: FirstCrackMode
@@ -297,6 +302,8 @@ class FirstCrackStatus:
     emitted_window_count: int = 0
     dropped_window_count: int = 0
     processed_window_count: int = 0
+    mic_peak_dbfs: float | None = None
+    mic_rms_dbfs: float | None = None
 
 
 T0RuntimeStatus = Literal["disabled", "pending", "detected", "unavailable"]
@@ -1377,6 +1384,8 @@ def _serialize_first_crack_status(
             emitted_window_count=runtime.emitted_window_count,
             dropped_window_count=runtime.dropped_window_count,
             processed_window_count=runtime.processed_window_count,
+            mic_peak_dbfs=runtime.mic_peak_dbfs,
+            mic_rms_dbfs=runtime.mic_rms_dbfs,
         )
     if session.faulted_at_utc is not None:
         runtime = _runtime_metrics(
@@ -1395,6 +1404,8 @@ def _serialize_first_crack_status(
             emitted_window_count=runtime.emitted_window_count,
             dropped_window_count=runtime.dropped_window_count,
             processed_window_count=runtime.processed_window_count,
+            mic_peak_dbfs=runtime.mic_peak_dbfs,
+            mic_rms_dbfs=runtime.mic_rms_dbfs,
         )
     if config.first_crack.mode == "disabled":
         return FirstCrackStatus(
@@ -1445,6 +1456,8 @@ def _serialize_first_crack_status(
             emitted_window_count=runtime.emitted_window_count,
             dropped_window_count=runtime.dropped_window_count,
             processed_window_count=runtime.processed_window_count,
+            mic_peak_dbfs=runtime.mic_peak_dbfs,
+            mic_rms_dbfs=runtime.mic_rms_dbfs,
         )
     reason = "Audio first-crack detection has not recorded first crack for this session."
     if (
@@ -1470,6 +1483,8 @@ def _serialize_first_crack_status(
         emitted_window_count=runtime.emitted_window_count,
         dropped_window_count=runtime.dropped_window_count,
         processed_window_count=runtime.processed_window_count,
+        mic_peak_dbfs=runtime.mic_peak_dbfs,
+        mic_rms_dbfs=runtime.mic_rms_dbfs,
     )
 
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1522,3 +1522,25 @@ def test_rolling_level_meter_tracks_recent_window_only() -> None:
     meter.reset()
     assert meter.peak_dbfs is None
     assert meter.rms_dbfs is None
+
+
+def test_rolling_level_meter_levels_is_a_coherent_pair() -> None:
+    """`levels` returns the (peak, rms) pair as ONE reference (#178).
+
+    The meter is written by the capture worker outside the pipeline state lock,
+    so the snapshot reads the pair via this single accessor to avoid a torn
+    (peak-from-one-update, rms-from-another) read. The peak/rms scalar
+    properties derive from the same tuple.
+    """
+    from coffee_roaster_mcp.audio import _RollingLevelMeter  # pyright: ignore[reportPrivateUsage]
+
+    meter = _RollingLevelMeter(window_sample_count=4)
+    assert meter.levels is None
+    meter.observe((0.5, -0.5, 0.5, -0.5))
+    levels = meter.levels
+    assert levels is not None
+    assert levels == (meter.peak_dbfs, meter.rms_dbfs)
+    # A constant half-scale block: peak == rms == -6.02 dBFS (2 dp).
+    assert levels == (-6.02, -6.02)
+    meter.reset()
+    assert meter.levels is None

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -20,6 +20,7 @@ from coffee_roaster_mcp.audio import (
     MicrophoneAudioInput,
     RoastAudioRecorder,
     WavAudioInput,
+    amplitude_to_dbfs,
     audio_capture_settings_from_config,
     build_audio_capture_pipeline,
     build_configured_audio_input,
@@ -1393,3 +1394,131 @@ def test_wav_writer_zero_frames_finalises_valid_header(tmp_path: Path) -> None:
         assert wav_file.getnframes() == 0
         assert wav_file.getframerate() == 16_000
         assert wav_file.getnchannels() == 1
+
+
+# --- #178: live in-session mic-levels readout -----------------------------
+
+
+def test_amplitude_to_dbfs_maps_levels_and_silence() -> None:
+    """`amplitude_to_dbfs` maps full-scale to 0, half-scale to ~-6, silence to -inf."""
+    import math
+
+    assert amplitude_to_dbfs(1.0) == 0.0
+    assert amplitude_to_dbfs(2.0) == 0.0  # clamped to full scale
+    # Rounded to 2 dp, half-scale is exactly -6.02 dBFS.
+    assert amplitude_to_dbfs(0.5) == -6.02
+    assert amplitude_to_dbfs(0.0) == -math.inf
+    assert amplitude_to_dbfs(-0.1) == -math.inf
+
+
+def test_capture_snapshot_reports_none_levels_before_any_samples() -> None:
+    """Before the worker reads a sample, the levels are `None` (not yet measured)."""
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device="mock-mic",
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=FiniteAudioInput(()),
+    )
+    snapshot = pipeline.snapshot()
+    assert snapshot.peak_dbfs is None
+    assert snapshot.rms_dbfs is None
+
+
+def test_capture_snapshot_reports_live_peak_and_rms_levels() -> None:
+    """The capture worker surfaces a non-trivial peak/RMS for a real signal (#178)."""
+    audio_input = MutableAudioInput((0.5, -0.5, 0.5, -0.5))
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device="mock-mic",
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+    )
+
+    pipeline.start()
+    try:
+        _wait_for(lambda: pipeline.snapshot().peak_dbfs is not None)
+        snapshot = pipeline.snapshot()
+    finally:
+        pipeline.stop()
+
+    # A constant 0.5 amplitude block is exactly -6.02 dBFS peak AND RMS
+    # (the helper rounds to 2 dp).
+    assert snapshot.peak_dbfs == -6.02
+    assert snapshot.rms_dbfs == -6.02
+
+
+def test_capture_snapshot_reports_silence_floor_for_a_dead_mic() -> None:
+    """A device that opens but delivers zeros reports -inf dBFS, not None (#178)."""
+    import math
+
+    audio_input = MutableAudioInput((0.0, 0.0, 0.0, 0.0))
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device="mock-mic",
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+    )
+
+    pipeline.start()
+    try:
+        _wait_for(lambda: pipeline.snapshot().peak_dbfs is not None)
+        snapshot = pipeline.snapshot()
+    finally:
+        pipeline.stop()
+
+    assert snapshot.peak_dbfs == -math.inf
+    assert snapshot.rms_dbfs == -math.inf
+
+
+def test_capture_levels_reset_on_pipeline_restart() -> None:
+    """The level meter clears on restart so a new run does not show stale levels."""
+    audio_input = MutableAudioInput((0.5, 0.5, 0.5, 0.5))
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device="mock-mic",
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().peak_dbfs is not None)
+    pipeline.stop()
+
+    pipeline.start()
+    try:
+        # Immediately after restart, before the worker has read, levels are reset.
+        assert pipeline.snapshot().peak_dbfs is None
+    finally:
+        pipeline.stop()
+
+
+def test_rolling_level_meter_tracks_recent_window_only() -> None:
+    """The meter reflects the recent window, dropping older quieter samples."""
+    from coffee_roaster_mcp.audio import _RollingLevelMeter  # pyright: ignore[reportPrivateUsage]
+
+    meter = _RollingLevelMeter(window_sample_count=4)
+    assert meter.peak_dbfs is None
+    # An empty observe is a no-op: levels stay unmeasured.
+    meter.observe(())
+    assert meter.peak_dbfs is None
+    meter.observe((0.0, 0.0))
+    assert meter.peak_dbfs == float("-inf")
+    # A later loud block displaces the early silence within the 4-sample window.
+    meter.observe((1.0, 1.0, 1.0, 1.0))
+    assert meter.peak_dbfs == 0.0
+    assert meter.rms_dbfs == 0.0
+    meter.reset()
+    assert meter.peak_dbfs is None
+    assert meter.rms_dbfs is None

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -51,10 +51,14 @@ class FakeAudioPipeline:
         *,
         latest_error: str | None = None,
         running_after_stop: bool = False,
+        peak_dbfs: float | None = None,
+        rms_dbfs: float | None = None,
     ) -> None:
         self._windows = list(windows)
         self.latest_error = latest_error
         self.running_after_stop = running_after_stop
+        self.peak_dbfs = peak_dbfs
+        self.rms_dbfs = rms_dbfs
         self.started = False
         self.stopped = False
         self.stop_reasons: list[float] = []
@@ -89,6 +93,8 @@ class FakeAudioPipeline:
             emitted_window_count=len(self._windows),
             dropped_window_count=0,
             latest_error=self.latest_error,
+            peak_dbfs=self.peak_dbfs,
+            rms_dbfs=self.rms_dbfs,
         )
 
 
@@ -294,6 +300,41 @@ def test_audio_runtime_reports_stopped_after_pipeline_stop_returns_running_snaps
     assert pipeline.stopped is True
     assert stopped.active is False
     assert stopped.audio_running is False
+
+
+def test_runtime_mic_levels_are_live_only_and_none_after_stop() -> None:
+    """mic_*_dbfs report the LIVE signal, and are None once capture stops (#178).
+
+    While audio capture runs, the runtime surfaces the meter's peak/RMS. After
+    stop_for_session — even though the runtime keeps the last capture snapshot —
+    the levels go None so a caller never reads a stale post-stop value (None
+    means "no live signal", per the field's documented semantics).
+    """
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    pipeline = FakeAudioPipeline(peak_dbfs=-6.02, rms_dbfs=-9.03)
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio")),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            MockDetectorBackend(()),
+        ),
+    )
+
+    runtime.start_for_session(session)
+    live = runtime.snapshot()
+    assert live.audio_running is True
+    assert live.mic_peak_dbfs == -6.02
+    assert live.mic_rms_dbfs == -9.03
+
+    stopped = runtime.stop_for_session(session.id, reason="roast complete")
+    assert stopped.audio_running is False
+    # The last capture snapshot is retained, but the stale levels are not surfaced.
+    assert stopped.mic_peak_dbfs is None
+    assert stopped.mic_rms_dbfs is None
 
 
 def test_audio_runtime_can_discard_queued_pre_t0_windows() -> None:

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -171,7 +171,12 @@ def test_audio_runtime_processes_after_beans_added_and_records_once() -> None:
     assert pre_t0.queued_window_count == 2
     assert detected.status == "detected"
     assert duplicate.status == "detected"
-    assert pipeline.stopped is True
+    # #181: detection stops INFERENCE only — the capture pipeline keeps running
+    # (and the recorder keeps teeing) so the recording spans charge→session stop,
+    # not charge→FC. The pipeline is finalised only at stop_for_session.
+    assert pipeline.stopped is False
+    assert detected.active is True
+    assert detected.audio_running is True
     assert [window.sequence_number for window in backend.windows] == [1]
     assert [event.kind for event in session.event_timeline] == [
         "beans_added",
@@ -180,6 +185,12 @@ def test_audio_runtime_processes_after_beans_added_and_records_once() -> None:
     # FC is backdated to the confirming-window onset (seq 1 starts at 505.0,
     # elapsed 5.0), not the detector timestamp 506.0 (#168).
     assert session.first_crack_monotonic_seconds == 5.0
+
+    # The real roast end finalises capture + the recorder (#181).
+    stopped = runtime.stop_for_session(session.id, reason="roast complete")
+    assert pipeline.stopped is True
+    assert stopped.active is False
+    assert stopped.audio_running is False
 
 
 def test_detector_paced_audio_runtime_drains_one_window_per_processing_tick() -> None:
@@ -268,10 +279,21 @@ def test_audio_runtime_reports_stopped_after_pipeline_stop_returns_running_snaps
     detected = runtime.process_available_windows(session_store=store, session=session)
     snapshot = runtime.snapshot()
 
-    assert detected.active is False
-    assert detected.audio_running is False
-    assert snapshot.active is False
-    assert snapshot.audio_running is False
+    # #181: at first crack the capture pipeline keeps running, so the runtime
+    # still reports active + audio_running. The recording spans charge→stop.
+    assert detected.status == "detected"
+    assert detected.active is True
+    assert detected.audio_running is True
+    assert snapshot.active is True
+    assert snapshot.audio_running is True
+
+    # stop_for_session finalises capture. Even though this pipeline's snapshot
+    # keeps claiming running after stop() (running_after_stop=True), the runtime
+    # forces the stopped snapshot once it has torn the pipeline down.
+    stopped = runtime.stop_for_session(session.id, reason="roast complete")
+    assert pipeline.stopped is True
+    assert stopped.active is False
+    assert stopped.audio_running is False
 
 
 def test_audio_runtime_can_discard_queued_pre_t0_windows() -> None:
@@ -1126,3 +1148,192 @@ def test_set_recording_metadata_after_build_warns_and_is_not_applied(
     with caplog.at_level(logging.WARNING, logger="coffee_roaster_mcp.first_crack_runtime"):
         runtime.set_recording_metadata(origin="next", roast_num=2)
     assert not any("arrived AFTER" in record.message for record in caplog.records)
+
+
+# --- #181: recording must span charge→session stop, not charge→first crack ---
+
+
+class _StreamingToneInput:
+    """An ``AudioInput`` that delivers a continuous tone in fixed-size reads.
+
+    Models a live microphone for the soak test: it never runs dry (always
+    returns the requested sample count), so the capture worker keeps reading,
+    teeing, and updating levels for the full session — before AND after first
+    crack — exactly as a real mic would.
+    """
+
+    def __init__(self, *, amplitude: float = 0.5) -> None:
+        self._amplitude = amplitude
+        self._phase = 0
+        self.total_read = 0
+        self.closed = False
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        if sample_count <= 0:
+            return ()
+        out: list[float] = []
+        for _ in range(sample_count):
+            # Alternate sign so peak and RMS are non-trivial and stable.
+            out.append(self._amplitude if self._phase % 2 == 0 else -self._amplitude)
+            self._phase += 1
+        self.total_read += sample_count
+        return tuple(out)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _confirmed_outputs(count: int) -> tuple[FirstCrackDetectorOutput, ...]:
+    return tuple(FirstCrackDetectorOutput(confirmed=True, confidence=0.95) for _ in range(count))
+
+
+def test_recording_spans_charge_to_session_stop_not_to_first_crack(tmp_path: Path) -> None:
+    """#181 soak: a sustained MCP-driven session records charge→stop, FC inside.
+
+    Drives the runtime API with a REAL capture pipeline teeing a REAL recorder:
+    charge, run a while, fire first crack via the detector, run MORE, then stop
+    the session. Asserts the WAV spans charge→stop (its duration exceeds the
+    first-crack offset by a clear margin — the post-FC tail is captured, not
+    truncated at FC), that first crack sits INSIDE the recording, and that
+    finalisation wrote both the recording sidecar and the annotation session
+    JSON. Run sustained: many capture cycles before and after FC.
+    """
+    import time
+
+    from coffee_roaster_mcp.audio import RoastAudioRecorder, build_audio_capture_pipeline
+    from coffee_roaster_mcp.config import RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    # Drive this soak on the REAL monotonic clock so the capture pipeline, the
+    # recorder, and the first-crack integrator all agree on time (the integrator
+    # rejects window timestamps that are future relative to its own clock). This
+    # is a genuine sustained run, not a stepped fixture.
+    store = RoastSessionStore()
+    session = store.start_session()
+
+    sample_rate = 4_000
+    config = AppConfig(
+        audio=AudioConfig(sample_rate=sample_rate, source="microphone"),
+        first_crack=FirstCrackConfig(mode="audio", revision="v0.1.0"),
+        recording=RecordingConfig(
+            enabled=True,
+            autocapture=True,
+            export_location=tmp_path / "captures",
+        ),
+    )
+
+    audio_input = _StreamingToneInput(amplitude=0.5)
+    # The detector confirms on the first window it sees once roasting; many
+    # confirmations queued so the post-FC ticks (which never reach the detector
+    # again) cannot exhaust it.
+    backend = MockDetectorBackend(_confirmed_outputs(50))
+
+    captured: dict[str, RoastAudioRecorder] = {}
+
+    def pipeline_factory(audio_config: AudioConfig) -> object:
+        # Tee the session recorder the runtime built into a REAL capture
+        # pipeline driven by the streaming tone input (the recorder is exposed
+        # to the runtime via build_session_recorder + the default factory; here
+        # we build the pipeline explicitly so the test owns the input).
+        recorder = build_session_recorder(config, session)
+        assert isinstance(recorder, RoastAudioRecorder)
+        captured["recorder"] = recorder
+        return build_audio_capture_pipeline(
+            audio_config,
+            input_factory=lambda settings: audio_input,  # noqa: ARG005 - fixed test input
+            window_seconds=0.05,
+            recorder=recorder,
+        )
+
+    runtime = FirstCrackSessionRuntime(
+        config=config,
+        audio_pipeline_factory=pipeline_factory,  # type: ignore[arg-type]
+        detector_adapter_factory=lambda fc_config: build_first_crack_detector_adapter(
+            fc_config,
+            _resolved_detector_artifacts(),
+            backend,
+        ),
+    )
+
+    runtime.start_for_session(session)
+    recorder = captured["recorder"]
+
+    # --- Phase 1: pre-charge / pre-FC — capture runs, no detection. ---
+    deadline = time.monotonic() + 2.0
+    while recorder.frames_written < sample_rate // 4 and time.monotonic() < deadline:
+        runtime.process_available_windows(session_store=store, session=session)
+        time.sleep(0.01)
+    frames_before_charge = recorder.frames_written
+    assert frames_before_charge > 0, "capture worker should be teeing before charge"
+
+    # --- Phase 2: charge, then let the detector confirm first crack. ---
+    store.record_event(session, "beans_added")
+    # Drop the pre-charge windows so first crack backdates to a post-charge
+    # window onset (a window captured before charge would be rejected as
+    # pre-beans by the integrator). Mirrors the auto-T0 boundary discard.
+    runtime.discard_queued_windows_for_session(session.id, reason="charge boundary")
+    # Let fresh post-charge windows accumulate before detecting.
+    time.sleep(0.2)
+    detected = None
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        snap = runtime.process_available_windows(session_store=store, session=session)
+        if snap.status == "detected":
+            detected = snap
+            break
+        time.sleep(0.01)
+    assert detected is not None, "first crack should be detected during roasting"
+    assert detected.status == "detected"
+    # Capture is STILL running after FC — the #181 invariant.
+    assert detected.active is True
+    assert detected.audio_running is True
+    frames_at_fc = recorder.frames_written
+
+    # --- Phase 3: run MORE after FC — capture must keep growing the WAV. ---
+    deadline = time.monotonic() + 2.0
+    target = frames_at_fc + sample_rate // 2  # at least ~0.5s more audio
+    while recorder.frames_written < target and time.monotonic() < deadline:
+        # Post-FC ticks must NOT drain/detect again (inference stopped, #181).
+        runtime.process_available_windows(session_store=store, session=session)
+        time.sleep(0.01)
+    frames_after_fc = recorder.frames_written
+    assert frames_after_fc > frames_at_fc, "the WAV must keep growing after first crack"
+    # The detector saw windows only up to the confirming one — post-FC windows
+    # are dropped from the bounded queue, never re-detected.
+    detector_windows_after = len(backend.windows)
+
+    # --- Stop the session: finalises capture + recorder at the REAL roast end. ---
+    stopped = runtime.stop_for_session(session.id, reason="roast complete")
+    assert stopped.active is False
+    assert stopped.audio_running is False
+    # No further detection happened during the post-FC tail.
+    runtime.process_available_windows(session_store=store, session=session)
+    assert len(backend.windows) == detector_windows_after
+
+    # --- Assert the on-disk recording spans charge→stop, FC inside it. ---
+    import json
+    import wave
+
+    wav_path = recorder.wav_path
+    assert wav_path.exists()
+    with wave.open(str(wav_path), "rb") as wav_file:
+        wav_frames = wav_file.getnframes()
+        wav_rate = wav_file.getframerate()
+    recorded_seconds = wav_frames / wav_rate
+    # The WAV holds the full pre-FC + post-FC audio, not a charge→FC slice.
+    assert wav_frames >= frames_after_fc
+    assert wav_frames > frames_at_fc
+
+    sidecar = json.loads(recorder.sidecar_path.read_text())
+    fc_offset = sidecar["milestones"]["first_crack"]
+    assert fc_offset is not None, "first crack milestone must be written"
+    # First crack sits INSIDE the recording, with a real post-FC tail after it.
+    assert 0.0 <= fc_offset < recorded_seconds
+    assert recorded_seconds - fc_offset > 0.1, "a post-FC tail must follow first crack in the WAV"
+
+    # Finalisation wrote BOTH JSONs: the recording sidecar and the annotation
+    # session JSON for the coffee-first-crack-detection pipeline.
+    annotation_path = recorder.sidecar_path.parent / f"{session.id}-roast0-session.json"
+    assert annotation_path.exists(), "annotation session JSON must be written at finalisation"
+    annotation = json.loads(annotation_path.read_text())
+    assert annotation["mics"][0]["file"] == wav_path.name

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -923,6 +923,8 @@ def test_get_roast_state_scopes_runtime_metrics_to_requested_session(tmp_path: P
             emitted_window_count=3,
             dropped_window_count=4,
             processed_window_count=5,
+            mic_peak_dbfs=-6.02,
+            mic_rms_dbfs=-9.03,
         ),
     )
     server = create_mcp_server(config_path=config_path)
@@ -948,6 +950,9 @@ def test_get_roast_state_scopes_runtime_metrics_to_requested_session(tmp_path: P
     assert first_state.first_crack_status.emitted_window_count == 0
     assert first_state.first_crack_status.dropped_window_count == 0
     assert first_state.first_crack_status.processed_window_count == 0
+    # The inactive session reports no live mic levels (#178).
+    assert first_state.first_crack_status.mic_peak_dbfs is None
+    assert first_state.first_crack_status.mic_rms_dbfs is None
 
     second_state = _call_tool(
         server,
@@ -961,6 +966,10 @@ def test_get_roast_state_scopes_runtime_metrics_to_requested_session(tmp_path: P
     assert second_state.first_crack_status.emitted_window_count == 3
     assert second_state.first_crack_status.dropped_window_count == 4
     assert second_state.first_crack_status.processed_window_count == 5
+    # The live mic levels surface in the runtime readout (#178) so a mis-gained
+    # or dead mic is visible under real conditions.
+    assert second_state.first_crack_status.mic_peak_dbfs == -6.02
+    assert second_state.first_crack_status.mic_rms_dbfs == -9.03
 
 
 def test_driver_command_failure_does_not_mutate_session_state(tmp_path: Path) -> None:
@@ -1518,6 +1527,8 @@ class FakeFirstCrackRuntime:
         emitted_window_count: int = 0,
         dropped_window_count: int = 0,
         processed_window_count: int = 0,
+        mic_peak_dbfs: float | None = None,
+        mic_rms_dbfs: float | None = None,
     ) -> None:
         self.status = status
         self.reason = reason
@@ -1527,6 +1538,8 @@ class FakeFirstCrackRuntime:
         self.emitted_window_count = emitted_window_count
         self.dropped_window_count = dropped_window_count
         self.processed_window_count = processed_window_count
+        self.mic_peak_dbfs = mic_peak_dbfs
+        self.mic_rms_dbfs = mic_rms_dbfs
         self.active_session_id: str | None = None
         self.started_sessions: list[str] = []
         self.processed_sessions: list[str] = []
@@ -1583,6 +1596,8 @@ class FakeFirstCrackRuntime:
             emitted_window_count=self.emitted_window_count,
             dropped_window_count=self.dropped_window_count,
             processed_window_count=self.processed_window_count,
+            mic_peak_dbfs=self.mic_peak_dbfs,
+            mic_rms_dbfs=self.mic_rms_dbfs,
         )
 
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -76,6 +76,8 @@ _EXPECTED_FIRST_CRACK_STATUS_KEYS = {
     "detected_monotonic_seconds",
     "dropped_window_count",
     "emitted_window_count",
+    "mic_peak_dbfs",
+    "mic_rms_dbfs",
     "mode",
     "processed_window_count",
     "queued_window_count",
@@ -94,7 +96,7 @@ _EXPECTED_T0_STATUS_KEYS = {
 
 
 def test_version_is_defined() -> None:
-    assert __version__ == "0.1.10"
+    assert __version__ == "0.1.11"
 
 
 def test_cli_parser_program_name() -> None:


### PR DESCRIPTION
## 0.1.11 — recordings now span the full roast + a live mic-levels readout

### #181 — recorder captures charge→drop, not charge→FC
The recorder was owned by the `AudioCapturePipeline`, which the FC runtime stopped the instant FC was confirmed (`_stop_locked("first crack detected")`), so recordings ended at FC. Now FC stops **inference only** (a new `_inference_stopped` flag; `_can_process_locked` bails so no further `drain`/`detect`), while the **capture worker keeps teeing to the WAVs**; the pipeline + recorder finalise at `stop_for_session` (the real roast end). The independent ATR2100x stream likewise runs to session end.

**Why it matters (auggie-confirmed cross-repo):** `coffee-first-crack-detection/chunk_audio.py` slides a window across the **full** recording and labels by overlap with the FC region — everything else is the negative class (~80% of the dataset). Truncating at FC discarded most of the no-FC training data; the post-FC tail is exactly what the pipeline wants.

**Soak (no roaster):** a runtime-API session with the real capture pipeline teeing a real recorder — FC milestone lands 0.04 s in, capture continues to a **232 s WAV with a ~232 s post-FC tail**, both sidecar JSONs written, detector saw only the 1 confirming window. Asserts strict post-FC growth.

### #178 — live in-session mic levels
A `_RollingLevelMeter` (vectorised, fed the detector's blocks, bounded to the recent window) surfaces `peak_dbfs`/`rms_dbfs` through `AudioCaptureSnapshot` → `FirstCrackRuntimeSnapshot` → `FirstCrackStatus` (the `get_roast_state` readout). `None` pre-samples, `-inf` for a dead mic — so a mis-gained/dead mic is visible under *real* roasting levels. Observability-only; agent ignores the new fields (`extra="ignore"`, auggie-confirmed).

### Gates
ruff / ruff format / pyright (strict, 0 errors, default + latest) / pytest 479 passed, coverage 90.62%.

Closes #181 · Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)