### PR TITLE
feat(#185): ambient environmental sensor (Yocto-Meteo-V2-C) in session state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,15 +73,21 @@ python -c "import os, tempfile; from coffee_roaster_mcp.config import load_confi
 
 ```text
 src/coffee_roaster_mcp/
-  __init__.py     - package version
-  cli.py          - console entrypoint
-  config.py       - typed configuration loading from defaults, YAML, and env vars
-  mcp_server.py   - FastMCP stdio entrypoint and bootstrap-safe tools
-  session.py      - authoritative roast session lifecycle, event timeline, and active-session owner
+  __init__.py         - package version
+  cli.py              - console entrypoint
+  config.py           - typed configuration loading from defaults, YAML, and env vars
+  mcp_server.py       - FastMCP stdio entrypoint and bootstrap-safe tools
+  session.py          - authoritative roast session lifecycle, event timeline, and active-session owner
+  ambient.py          - Yoctopuce Yocto-Meteo ambient sensor reader (#185), mirrors audio.py's
+                        lazy-load pattern; read-only, no roaster-write involvement
+  ambient_runtime.py  - session-owned ambient runtime (#185): lazy-refresh-with-staleness cache,
+                        fail-soft on any probe error, mirrors first_crack_runtime.py's shape
 tests/
-  test_package.py - package and CLI smoke coverage
-  test_config.py  - config defaults, YAML, env override, and validation coverage
-  test_session.py - roast session lifecycle and active-session ownership coverage
+  test_package.py         - package and CLI smoke coverage
+  test_config.py          - config defaults, YAML, env override, and validation coverage
+  test_session.py         - roast session lifecycle and active-session ownership coverage
+  test_ambient.py         - Yocto-Meteo reader unit coverage, incl. missing-runtime fail-soft
+  test_ambient_runtime.py - ambient runtime fail-soft + poll-caching coverage
 docs/state/
   registry.md     - active project state pointer
   epics/          - durable epic and story state

--- a/docs/release.md
+++ b/docs/release.md
@@ -10,6 +10,23 @@ The release workflow is `.github/workflows/release.yml`. It supports two paths:
 
 ## Changelog
 
+### 0.1.12
+
+- feat(#185): ambient environmental sensor — read a Yoctopuce Yocto-Meteo-V2-C
+  USB probe (temperature / relative humidity / barometric pressure) as an
+  MCP-owned device, mirroring the first-crack microphone pipeline. The triad
+  rides the existing `get_roast_state` session state as `ambient_status`
+  (mode / status / `temperature_c` / `humidity_percent` / `pressure_hpa` +
+  liveness), so no new tool is added. Default `ambient.mode: disabled` — zero
+  behaviour change for existing configs. **Fail-soft**: an absent, unplugged,
+  or erroring probe (or a missing `yoctopuce` package) reports `unavailable`
+  with null readings and never blocks or faults a roast. The reader is
+  lazy-loaded and polled at most once per `poll_interval_seconds` (default 30 s)
+  so the USB bus is never hit at the 1 Hz state-read rate; the last-known-good
+  reading is preserved across a transient read error. Adds the `yoctopuce`
+  runtime dependency. Agent-side consumer: roastpilot-agent#342 (revises D60 →
+  D85: ambient is MCP-owned, mirroring the mic).
+
 ### 0.1.6
 
 - fix(#163): `drop_beans` keeps the drum running so beans eject; `stop_cooling`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dependencies = [
   "pyserial>=3.5",
   "PyYAML>=6.0.2",
   "sounddevice>=0.5,<1",
-  "transformers>=4.40,<5"
+  "transformers>=4.40,<5",
+  "yoctopuce>=2.0,<3"
 ]
 
 [project.urls]

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.syamaner/coffee-roaster-mcp",
   "title": "RoastPilot",
   "description": "RoastPilot controls coffee roasting sessions through local stdio MCP tools and exports logs.",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "websiteUrl": "https://github.com/syamaner/coffee-roaster-mcp#readme",
   "repository": {
     "url": "https://github.com/syamaner/coffee-roaster-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "coffee-roaster-mcp",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "runtimeHint": "uvx",
       "packageArguments": [
         {

--- a/src/coffee_roaster_mcp/__init__.py
+++ b/src/coffee_roaster_mcp/__init__.py
@@ -1,3 +1,3 @@
 """RoastPilot MCP server package."""
 
-__version__ = "0.1.11"
+__version__ = "0.1.12"

--- a/src/coffee_roaster_mcp/ambient.py
+++ b/src/coffee_roaster_mcp/ambient.py
@@ -1,0 +1,221 @@
+"""Ambient environmental sensor reading (#185).
+
+Mirrors the first-crack microphone pipeline exactly: an MCP-owned USB device
+(Yoctopuce Yocto-Meteo-V2-C) read for temperature, relative humidity, and
+barometric pressure. Read-only, corpus-metadata for the roast record — no
+roaster-write or control-loop involvement. Fail-soft by design: an absent,
+unplugged, or erroring probe never blocks or faults a roast.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from coffee_roaster_mcp.config import AmbientConfig
+
+DEFAULT_AMBIENT_HUB_URL = "usb"
+
+
+class AmbientReaderError(RuntimeError):
+    """Raised when an ambient sensor reading cannot be obtained."""
+
+
+@dataclass(frozen=True)
+class AmbientReading:
+    """One ambient environmental reading.
+
+    Attributes:
+        temperature_c: Ambient (room) temperature in Celsius.
+        humidity_percent: Relative humidity as a percentage (0-100).
+        pressure_hpa: Barometric pressure in hectopascals.
+        monotonic_seconds: Monotonic clock timestamp when the reading was taken.
+    """
+
+    temperature_c: float
+    humidity_percent: float
+    pressure_hpa: float
+    monotonic_seconds: float
+
+
+class AmbientReader(Protocol):
+    """Readable ambient sensor source."""
+
+    def read(self) -> AmbientReading:
+        """Return one fresh ambient reading, or raise `AmbientReaderError`."""
+        ...
+
+
+class AmbientReaderFactory(Protocol):
+    """Factory for configured ambient readers."""
+
+    def __call__(self, config: AmbientConfig) -> AmbientReader:
+        """Create an ambient reader for the supplied configuration."""
+        ...
+
+
+class YoctoMeteoAmbientReader:
+    """Read temperature/humidity/pressure from a Yoctopuce Yocto-Meteo-V2-C.
+
+    Lifecycle: `YAPI.RegisterHub("usb")` is called once, lazily, on the first
+    read and left registered for the life of this reader instance (mirroring
+    how `MicrophoneAudioInput` opens its stream lazily and keeps it open across
+    reads). Registering per read would repeatedly re-enumerate the USB bus for
+    no benefit, since only one process may hold direct USB access to Yoctopuce
+    devices at a time; a single long-lived registration is the simpler correct
+    choice and matches the poll-interval-bounded read cadence. `close()` calls
+    `YAPI.FreeAPI()` to release the hub registration cleanly.
+    """
+
+    def __init__(
+        self,
+        config: AmbientConfig,
+        *,
+        yoctopuce_api_module: Any | None = None,
+        yoctopuce_temperature_module: Any | None = None,
+        yoctopuce_humidity_module: Any | None = None,
+        yoctopuce_pressure_module: Any | None = None,
+    ) -> None:
+        """Configure a Yocto-Meteo reader that registers its USB hub lazily.
+
+        Args:
+            config: Validated ambient sensor configuration.
+            yoctopuce_api_module: Optional injected `yoctopuce.yocto_api`-compatible
+                module for tests.
+            yoctopuce_temperature_module: Optional injected
+                `yoctopuce.yocto_temperature`-compatible module for tests.
+            yoctopuce_humidity_module: Optional injected
+                `yoctopuce.yocto_humidity`-compatible module for tests.
+            yoctopuce_pressure_module: Optional injected
+                `yoctopuce.yocto_pressure`-compatible module for tests.
+        """
+        self._config = config
+        self._yocto_api = yoctopuce_api_module or _load_yoctopuce("yocto_api")
+        self._yocto_temperature = yoctopuce_temperature_module or _load_yoctopuce(
+            "yocto_temperature"
+        )
+        self._yocto_humidity = yoctopuce_humidity_module or _load_yoctopuce("yocto_humidity")
+        self._yocto_pressure = yoctopuce_pressure_module or _load_yoctopuce("yocto_pressure")
+        self._hub_registered = False
+
+    def _ensure_hub_registered(self) -> None:
+        if self._hub_registered:
+            return
+        yapi = self._yocto_api.YAPI
+        errmsg = self._yocto_api.YRefParam()
+        try:
+            result = yapi.RegisterHub(DEFAULT_AMBIENT_HUB_URL, errmsg)
+        except Exception as exc:  # noqa: BLE001 - native backend exceptions vary.
+            raise AmbientReaderError(f"Could not register the Yoctopuce USB hub: {exc}") from exc
+        if yapi.YISERR(result):
+            raise AmbientReaderError(f"Could not register the Yoctopuce USB hub: {errmsg.value}")
+        self._hub_registered = True
+
+    def _function_selector(self, sensor_suffix: str) -> str | None:
+        """Return an explicit `FindXxx` selector, or `None` to use the first device."""
+        if self._config.device is None:
+            return None
+        return f"{self._config.device}.{sensor_suffix}"
+
+    def read(self) -> AmbientReading:
+        """Read one fresh temperature/humidity/pressure reading from the probe."""
+        try:
+            self._ensure_hub_registered()
+            temperature_sensor = self._resolve_sensor(
+                self._yocto_temperature.YTemperature,
+                sensor_suffix="temperature",
+            )
+            humidity_sensor = self._resolve_sensor(
+                self._yocto_humidity.YHumidity,
+                sensor_suffix="humidity",
+            )
+            pressure_sensor = self._resolve_sensor(
+                self._yocto_pressure.YPressure,
+                sensor_suffix="pressure",
+            )
+            temperature_c = self._current_value(temperature_sensor, label="temperature")
+            humidity_percent = self._current_value(humidity_sensor, label="humidity")
+            pressure_hpa = self._current_value(pressure_sensor, label="pressure")
+        except AmbientReaderError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - native backend exceptions vary.
+            raise AmbientReaderError(f"Could not read the Yocto-Meteo probe: {exc}") from exc
+        return AmbientReading(
+            temperature_c=temperature_c,
+            humidity_percent=humidity_percent,
+            pressure_hpa=pressure_hpa,
+            monotonic_seconds=time.monotonic(),
+        )
+
+    def _resolve_sensor(self, sensor_class: Any, *, sensor_suffix: str) -> Any:
+        selector = self._function_selector(sensor_suffix)
+        sensor = (
+            self._find_sensor(sensor_class, sensor_suffix, selector)
+            if selector is not None
+            else self._first_sensor(sensor_class, sensor_suffix)
+        )
+        if sensor is None or not sensor.isOnline():
+            raise AmbientReaderError(f"No online Yocto-Meteo {sensor_suffix} sensor was found.")
+        return sensor
+
+    def _find_sensor(self, sensor_class: Any, sensor_suffix: str, selector: str) -> Any:
+        if sensor_suffix == "temperature":
+            return sensor_class.FindTemperature(selector)
+        if sensor_suffix == "humidity":
+            return sensor_class.FindHumidity(selector)
+        return sensor_class.FindPressure(selector)
+
+    def _first_sensor(self, sensor_class: Any, sensor_suffix: str) -> Any:
+        if sensor_suffix == "temperature":
+            return sensor_class.FirstTemperature()
+        if sensor_suffix == "humidity":
+            return sensor_class.FirstHumidity()
+        return sensor_class.FirstPressure()
+
+    def _current_value(self, sensor: Any, *, label: str) -> float:
+        value = sensor.get_currentValue()
+        invalid = getattr(sensor, "CURRENTVALUE_INVALID", None)
+        if invalid is not None and value == invalid:
+            raise AmbientReaderError(f"Yocto-Meteo {label} reading is invalid.")
+        return float(value)
+
+    def close(self) -> None:
+        """Release the Yoctopuce USB hub registration, if held.
+
+        Idempotent: safe to call multiple times or on a reader that never
+        successfully registered a hub.
+        """
+        if not self._hub_registered:
+            return
+        try:
+            self._yocto_api.YAPI.FreeAPI()
+        finally:
+            self._hub_registered = False
+
+
+def build_configured_ambient_reader(config: AmbientConfig) -> AmbientReader:
+    """Create the concrete configured ambient reader.
+
+    Args:
+        config: Validated ambient sensor configuration.
+
+    Returns:
+        A configured `AmbientReader`.
+
+    Raises:
+        AmbientReaderError: If `config.mode` is not a supported reader mode.
+    """
+    if config.mode == "yoctopuce":
+        return YoctoMeteoAmbientReader(config)
+    raise AmbientReaderError(f"Unsupported ambient sensor mode: {config.mode}")
+
+
+def _load_yoctopuce(module_name: str) -> Any:
+    try:
+        return importlib.import_module(f"yoctopuce.{module_name}")
+    except (ImportError, OSError) as exc:
+        raise AmbientReaderError(
+            "Ambient sensor input requires the yoctopuce package and its native runtime."
+        ) from exc

--- a/src/coffee_roaster_mcp/ambient_runtime.py
+++ b/src/coffee_roaster_mcp/ambient_runtime.py
@@ -1,0 +1,239 @@
+"""Session-owned ambient sensor runtime orchestration (#185).
+
+Mirrors the shape of `first_crack_runtime.FirstCrackSessionRuntime`, simplified
+for a periodically-polled sensor rather than a streaming detector: there is no
+audio pipeline, no windowing, and no detector adapter. The runtime owns a
+lazy-refresh-with-staleness cache so `get_roast_state` (polled at ~1 Hz by the
+agent) never hits the USB bus more than once per `poll_interval_seconds`, and
+every read is fail-soft: an absent, unplugged, or erroring probe moves the
+runtime to `unavailable` and is never allowed to raise out of the session-read
+hot path.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from threading import RLock
+from typing import Literal
+
+from coffee_roaster_mcp.ambient import (
+    AmbientReader,
+    AmbientReaderError,
+    AmbientReading,
+    build_configured_ambient_reader,
+)
+from coffee_roaster_mcp.config import AmbientConfig, AppConfig
+from coffee_roaster_mcp.session import RoastSession
+
+_LOGGER = logging.getLogger(__name__)
+
+AmbientRuntimeState = Literal["disabled", "ok", "unavailable"]
+
+AmbientReaderFactory = Callable[[AmbientConfig], AmbientReader]
+
+
+@dataclass(frozen=True)
+class AmbientRuntimeSnapshot:
+    """MCP-visible ambient runtime status.
+
+    Attributes:
+        status: Current runtime state.
+        active_session_id: Session id that owns the runtime, if any.
+        reason: Human-readable status detail.
+        ambient_running: Whether the runtime is prepared to poll readings for
+            the owning session (mirrors `audio_running` in the FC snapshot).
+        temperature_c: Last-known ambient temperature in Celsius, or `None`.
+        humidity_percent: Last-known relative humidity percentage, or `None`.
+        pressure_hpa: Last-known barometric pressure in hectopascals, or `None`.
+        last_reading_monotonic_seconds: Monotonic timestamp of the last
+            successful reading, or `None` if none has ever succeeded.
+    """
+
+    status: AmbientRuntimeState
+    active_session_id: str | None
+    reason: str | None = None
+    ambient_running: bool = False
+    temperature_c: float | None = None
+    humidity_percent: float | None = None
+    pressure_hpa: float | None = None
+    last_reading_monotonic_seconds: float | None = None
+
+
+class AmbientSessionRuntime:
+    """Own ambient sensor polling for roast sessions.
+
+    Read-only and fail-soft by design: no method here ever raises out to a
+    caller on the state-read path. A configuration or hardware problem is
+    always surfaced as an `unavailable` snapshot instead.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: AppConfig,
+        reader_factory: AmbientReaderFactory | None = None,
+        monotonic_now: Callable[[], float] | None = None,
+    ) -> None:
+        """Initialize a session-owned ambient runtime.
+
+        Args:
+            config: Application configuration.
+            reader_factory: Optional test double for ambient reader construction.
+            monotonic_now: Optional monotonic clock supplier for tests.
+        """
+        self._config = config
+        self._reader_factory = reader_factory or build_configured_ambient_reader
+        self._monotonic_now = monotonic_now or time.monotonic
+        self._lock = RLock()
+        self._active_session_id: str | None = None
+        self._reader: AmbientReader | None = None
+        self._status: AmbientRuntimeState = _initial_status(config.ambient)
+        self._reason: str | None = _initial_reason(config.ambient)
+        self._last_reading: AmbientReading | None = None
+        self._last_refresh_monotonic_seconds: float | None = None
+
+    def start_for_session(self, session: RoastSession) -> AmbientRuntimeSnapshot:
+        """Start or prepare ambient sensing for a roast session.
+
+        Fail-soft: any reader-construction error (missing dependency, no
+        device present) is caught here and reported as `unavailable` rather
+        than raised, so a roast session always starts regardless of probe
+        health.
+        """
+        with self._lock:
+            self._active_session_id = session.id
+            self._last_reading = None
+            self._last_refresh_monotonic_seconds = None
+            self._reader = None
+
+            if self._config.ambient.mode == "disabled":
+                self._status = "disabled"
+                self._reason = "Ambient sensing is disabled by configuration."
+                return self.snapshot()
+
+            try:
+                self._reader = self._reader_factory(self._config.ambient)
+            except AmbientReaderError as exc:
+                self._status = "unavailable"
+                self._reason = f"Ambient sensor is unavailable: {exc}"
+                self._reader = None
+                return self.snapshot()
+            except Exception as exc:  # noqa: BLE001 - dependency backends vary.
+                self._status = "unavailable"
+                self._reason = f"Ambient sensor could not be prepared: {type(exc).__name__}: {exc}"
+                self._reader = None
+                return self.snapshot()
+
+            self._status = "ok"
+            self._reason = None
+            return self.snapshot()
+
+    def poll(self) -> AmbientRuntimeSnapshot:
+        """Refresh the cached reading if the poll interval has elapsed.
+
+        Bounded, fail-soft refresh intended to be called from the
+        `get_roast_state` hot path: a read is only attempted once per
+        `poll_interval_seconds`, and any read failure demotes the runtime to
+        `unavailable` while preserving the last-known-good reading in the
+        snapshot rather than raising.
+        """
+        with self._lock:
+            if self._config.ambient.mode == "disabled" or self._reader is None:
+                return self.snapshot()
+
+            now = self._monotonic_now()
+            if (
+                self._last_refresh_monotonic_seconds is not None
+                and now - self._last_refresh_monotonic_seconds
+                < self._config.ambient.poll_interval_seconds
+            ):
+                return self.snapshot()
+
+            try:
+                reading = self._reader.read()
+            except AmbientReaderError as exc:
+                self._last_refresh_monotonic_seconds = now
+                self._status = "unavailable"
+                self._reason = f"Ambient sensor read failed: {exc}"
+                _LOGGER.warning("Ambient sensor read failed: %s", exc)
+                return self.snapshot()
+            except Exception as exc:  # noqa: BLE001 - dependency backends vary.
+                self._last_refresh_monotonic_seconds = now
+                self._status = "unavailable"
+                self._reason = f"Ambient sensor read failed: {type(exc).__name__}: {exc}"
+                _LOGGER.warning("Ambient sensor read failed: %s", exc)
+                return self.snapshot()
+
+            self._last_refresh_monotonic_seconds = now
+            self._last_reading = reading
+            self._status = "ok"
+            self._reason = None
+            return self.snapshot()
+
+    def stop_for_session(self, session_id: str, *, reason: str) -> AmbientRuntimeSnapshot:
+        """Stop ambient sensing if it belongs to the supplied session."""
+        with self._lock:
+            if self._active_session_id != session_id:
+                return self.snapshot()
+            self._stop_locked(reason=reason)
+            return self.snapshot()
+
+    def shutdown(self) -> AmbientRuntimeSnapshot:
+        """Stop any active ambient runtime for process shutdown."""
+        with self._lock:
+            self._stop_locked(reason="process shutdown")
+            return self.snapshot()
+
+    def snapshot(self) -> AmbientRuntimeSnapshot:
+        """Return an MCP-visible runtime snapshot."""
+        with self._lock:
+            reading = self._last_reading
+            return AmbientRuntimeSnapshot(
+                status=self._status,
+                active_session_id=self._active_session_id,
+                reason=self._reason,
+                ambient_running=self._reader is not None,
+                temperature_c=reading.temperature_c if reading is not None else None,
+                humidity_percent=reading.humidity_percent if reading is not None else None,
+                pressure_hpa=reading.pressure_hpa if reading is not None else None,
+                last_reading_monotonic_seconds=(
+                    reading.monotonic_seconds if reading is not None else None
+                ),
+            )
+
+    def _stop_locked(self, *, reason: str) -> None:
+        reader = self._reader
+        if reader is not None:
+            close = getattr(reader, "close", None)
+            if close is not None:
+                try:
+                    close()
+                except Exception as exc:  # noqa: BLE001 - shutdown should be best effort.
+                    _LOGGER.warning("Ambient sensor close failed: %s", exc)
+        self._reader = None
+        if self._status == "ok":
+            self._reason = f"Ambient sensing stopped: {reason}."
+
+
+def build_ambient_session_runtime(
+    config: AppConfig,
+    *,
+    reader_factory: AmbientReaderFactory | None = None,
+) -> AmbientSessionRuntime:
+    """Build the configured session-owned ambient runtime."""
+    return AmbientSessionRuntime(config=config, reader_factory=reader_factory)
+
+
+def _initial_status(config: AmbientConfig) -> AmbientRuntimeState:
+    if config.mode == "disabled":
+        return "disabled"
+    return "unavailable"
+
+
+def _initial_reason(config: AmbientConfig) -> str | None:
+    if config.mode == "disabled":
+        return "Ambient sensing is disabled by configuration."
+    return "Ambient sensing has not started."

--- a/src/coffee_roaster_mcp/config.py
+++ b/src/coffee_roaster_mcp/config.py
@@ -18,6 +18,7 @@ ModelPrecision = Literal["int8", "fp32"]
 AudioSource = Literal["microphone", "wav"]
 AudioReplayMode = Literal["realtime", "detector_paced"]
 ExportFormat = Literal["jsonl", "csv", "summary"]
+AmbientMode = Literal["disabled", "yoctopuce"]
 
 
 @dataclass(frozen=True)
@@ -97,6 +98,32 @@ class AudioConfig:
 
 
 @dataclass(frozen=True)
+class AmbientConfig:
+    """Ambient environmental sensor configuration (#185).
+
+    Mirrors the first-crack microphone pipeline: an MCP-owned USB device that
+    is read-only, has no roaster-write or control-loop involvement, and is
+    disabled by default so existing configs are unchanged. Corpus-metadata for
+    the roast record (Yoctopuce Yocto-Meteo-V2-C: temperature, relative
+    humidity, barometric pressure).
+
+    Attributes:
+        mode: Ambient sensor mode: `disabled` or `yoctopuce`.
+        device: Optional Yoctopuce module serial number or logical name to
+            target a specific probe. When unset, the first detected Yocto
+            Meteo device is used.
+        poll_interval_seconds: Minimum seconds between USB reads. The runtime
+            caches the last reading and refreshes at most once per interval
+            when polled from the state-read path, so the USB bus is never hit
+            on every 1 Hz `get_roast_state` call.
+    """
+
+    mode: AmbientMode = "disabled"
+    device: str | None = None
+    poll_interval_seconds: float = 30.0
+
+
+@dataclass(frozen=True)
 class LoggingConfig:
     """Roast logging configuration."""
 
@@ -172,6 +199,7 @@ class AppConfig:
     roaster: RoasterConfig = field(default_factory=RoasterConfig)
     first_crack: FirstCrackConfig = field(default_factory=FirstCrackConfig)
     audio: AudioConfig = field(default_factory=AudioConfig)
+    ambient: AmbientConfig = field(default_factory=AmbientConfig)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
     recording: RecordingConfig = field(default_factory=RecordingConfig)
     session: SessionConfig = field(default_factory=SessionConfig)
@@ -249,6 +277,7 @@ def _config_from_mapping(raw_config: Mapping[str, Any], source_path: Path | None
         roaster=_roaster_from_mapping(_section(raw_config, "roaster")),
         first_crack=_first_crack_from_mapping(_section(raw_config, "first_crack")),
         audio=_audio_from_mapping(_section(raw_config, "audio")),
+        ambient=_ambient_from_mapping(_section(raw_config, "ambient")),
         logging=_logging_from_mapping(_section(raw_config, "logging")),
         recording=_recording_from_mapping(_section(raw_config, "recording")),
         session=_session_from_mapping(_section(raw_config, "session")),
@@ -372,6 +401,22 @@ def _audio_from_mapping(raw: Mapping[str, Any]) -> AudioConfig:
     )
 
 
+def _ambient_from_mapping(raw: Mapping[str, Any]) -> AmbientConfig:
+    return AmbientConfig(
+        mode=_ambient_mode(
+            _string(raw, "mode", "disabled", label="ambient.mode"),
+            label="ambient.mode",
+        ),
+        device=_optional_string(raw, "device", label="ambient.device"),
+        poll_interval_seconds=_positive_float(
+            raw,
+            "poll_interval_seconds",
+            30.0,
+            label="ambient.poll_interval_seconds",
+        ),
+    )
+
+
 def _logging_from_mapping(raw: Mapping[str, Any]) -> LoggingConfig:
     return LoggingConfig(
         log_dir=_path(raw, "log_dir", Path("./logs"), label="logging.log_dir"),
@@ -438,6 +483,7 @@ def _apply_env_overrides(config: AppConfig, environ: Mapping[str, str]) -> AppCo
     roaster = config.roaster
     first_crack = config.first_crack
     audio = config.audio
+    ambient = config.ambient
     logging = config.logging
     recording = config.recording
 
@@ -581,6 +627,22 @@ def _apply_env_overrides(config: AppConfig, environ: Mapping[str, str]) -> AppCo
         window_label="COFFEE_AUDIO_WINDOW_SECONDS",
     )
 
+    if "COFFEE_AMBIENT_MODE" in environ:
+        ambient = replace(
+            ambient,
+            mode=_ambient_mode(environ["COFFEE_AMBIENT_MODE"], label="COFFEE_AMBIENT_MODE"),
+        )
+    if "COFFEE_AMBIENT_DEVICE" in environ:
+        ambient = replace(ambient, device=_none_if_empty(environ["COFFEE_AMBIENT_DEVICE"]))
+    if "COFFEE_AMBIENT_POLL_INTERVAL_SECONDS" in environ:
+        ambient = replace(
+            ambient,
+            poll_interval_seconds=_parse_positive_float(
+                environ["COFFEE_AMBIENT_POLL_INTERVAL_SECONDS"],
+                "COFFEE_AMBIENT_POLL_INTERVAL_SECONDS",
+            ),
+        )
+
     if "COFFEE_ROAST_LOG_DIR" in environ:
         logging = replace(
             logging,
@@ -637,6 +699,7 @@ def _apply_env_overrides(config: AppConfig, environ: Mapping[str, str]) -> AppCo
         roaster=roaster,
         first_crack=first_crack,
         audio=audio,
+        ambient=ambient,
         logging=logging,
         recording=recording,
         session=session,
@@ -929,6 +992,13 @@ def _audio_replay_mode(value: str, label: str = "audio.replay_mode") -> AudioRep
     if normalized not in {"realtime", "detector_paced"}:
         raise ConfigError(f"{label} must be one of: realtime, detector_paced.")
     return cast(AudioReplayMode, normalized)
+
+
+def _ambient_mode(value: str, label: str = "ambient.mode") -> AmbientMode:
+    normalized = _normalized_token(value)
+    if normalized not in {"disabled", "yoctopuce"}:
+        raise ConfigError(f"{label} must be one of: disabled, yoctopuce.")
+    return cast(AmbientMode, normalized)
 
 
 def _export_formats(value: object) -> tuple[ExportFormat, ...]:

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -16,7 +16,18 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 
 from coffee_roaster_mcp import __version__
-from coffee_roaster_mcp.config import AppConfig, ConfigError, FirstCrackMode, load_config
+from coffee_roaster_mcp.ambient_runtime import (
+    AmbientRuntimeSnapshot,
+    AmbientSessionRuntime,
+    build_ambient_session_runtime,
+)
+from coffee_roaster_mcp.config import (
+    AmbientMode,
+    AppConfig,
+    ConfigError,
+    FirstCrackMode,
+    load_config,
+)
 from coffee_roaster_mcp.drivers import RoasterDriver, RoasterState, create_roaster_driver
 from coffee_roaster_mcp.exports import export_roast_snapshot
 from coffee_roaster_mcp.first_crack_runtime import (
@@ -47,6 +58,7 @@ class ServerContext:
         session_store: Authoritative in-process roast session owner.
         roaster_driver: Configured driver boundary.
         first_crack_runtime: Session-owned first-crack detector runtime.
+        ambient_runtime: Session-owned ambient sensor runtime (#185).
         telemetry_sampler: Session-owned autonomous telemetry sampler.
         started_at_utc: UTC time when the MCP process initialized.
     """
@@ -56,6 +68,7 @@ class ServerContext:
     session_store: RoastSessionStore
     roaster_driver: RoasterDriver
     first_crack_runtime: FirstCrackSessionRuntime
+    ambient_runtime: AmbientSessionRuntime
     telemetry_sampler: _TelemetrySampler
     started_at_utc: datetime
 
@@ -242,6 +255,8 @@ FirstCrackRuntimeStatus = Literal[
     "unavailable",
 ]
 
+AmbientRuntimeStatus = Literal["disabled", "unavailable", "ok"]
+
 
 @dataclass(frozen=True)
 class RoasterDeviceState:
@@ -306,6 +321,38 @@ class FirstCrackStatus:
     mic_rms_dbfs: float | None = None
 
 
+@dataclass(frozen=True)
+class AmbientStatus:
+    """Serializable ambient sensor status for the roast record (#185).
+
+    Read-only corpus metadata: no roaster-write or control-loop involvement.
+    Fail-soft by design — an absent, unplugged, or erroring probe always
+    reports `unavailable` with null readings rather than raising or blocking
+    the roast.
+
+    Attributes:
+        mode: Configured ambient sensor mode.
+        status: Current ambient runtime status.
+        reason: Human-readable reason when status needs extra context.
+        ambient_running: Whether the session-owned ambient runtime is prepared
+            to poll readings.
+        temperature_c: Last-known ambient temperature in Celsius, or `None`.
+        humidity_percent: Last-known relative humidity percentage, or `None`.
+        pressure_hpa: Last-known barometric pressure in hectopascals, or `None`.
+        last_reading_monotonic_seconds: Monotonic timestamp of the last
+            successful reading, or `None` if none has ever succeeded.
+    """
+
+    mode: AmbientMode
+    status: AmbientRuntimeStatus
+    reason: str | None = None
+    ambient_running: bool = False
+    temperature_c: float | None = None
+    humidity_percent: float | None = None
+    pressure_hpa: float | None = None
+    last_reading_monotonic_seconds: float | None = None
+
+
 T0RuntimeStatus = Literal["disabled", "pending", "detected", "unavailable"]
 
 
@@ -367,6 +414,7 @@ class RoastSessionState:
     device_state: RoasterDeviceState | None
     t0_status: T0Status
     first_crack_status: FirstCrackStatus
+    ambient_status: AmbientStatus
     events: tuple[EventSnapshot, ...]
     log_dir: str | None
 
@@ -470,6 +518,7 @@ def build_server_context(
         ),
         roaster_driver=roaster_driver,
         first_crack_runtime=build_first_crack_session_runtime(config),
+        ambient_runtime=build_ambient_session_runtime(config),
         telemetry_sampler=telemetry_sampler,
         started_at_utc=datetime.now(UTC),
     )
@@ -500,6 +549,7 @@ def create_mcp_server(
         finally:
             server_context.telemetry_sampler.shutdown()
             server_context.first_crack_runtime.shutdown()
+            server_context.ambient_runtime.shutdown()
 
     mcp = FastMCP(
         name="RoastPilot",
@@ -584,12 +634,14 @@ def create_mcp_server(
             server_context.session_store.clear_session_start_reservation(reservation)
             raise
         _start_first_crack_runtime(server_context, session=session)
+        server_context.ambient_runtime.start_for_session(session)
         server_context.telemetry_sampler.start_for_session(session.id)
         return StartRoastSessionResult(
             session=_serialize_session_state(
                 session,
                 config=server_context.config,
                 first_crack_runtime=server_context.first_crack_runtime.snapshot(),
+                ambient_runtime=server_context.ambient_runtime.snapshot(),
             )
         )
 
@@ -620,12 +672,14 @@ def create_mcp_server(
                 reason="Dropped queued pre-T0 detector windows after automatic T0.",
             )
         _process_first_crack_runtime_for_active_session(server_context, session_id=session_id)
+        _process_ambient_runtime_for_active_session(server_context, session_id=session_id)
         session = _resolve_session(server_context, session_id=session_id)
         return _serialize_session_state(
             session,
             config=server_context.config,
             device_state=device_state,
             first_crack_runtime=server_context.first_crack_runtime.snapshot(),
+            ambient_runtime=server_context.ambient_runtime.snapshot(),
         )
 
     @mcp.tool()
@@ -712,6 +766,7 @@ def create_mcp_server(
         )
         if not snapshot.active:
             server_context.telemetry_sampler.stop_for_session(snapshot.id, reason="beans dropped")
+            server_context.ambient_runtime.stop_for_session(snapshot.id, reason="beans dropped")
         return _serialize_event_result(snapshot=snapshot, event=event)
 
     @mcp.tool()
@@ -744,6 +799,10 @@ def create_mcp_server(
             reason="cooling stopped",
         )
         server_context.telemetry_sampler.stop_for_session(
+            snapshot.id,
+            reason="cooling stopped",
+        )
+        server_context.ambient_runtime.stop_for_session(
             snapshot.id,
             reason="cooling stopped",
         )
@@ -794,6 +853,10 @@ def create_mcp_server(
             reason="emergency stop",
         )
         server_context.telemetry_sampler.stop_for_session(
+            snapshot.id,
+            reason="emergency stop",
+        )
+        server_context.ambient_runtime.stop_for_session(
             snapshot.id,
             reason="emergency stop",
         )
@@ -960,6 +1023,26 @@ def _process_first_crack_runtime_for_active_session(
         session_store=server_context.session_store,
         session=active_session,
     )
+
+
+def _process_ambient_runtime_for_active_session(
+    server_context: ServerContext,
+    *,
+    session_id: str | None,
+) -> None:
+    """Refresh the ambient sensor cache when the requested session is active.
+
+    The ambient runtime's own `poll` is already bounded by
+    `poll_interval_seconds` and fail-soft on read errors, so this is safe to
+    call on every `get_roast_state` tick without hitting the USB bus each time
+    or ever raising into the state-read hot path.
+    """
+    active_session = server_context.session_store.get_active_session()
+    if active_session is None:
+        return
+    if session_id is not None and session_id != active_session.id:
+        return
+    server_context.ambient_runtime.poll()
 
 
 def _process_auto_t0_for_active_session(
@@ -1289,6 +1372,10 @@ def _fault_active_session_after_sampler_failure(
         snapshot.id,
         reason="autonomous telemetry sampler failure",
     )
+    server_context.ambient_runtime.stop_for_session(
+        snapshot.id,
+        reason="autonomous telemetry sampler failure",
+    )
 
 
 def _serialize_session_state(
@@ -1297,6 +1384,7 @@ def _serialize_session_state(
     config: AppConfig,
     device_state: RoasterDeviceState | None = None,
     first_crack_runtime: FirstCrackRuntimeSnapshot | None = None,
+    ambient_runtime: AmbientRuntimeSnapshot | None = None,
 ) -> RoastSessionState:
     """Convert one in-memory session into an MCP-safe snapshot."""
     metrics = compute_roast_metrics(
@@ -1339,6 +1427,10 @@ def _serialize_session_state(
             session,
             config=config,
             first_crack_runtime=first_crack_runtime,
+        ),
+        ambient_status=_serialize_ambient_status(
+            config=config,
+            ambient_runtime=ambient_runtime,
         ),
         events=tuple(_serialize_event(event) for event in session.event_timeline),
         log_dir=str(session.log_writer.log_dir.resolve())
@@ -1500,6 +1592,43 @@ def _runtime_metrics(
         status="disabled",
         active_session_id=None,
         active=False,
+    )
+
+
+def _serialize_ambient_status(
+    *,
+    config: AppConfig,
+    ambient_runtime: AmbientRuntimeSnapshot | None,
+) -> AmbientStatus:
+    """Derive ambient sensor status from config and the runtime snapshot.
+
+    Simpler state machine than first-crack's: `disabled` (config off) →
+    `unavailable` (no runtime snapshot yet, or the probe could not be
+    prepared/read) → `ok` (a live cached reading is available). Read-only
+    corpus metadata, so there is no session-timeline-derived "detected" state
+    to branch on.
+    """
+    if config.ambient.mode == "disabled":
+        return AmbientStatus(
+            mode=config.ambient.mode,
+            status="disabled",
+            reason="Ambient sensing is disabled by configuration.",
+        )
+    if ambient_runtime is None:
+        return AmbientStatus(
+            mode=config.ambient.mode,
+            status="unavailable",
+            reason="Ambient sensing has not started.",
+        )
+    return AmbientStatus(
+        mode=config.ambient.mode,
+        status=ambient_runtime.status,
+        reason=ambient_runtime.reason,
+        ambient_running=ambient_runtime.ambient_running,
+        temperature_c=ambient_runtime.temperature_c,
+        humidity_percent=ambient_runtime.humidity_percent,
+        pressure_hpa=ambient_runtime.pressure_hpa,
+        last_reading_monotonic_seconds=ambient_runtime.last_reading_monotonic_seconds,
     )
 
 

--- a/tests/test_ambient.py
+++ b/tests/test_ambient.py
@@ -1,0 +1,298 @@
+"""Unit coverage for the Yoctopuce ambient sensor reader (#185)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from coffee_roaster_mcp import ambient as ambient_module
+from coffee_roaster_mcp.ambient import (
+    AmbientReaderError,
+    YoctoMeteoAmbientReader,
+    build_configured_ambient_reader,
+)
+from coffee_roaster_mcp.config import AmbientConfig
+
+
+class FakeSensor:
+    """Minimal stand-in for a YSensor-derived Yoctopuce function object."""
+
+    CURRENTVALUE_INVALID = -999999.0
+
+    def __init__(self, *, value: float, online: bool = True) -> None:
+        self._value = value
+        self._online = online
+
+    def isOnline(self) -> bool:  # noqa: N802 - mirrors the Yoctopuce SDK naming.
+        return self._online
+
+    def get_currentValue(self) -> float:  # noqa: N802 - mirrors the Yoctopuce SDK naming.
+        return self._value
+
+
+def _fake_sensor_class(
+    *,
+    first_sensor: FakeSensor | None,
+    find_sensor: FakeSensor | None = None,
+) -> Any:
+    find_calls: list[str] = []
+
+    def first() -> FakeSensor | None:
+        return first_sensor
+
+    def find(selector: str) -> FakeSensor | None:
+        find_calls.append(selector)
+        return find_sensor
+
+    return SimpleNamespace(
+        FirstTemperature=first,
+        FindTemperature=find,
+        FirstHumidity=first,
+        FindHumidity=find,
+        FirstPressure=first,
+        FindPressure=find,
+        calls={"find": find_calls},
+    )
+
+
+class FakeYAPI:
+    """Fake `yoctopuce.yocto_api.YAPI` sufficient for hub registration tests."""
+
+    def __init__(self, *, register_result: int = 0, register_errmsg: str = "") -> None:
+        self.register_result = register_result
+        self.register_errmsg = register_errmsg
+        self.register_calls: list[str] = []
+        self.free_api_calls = 0
+
+    def RegisterHub(self, url: str, errmsg: Any) -> int:  # noqa: N802
+        self.register_calls.append(url)
+        if self.register_result != 0:
+            errmsg.value = self.register_errmsg
+        return self.register_result
+
+    def YISERR(self, result: int) -> bool:  # noqa: N802
+        return result != 0
+
+    def FreeAPI(self) -> None:  # noqa: N802
+        self.free_api_calls += 1
+
+
+class FakeYRefParam:
+    def __init__(self) -> None:
+        self.value = ""
+
+
+def _fake_api_module(**kwargs: Any) -> Any:
+    return SimpleNamespace(YAPI=FakeYAPI(**kwargs), YRefParam=FakeYRefParam)
+
+
+def _reader(
+    *,
+    config: AmbientConfig | None = None,
+    api_module: Any | None = None,
+    temperature: FakeSensor | None = None,
+    humidity: FakeSensor | None = None,
+    pressure: FakeSensor | None = None,
+) -> YoctoMeteoAmbientReader:
+    return YoctoMeteoAmbientReader(
+        config or AmbientConfig(mode="yoctopuce"),
+        yoctopuce_api_module=api_module or _fake_api_module(),
+        yoctopuce_temperature_module=SimpleNamespace(
+            YTemperature=_fake_sensor_class(first_sensor=temperature)
+        ),
+        yoctopuce_humidity_module=SimpleNamespace(
+            YHumidity=_fake_sensor_class(first_sensor=humidity)
+        ),
+        yoctopuce_pressure_module=SimpleNamespace(
+            YPressure=_fake_sensor_class(first_sensor=pressure)
+        ),
+    )
+
+
+def test_reader_reads_temperature_humidity_pressure() -> None:
+    reader = _reader(
+        temperature=FakeSensor(value=21.5),
+        humidity=FakeSensor(value=45.0),
+        pressure=FakeSensor(value=1013.25),
+    )
+
+    reading = reader.read()
+
+    assert reading.temperature_c == 21.5
+    assert reading.humidity_percent == 45.0
+    assert reading.pressure_hpa == 1013.25
+    assert reading.monotonic_seconds > 0
+
+
+def test_reader_registers_hub_once_across_multiple_reads() -> None:
+    api_module = _fake_api_module()
+    reader = _reader(
+        api_module=api_module,
+        temperature=FakeSensor(value=20.0),
+        humidity=FakeSensor(value=40.0),
+        pressure=FakeSensor(value=1000.0),
+    )
+
+    reader.read()
+    reader.read()
+
+    assert api_module.YAPI.register_calls == ["usb"]
+
+
+def test_reader_uses_configured_device_selector() -> None:
+    config = AmbientConfig(mode="yoctopuce", device="METEOMK2-12345")
+    temperature_module = SimpleNamespace(
+        YTemperature=_fake_sensor_class(
+            first_sensor=None,
+            find_sensor=FakeSensor(value=22.0),
+        )
+    )
+    humidity_module = SimpleNamespace(
+        YHumidity=_fake_sensor_class(first_sensor=None, find_sensor=FakeSensor(value=41.0))
+    )
+    pressure_module = SimpleNamespace(
+        YPressure=_fake_sensor_class(first_sensor=None, find_sensor=FakeSensor(value=1001.0))
+    )
+    reader = YoctoMeteoAmbientReader(
+        config,
+        yoctopuce_api_module=_fake_api_module(),
+        yoctopuce_temperature_module=temperature_module,
+        yoctopuce_humidity_module=humidity_module,
+        yoctopuce_pressure_module=pressure_module,
+    )
+
+    reading = reader.read()
+
+    assert reading.temperature_c == 22.0
+    assert temperature_module.YTemperature.calls["find"] == ["METEOMK2-12345.temperature"]
+    assert humidity_module.YHumidity.calls["find"] == ["METEOMK2-12345.humidity"]
+    assert pressure_module.YPressure.calls["find"] == ["METEOMK2-12345.pressure"]
+
+
+def test_reader_fails_soft_when_hub_registration_fails() -> None:
+    reader = _reader(
+        api_module=_fake_api_module(register_result=1, register_errmsg="no hub available"),
+    )
+
+    with pytest.raises(AmbientReaderError, match="no hub available"):
+        reader.read()
+
+
+def test_reader_fails_soft_when_hub_registration_raises() -> None:
+    class RaisingYAPI(FakeYAPI):
+        def RegisterHub(self, url: str, errmsg: Any) -> int:  # noqa: N802
+            raise RuntimeError("USB backend unavailable")
+
+    reader = _reader(
+        api_module=SimpleNamespace(YAPI=RaisingYAPI(), YRefParam=FakeYRefParam),
+    )
+
+    with pytest.raises(AmbientReaderError, match="Could not register the Yoctopuce USB hub"):
+        reader.read()
+
+
+def test_reader_fails_soft_when_no_sensor_present() -> None:
+    reader = _reader(temperature=None, humidity=None, pressure=None)
+
+    with pytest.raises(AmbientReaderError, match="No online Yocto-Meteo temperature sensor"):
+        reader.read()
+
+
+def test_reader_fails_soft_when_sensor_is_offline() -> None:
+    reader = _reader(
+        temperature=FakeSensor(value=20.0, online=False),
+        humidity=FakeSensor(value=40.0),
+        pressure=FakeSensor(value=1000.0),
+    )
+
+    with pytest.raises(AmbientReaderError, match="No online Yocto-Meteo temperature sensor"):
+        reader.read()
+
+
+def test_reader_fails_soft_on_invalid_current_value() -> None:
+    invalid_sensor = FakeSensor(value=FakeSensor.CURRENTVALUE_INVALID)
+    reader = _reader(
+        temperature=invalid_sensor,
+        humidity=FakeSensor(value=40.0),
+        pressure=FakeSensor(value=1000.0),
+    )
+
+    with pytest.raises(AmbientReaderError, match="temperature reading is invalid"):
+        reader.read()
+
+
+def test_reader_wraps_unexpected_backend_exception() -> None:
+    class ExplodingSensorClass:
+        @staticmethod
+        def FirstTemperature() -> FakeSensor:  # noqa: N802
+            raise RuntimeError("native backend exploded")
+
+    reader = YoctoMeteoAmbientReader(
+        AmbientConfig(mode="yoctopuce"),
+        yoctopuce_api_module=_fake_api_module(),
+        yoctopuce_temperature_module=SimpleNamespace(YTemperature=ExplodingSensorClass),
+        yoctopuce_humidity_module=SimpleNamespace(
+            YHumidity=_fake_sensor_class(first_sensor=FakeSensor(value=40.0))
+        ),
+        yoctopuce_pressure_module=SimpleNamespace(
+            YPressure=_fake_sensor_class(first_sensor=FakeSensor(value=1000.0))
+        ),
+    )
+
+    with pytest.raises(AmbientReaderError, match="Could not read the Yocto-Meteo probe"):
+        reader.read()
+
+
+def test_reader_close_frees_api_and_is_idempotent() -> None:
+    api_module = _fake_api_module()
+    reader = _reader(
+        api_module=api_module,
+        temperature=FakeSensor(value=20.0),
+        humidity=FakeSensor(value=40.0),
+        pressure=FakeSensor(value=1000.0),
+    )
+    reader.read()
+
+    reader.close()
+    reader.close()
+
+    assert api_module.YAPI.free_api_calls == 1
+
+
+def test_close_before_any_read_is_a_no_op() -> None:
+    reader = _reader()
+
+    reader.close()  # must not raise even though the hub was never registered
+
+
+def test_build_configured_ambient_reader_returns_yocto_meteo_reader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_load_yoctopuce(module_name: str) -> Any:
+        return SimpleNamespace()
+
+    monkeypatch.setattr(ambient_module, "_load_yoctopuce", _fake_load_yoctopuce)
+
+    reader = build_configured_ambient_reader(AmbientConfig(mode="yoctopuce"))
+
+    assert isinstance(reader, YoctoMeteoAmbientReader)
+
+
+def test_build_configured_ambient_reader_rejects_disabled_mode() -> None:
+    with pytest.raises(AmbientReaderError, match="Unsupported ambient sensor mode"):
+        build_configured_ambient_reader(AmbientConfig(mode="disabled"))
+
+
+def test_missing_yoctopuce_runtime_fails_soft(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mirrors `test_microphone_audio_input_normalizes_missing_portaudio_runtime`."""
+
+    def fail_import(module_name: str) -> object:
+        assert module_name == "yoctopuce.yocto_api"
+        raise OSError("Yoctopuce native runtime not found")
+
+    monkeypatch.setattr(ambient_module.importlib, "import_module", fail_import)
+
+    with pytest.raises(AmbientReaderError, match="yoctopuce package and its native runtime"):
+        YoctoMeteoAmbientReader(AmbientConfig(mode="yoctopuce"))

--- a/tests/test_ambient_runtime.py
+++ b/tests/test_ambient_runtime.py
@@ -1,0 +1,335 @@
+"""Unit coverage for the session-owned ambient sensor runtime (#185)."""
+
+from __future__ import annotations
+
+from coffee_roaster_mcp.ambient import AmbientReaderError, AmbientReading
+from coffee_roaster_mcp.ambient_runtime import (
+    AmbientSessionRuntime,
+    build_ambient_session_runtime,
+)
+from coffee_roaster_mcp.config import AmbientConfig, AppConfig
+from coffee_roaster_mcp.session import RoastSessionStore
+
+
+class ClockHarness:
+    def __init__(self, *, start: float = 100.0) -> None:
+        self.value = start
+
+    def monotonic_now(self) -> float:
+        return self.value
+
+
+class FakeAmbientReader:
+    def __init__(self, readings: list[AmbientReading | Exception]) -> None:
+        self._readings = list(readings)
+        self.read_count = 0
+        self.closed = False
+
+    def read(self) -> AmbientReading:
+        self.read_count += 1
+        outcome = self._readings.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _reading(*, temperature_c: float = 20.0, monotonic_seconds: float = 100.0) -> AmbientReading:
+    return AmbientReading(
+        temperature_c=temperature_c,
+        humidity_percent=45.0,
+        pressure_hpa=1013.0,
+        monotonic_seconds=monotonic_seconds,
+    )
+
+
+def test_disabled_mode_never_builds_a_reader() -> None:
+    store = RoastSessionStore()
+    session = store.start_session()
+    calls: list[AmbientConfig] = []
+
+    def factory(config: AmbientConfig) -> FakeAmbientReader:
+        calls.append(config)
+        raise AssertionError("reader factory should not be called when disabled")
+
+    runtime = AmbientSessionRuntime(
+        config=AppConfig(ambient=AmbientConfig(mode="disabled")),
+        reader_factory=factory,
+    )
+
+    snapshot = runtime.start_for_session(session)
+
+    assert snapshot.status == "disabled"
+    assert snapshot.ambient_running is False
+    assert calls == []
+
+    polled = runtime.poll()
+    assert polled.status == "disabled"
+
+
+def test_start_for_session_fails_soft_when_reader_construction_raises() -> None:
+    store = RoastSessionStore()
+    session = store.start_session()
+
+    def factory(config: AmbientConfig) -> FakeAmbientReader:
+        raise AmbientReaderError("no Yocto-Meteo device found on the USB bus")
+
+    runtime = AmbientSessionRuntime(
+        config=AppConfig(ambient=AmbientConfig(mode="yoctopuce")),
+        reader_factory=factory,
+    )
+
+    snapshot = runtime.start_for_session(session)
+
+    assert snapshot.status == "unavailable"
+    assert snapshot.reason is not None
+    assert "no Yocto-Meteo device found" in snapshot.reason
+    assert snapshot.ambient_running is False
+
+
+def test_start_for_session_fails_soft_on_unexpected_exception() -> None:
+    store = RoastSessionStore()
+    session = store.start_session()
+
+    def factory(config: AmbientConfig) -> FakeAmbientReader:
+        raise RuntimeError("unexpected native failure")
+
+    runtime = AmbientSessionRuntime(
+        config=AppConfig(ambient=AmbientConfig(mode="yoctopuce")),
+        reader_factory=factory,
+    )
+
+    snapshot = runtime.start_for_session(session)
+
+    assert snapshot.status == "unavailable"
+    assert snapshot.reason is not None
+    assert "RuntimeError" in snapshot.reason
+
+
+def test_poll_caches_reading_and_refreshes_only_after_interval() -> None:
+    store = RoastSessionStore()
+    session = store.start_session()
+    clock = ClockHarness(start=100.0)
+    reader = FakeAmbientReader([_reading(temperature_c=20.0), _reading(temperature_c=21.0)])
+    runtime = AmbientSessionRuntime(
+        config=AppConfig(ambient=AmbientConfig(mode="yoctopuce", poll_interval_seconds=10.0)),
+        reader_factory=lambda _: reader,
+        monotonic_now=clock.monotonic_now,
+    )
+
+    runtime.start_for_session(session)
+    first_poll = runtime.poll()
+    assert first_poll.status == "ok"
+    assert first_poll.temperature_c == 20.0
+    assert reader.read_count == 1
+
+    # Within the poll interval: cached reading is returned, no second read.
+    clock.value = 105.0
+    cached_poll = runtime.poll()
+    assert cached_poll.temperature_c == 20.0
+    assert reader.read_count == 1
+
+    # Past the poll interval: a fresh read happens.
+    clock.value = 111.0
+    refreshed_poll = runtime.poll()
+    assert refreshed_poll.temperature_c == 21.0
+    assert reader.read_count == 2
+
+
+def test_poll_fails_soft_on_read_error_and_preserves_last_reading() -> None:
+    store = RoastSessionStore()
+    session = store.start_session()
+    clock = ClockHarness(start=100.0)
+    reader = FakeAmbientReader(
+        [
+            _reading(temperature_c=20.0),
+            AmbientReaderError("device disconnected"),
+        ]
+    )
+    runtime = AmbientSessionRuntime(
+        config=AppConfig(ambient=AmbientConfig(mode="yoctopuce", poll_interval_seconds=1.0)),
+        reader_factory=lambda _: reader,
+        monotonic_now=clock.monotonic_now,
+    )
+
+    runtime.start_for_session(session)
+    first_poll = runtime.poll()
+    assert first_poll.status == "ok"
+    assert first_poll.temperature_c == 20.0
+
+    clock.value = 102.0
+    failed_poll = runtime.poll()
+
+    assert failed_poll.status == "unavailable"
+    assert failed_poll.reason is not None
+    assert "device disconnected" in failed_poll.reason
+    # The last-known-good reading is preserved rather than blanked.
+    assert failed_poll.temperature_c == 20.0
+
+
+def test_poll_fails_soft_on_unexpected_read_exception() -> None:
+    store = RoastSessionStore()
+    session = store.start_session()
+    reader = FakeAmbientReader([RuntimeError("native crash")])
+    runtime = AmbientSessionRuntime(
+        config=AppConfig(ambient=AmbientConfig(mode="yoctopuce")),
+        reader_factory=lambda _: reader,
+    )
+
+    runtime.start_for_session(session)
+    snapshot = runtime.poll()
+
+    assert snapshot.status == "unavailable"
+    assert snapshot.reason is not None
+    assert "RuntimeError" in snapshot.reason
+
+
+def test_poll_is_a_no_op_when_runtime_never_started() -> None:
+    runtime = AmbientSessionRuntime(config=AppConfig(ambient=AmbientConfig(mode="yoctopuce")))
+
+    snapshot = runtime.poll()
+
+    assert snapshot.status == "unavailable"
+    assert snapshot.ambient_running is False
+
+
+def test_stop_for_session_closes_reader_and_ignores_other_sessions() -> None:
+    store = RoastSessionStore()
+    session = store.start_session()
+    reader = FakeAmbientReader([_reading()])
+    runtime = AmbientSessionRuntime(
+        config=AppConfig(ambient=AmbientConfig(mode="yoctopuce")),
+        reader_factory=lambda _: reader,
+    )
+    runtime.start_for_session(session)
+    runtime.poll()
+
+    ignored = runtime.stop_for_session("some-other-session-id", reason="ignored")
+    assert ignored.ambient_running is True
+    assert reader.closed is False
+
+    stopped = runtime.stop_for_session(session.id, reason="beans dropped")
+    assert stopped.ambient_running is False
+    assert reader.closed is True
+
+
+def test_shutdown_closes_active_reader() -> None:
+    store = RoastSessionStore()
+    session = store.start_session()
+    reader = FakeAmbientReader([_reading()])
+    runtime = AmbientSessionRuntime(
+        config=AppConfig(ambient=AmbientConfig(mode="yoctopuce")),
+        reader_factory=lambda _: reader,
+    )
+    runtime.start_for_session(session)
+    runtime.poll()
+
+    snapshot = runtime.shutdown()
+
+    assert snapshot.ambient_running is False
+    assert reader.closed is True
+
+
+def test_shutdown_tolerates_reader_close_failure() -> None:
+    class ExplodingCloseReader(FakeAmbientReader):
+        def close(self) -> None:
+            raise RuntimeError("close failed")
+
+    store = RoastSessionStore()
+    session = store.start_session()
+    reader = ExplodingCloseReader([_reading()])
+    runtime = AmbientSessionRuntime(
+        config=AppConfig(ambient=AmbientConfig(mode="yoctopuce")),
+        reader_factory=lambda _: reader,
+    )
+    runtime.start_for_session(session)
+    runtime.poll()
+
+    snapshot = runtime.shutdown()  # must not raise
+
+    assert snapshot.ambient_running is False
+
+
+def test_start_for_session_resets_stale_state_from_a_previous_session() -> None:
+    store = RoastSessionStore()
+    first_session = store.start_session()
+    reader = FakeAmbientReader([_reading(temperature_c=19.0)])
+    runtime = AmbientSessionRuntime(
+        config=AppConfig(ambient=AmbientConfig(mode="yoctopuce")),
+        reader_factory=lambda _: reader,
+    )
+    runtime.start_for_session(first_session)
+    runtime.poll()
+    runtime.stop_for_session(first_session.id, reason="roast complete")
+
+    store.stop_session()
+    second_session = store.start_session()
+    second_reader = FakeAmbientReader([])
+    runtime_with_new_reader = AmbientSessionRuntime(
+        config=AppConfig(ambient=AmbientConfig(mode="yoctopuce")),
+        reader_factory=lambda _: second_reader,
+    )
+    snapshot = runtime_with_new_reader.start_for_session(second_session)
+
+    assert snapshot.temperature_c is None
+    assert snapshot.last_reading_monotonic_seconds is None
+
+
+def test_stop_for_session_on_disabled_mode_is_a_no_op() -> None:
+    store = RoastSessionStore()
+    session = store.start_session()
+    runtime = AmbientSessionRuntime(config=AppConfig(ambient=AmbientConfig(mode="disabled")))
+    runtime.start_for_session(session)
+
+    snapshot = runtime.stop_for_session(session.id, reason="beans dropped")
+
+    assert snapshot.status == "disabled"
+    assert snapshot.ambient_running is False
+
+
+def test_stop_for_session_tolerates_a_reader_without_close() -> None:
+    class NoCloseReader:
+        def read(self) -> AmbientReading:
+            return _reading()
+
+    store = RoastSessionStore()
+    session = store.start_session()
+    runtime = AmbientSessionRuntime(
+        config=AppConfig(ambient=AmbientConfig(mode="yoctopuce")),
+        reader_factory=lambda _: NoCloseReader(),
+    )
+    runtime.start_for_session(session)
+
+    snapshot = runtime.stop_for_session(session.id, reason="beans dropped")  # must not raise
+
+    assert snapshot.ambient_running is False
+
+
+def test_stop_for_session_when_status_never_reached_ok_keeps_unavailable_reason() -> None:
+    store = RoastSessionStore()
+    session = store.start_session()
+
+    def factory(config: AmbientConfig) -> FakeAmbientReader:
+        raise AmbientReaderError("no device present")
+
+    runtime = AmbientSessionRuntime(
+        config=AppConfig(ambient=AmbientConfig(mode="yoctopuce")),
+        reader_factory=factory,
+    )
+    runtime.start_for_session(session)
+
+    snapshot = runtime.stop_for_session(session.id, reason="beans dropped")
+
+    assert snapshot.status == "unavailable"
+    assert snapshot.reason is not None
+    assert "no device present" in snapshot.reason
+
+
+def test_build_ambient_session_runtime_returns_configured_runtime() -> None:
+    runtime = build_ambient_session_runtime(AppConfig(ambient=AmbientConfig(mode="disabled")))
+
+    assert isinstance(runtime, AmbientSessionRuntime)
+    snapshot = runtime.snapshot()
+    assert snapshot.status == "disabled"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,9 @@ def test_default_config_allows_mock_run_without_file(
     assert config.logging.export_formats == ("jsonl", "csv", "summary")
     assert config.session.auto_t0_detection_enabled is False
     assert config.session.auto_t0_drop_threshold_c == 25.0
+    assert config.ambient.mode == "disabled"
+    assert config.ambient.device is None
+    assert config.ambient.poll_interval_seconds == 30.0
 
 
 def test_missing_explicit_config_file_fails(tmp_path: Path) -> None:
@@ -82,6 +85,10 @@ session:
   auto_t0_drop_threshold_c: 20.5
   ror_window_seconds: 45
   ror_min_sample_seconds: 12
+ambient:
+  mode: " yoctopuce "
+  device: METEOMK2-98765
+  poll_interval_seconds: 15.0
 """,
         encoding="utf-8",
     )
@@ -119,6 +126,9 @@ session:
     assert config.session.auto_t0_drop_threshold_c == 20.5
     assert config.session.ror_window_seconds == 45
     assert config.session.ror_min_sample_seconds == 12
+    assert config.ambient.mode == "yoctopuce"
+    assert config.ambient.device == "METEOMK2-98765"
+    assert config.ambient.poll_interval_seconds == 15.0
 
 
 def test_logging_sample_interval_must_be_positive(tmp_path: Path) -> None:
@@ -182,6 +192,9 @@ logging:
             "COFFEE_AUDIO_HOP_SECONDS": "1.25",
             "COFFEE_ROAST_LOG_DIR": "/tmp/roasts",
             "COFFEE_AUTO_T0_DROP_THRESHOLD_C": "30",
+            "COFFEE_AMBIENT_MODE": "yoctopuce\n",
+            "COFFEE_AMBIENT_DEVICE": "METEOMK2-12345",
+            "COFFEE_AMBIENT_POLL_INTERVAL_SECONDS": "45",
         },
     )
 
@@ -207,6 +220,9 @@ logging:
     assert config.audio.hop_seconds == 1.25
     assert config.logging.log_dir == Path("/tmp/roasts")
     assert config.session.auto_t0_drop_threshold_c == 30.0
+    assert config.ambient.mode == "yoctopuce"
+    assert config.ambient.device == "METEOMK2-12345"
+    assert config.ambient.poll_interval_seconds == 45.0
 
 
 def test_environment_config_path_is_supported(tmp_path: Path) -> None:
@@ -238,6 +254,56 @@ def test_invalid_audio_source_fails(tmp_path: Path) -> None:
 
     with pytest.raises(ConfigError, match="audio.source"):
         load_config(config_path, environ={})
+
+
+def test_invalid_ambient_mode_fails(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("ambient:\n  mode: bluetooth\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="ambient.mode"):
+        load_config(config_path, environ={})
+
+
+def test_invalid_ambient_poll_interval_fails(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "ambient:\n  mode: yoctopuce\n  poll_interval_seconds: 0\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigError, match="ambient.poll_interval_seconds"):
+        load_config(config_path, environ={})
+
+
+def test_invalid_ambient_mode_environment_override_fails(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("roaster:\n  driver: mock\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="COFFEE_AMBIENT_MODE"):
+        load_config(config_path, environ={"COFFEE_AMBIENT_MODE": "bluetooth"})
+
+
+def test_invalid_ambient_poll_interval_environment_override_fails(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text("roaster:\n  driver: mock\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="COFFEE_AMBIENT_POLL_INTERVAL_SECONDS"):
+        load_config(
+            config_path,
+            environ={"COFFEE_AMBIENT_POLL_INTERVAL_SECONDS": "-1"},
+        )
+
+
+def test_empty_ambient_device_environment_override_clears_selector(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "ambient:\n  mode: yoctopuce\n  device: METEOMK2-11111\n",
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path, environ={"COFFEE_AMBIENT_DEVICE": "  "})
+
+    assert config.ambient.device is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 import pytest
 from mcp.server.fastmcp import FastMCP
 
+from coffee_roaster_mcp.ambient_runtime import AmbientRuntimeSnapshot, AmbientRuntimeState
 from coffee_roaster_mcp.drivers import EmergencyStopResult, MockRoasterDriver, RoasterState
 from coffee_roaster_mcp.first_crack_runtime import (
     FirstCrackRuntimeSnapshot,
@@ -902,6 +903,133 @@ def test_get_roast_state_exposes_first_crack_statuses(tmp_path: Path) -> None:
     assert fault_state.first_crack_status.status == "faulted"
 
 
+def test_get_roast_state_exposes_ambient_status_disabled_by_default(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    assert start_result.session.ambient_status.status == "disabled"
+    assert start_result.session.ambient_status.mode == "disabled"
+    assert start_result.session.ambient_status.temperature_c is None
+
+    state = _call_tool(
+        server,
+        "get_roast_state",
+        ctx,
+        session_id=start_result.session.session_id,
+    )
+
+    assert state.ambient_status.status == "disabled"
+    assert state.ambient_status.ambient_running is False
+    assert state.ambient_status.reason == "Ambient sensing is disabled by configuration."
+
+
+def test_get_roast_state_exposes_ambient_status_unavailable_when_probe_missing(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "ambient:",
+                "  mode: yoctopuce",
+                f"logging:\n  log_dir: {tmp_path / 'logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server_context = build_server_context(config_path=config_path)
+    _set_ambient_runtime(
+        server_context,
+        FakeAmbientRuntime(status="unavailable", reason="No Yocto-Meteo device found."),
+    )
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+
+    assert start_result.session.ambient_status.status == "unavailable"
+    assert start_result.session.ambient_status.mode == "yoctopuce"
+    assert start_result.session.ambient_status.reason == "No Yocto-Meteo device found."
+    assert start_result.session.ambient_status.temperature_c is None
+
+
+def test_get_roast_state_exposes_ambient_status_ok_with_readings(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "ambient:",
+                "  mode: yoctopuce",
+                f"logging:\n  log_dir: {tmp_path / 'logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server_context = build_server_context(config_path=config_path)
+    _set_ambient_runtime(
+        server_context,
+        FakeAmbientRuntime(
+            status="ok",
+            ambient_running=True,
+            temperature_c=21.4,
+            humidity_percent=42.0,
+            pressure_hpa=1012.3,
+            last_reading_monotonic_seconds=123.0,
+        ),
+    )
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    state = _call_tool(
+        server,
+        "get_roast_state",
+        ctx,
+        session_id=start_result.session.session_id,
+    )
+
+    assert state.ambient_status.status == "ok"
+    assert state.ambient_status.ambient_running is True
+    assert state.ambient_status.temperature_c == 21.4
+    assert state.ambient_status.humidity_percent == 42.0
+    assert state.ambient_status.pressure_hpa == 1012.3
+    assert state.ambient_status.last_reading_monotonic_seconds == 123.0
+
+
+def test_ambient_runtime_stops_on_terminal_session_transitions(tmp_path: Path) -> None:
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "ambient:",
+                "  mode: yoctopuce",
+                f"logging:\n  log_dir: {tmp_path / 'logs'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server_context = build_server_context(config_path=config_path)
+    fake_ambient = FakeAmbientRuntime(status="ok", ambient_running=True)
+    _set_ambient_runtime(server_context, fake_ambient)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    start_result = _call_tool(server, "start_roast_session", ctx)
+    assert fake_ambient.started_sessions == [start_result.session.session_id]
+
+    _call_tool(server, "mark_beans_added", ctx)
+    _call_tool(server, "drop_beans", ctx)
+    assert fake_ambient.stopped_sessions == []
+
+    _call_tool(server, "stop_cooling", ctx)
+
+    assert fake_ambient.stopped_sessions == [start_result.session.session_id]
+
+
 def test_get_roast_state_scopes_runtime_metrics_to_requested_session(tmp_path: Path) -> None:
     config_path = tmp_path / "audio.yaml"
     config_path.write_text(
@@ -1601,6 +1729,60 @@ class FakeFirstCrackRuntime:
         )
 
 
+class FakeAmbientRuntime:
+    """Runtime double that keeps ambient-mode MCP tests hardware-free (#185)."""
+
+    def __init__(
+        self,
+        *,
+        status: str = "unavailable",
+        reason: str | None = None,
+        ambient_running: bool = False,
+        temperature_c: float | None = None,
+        humidity_percent: float | None = None,
+        pressure_hpa: float | None = None,
+        last_reading_monotonic_seconds: float | None = None,
+    ) -> None:
+        self.status = status
+        self.reason = reason
+        self.ambient_running = ambient_running
+        self.temperature_c = temperature_c
+        self.humidity_percent = humidity_percent
+        self.pressure_hpa = pressure_hpa
+        self.last_reading_monotonic_seconds = last_reading_monotonic_seconds
+        self.active_session_id: str | None = None
+        self.started_sessions: list[str] = []
+        self.stopped_sessions: list[str] = []
+
+    def start_for_session(self, session: RoastSession) -> AmbientRuntimeSnapshot:
+        self.active_session_id = session.id
+        self.started_sessions.append(session.id)
+        return self.snapshot()
+
+    def poll(self) -> AmbientRuntimeSnapshot:
+        return self.snapshot()
+
+    def stop_for_session(self, session_id: str, *, reason: str) -> AmbientRuntimeSnapshot:
+        self.stopped_sessions.append(session_id)
+        self.reason = reason
+        return self.snapshot()
+
+    def shutdown(self) -> AmbientRuntimeSnapshot:
+        return self.snapshot()
+
+    def snapshot(self) -> AmbientRuntimeSnapshot:
+        return AmbientRuntimeSnapshot(
+            status=cast(AmbientRuntimeState, self.status),
+            active_session_id=self.active_session_id,
+            reason=self.reason,
+            ambient_running=self.ambient_running,
+            temperature_c=self.temperature_c,
+            humidity_percent=self.humidity_percent,
+            pressure_hpa=self.pressure_hpa,
+            last_reading_monotonic_seconds=self.last_reading_monotonic_seconds,
+        )
+
+
 def _ctx(server_context: ServerContext) -> Any:
     """Build the minimal context shape used by FastMCP tool functions."""
     return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=server_context))
@@ -1611,6 +1793,13 @@ def _set_first_crack_runtime(
     runtime: FakeFirstCrackRuntime,
 ) -> None:
     object.__setattr__(server_context, "first_crack_runtime", runtime)
+
+
+def _set_ambient_runtime(
+    server_context: ServerContext,
+    runtime: FakeAmbientRuntime,
+) -> None:
+    object.__setattr__(server_context, "ambient_runtime", runtime)
 
 
 def _record_tool_error(

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -50,6 +50,7 @@ _EXPECTED_ROAST_STATE_KEYS = {
     "faulted_monotonic_seconds",
     "first_crack_at_utc",
     "first_crack_monotonic_seconds",
+    "ambient_status",
     "first_crack_status",
     "heat_level_percent",
     "log_dir",
@@ -93,10 +94,20 @@ _EXPECTED_T0_STATUS_KEYS = {
     "reason",
     "status",
 }
+_EXPECTED_AMBIENT_STATUS_KEYS = {
+    "ambient_running",
+    "humidity_percent",
+    "last_reading_monotonic_seconds",
+    "mode",
+    "pressure_hpa",
+    "reason",
+    "status",
+    "temperature_c",
+}
 
 
 def test_version_is_defined() -> None:
-    assert __version__ == "0.1.11"
+    assert __version__ == "0.1.12"
 
 
 def test_cli_parser_program_name() -> None:
@@ -431,6 +442,16 @@ async def _assert_basic_mock_roast_flow(tmp_path: Path) -> None:
         assert t0_status["auto_detection_enabled"] is False
         assert t0_status["status"] == "detected"
         assert t0_status["drop_threshold_c"] == 25.0
+
+        ambient_status = state_content["ambient_status"]
+        assert set(ambient_status) == _EXPECTED_AMBIENT_STATUS_KEYS
+        assert ambient_status["mode"] == "disabled"
+        assert ambient_status["status"] == "disabled"
+        assert ambient_status["ambient_running"] is False
+        assert ambient_status["temperature_c"] is None
+        assert ambient_status["humidity_percent"] is None
+        assert ambient_status["pressure_hpa"] is None
+        assert ambient_status["last_reading_monotonic_seconds"] is None
         assert t0_status["charge_temperature_c"] is None
         assert t0_status["detected_bean_temperature_c"] is None
         assert t0_status["reason"] is None


### PR DESCRIPTION
Adds a USB **ambient environmental sensor** (Yoctopuce Yocto-Meteo-V2-C: temperature / relative humidity / barometric pressure) as an MCP-owned device, **mirroring the FC-microphone pipeline** (config → reader → session runtime → `get_roast_state` state field → tests). **Read-only corpus metadata — no roaster-write / control-loop / safety surface.**

Design: roastpilot-plan **D85** (revises D60 — ambient is MCP-owned, like the mic, keeping the agent hardware-free). Agent-side consumer: **syamaner/roastpilot-agent#342**.

## What's added
- **`ambient.py`** — `AmbientReading` / `AmbientReader` Protocol + `YoctoMeteoAmbientReader` (lazy `_load_yoctopuce()`, mirroring `_load_sounddevice()`; `YAPI.RegisterHub('usb')` once per reader, freed on stop) + `build_configured_ambient_reader`.
- **`ambient_runtime.py`** — `AmbientSessionRuntime`: **fail-soft** `start_for_session` (any device error → `status='unavailable'`, never raises) + **lazy-refresh staleness cache** (`poll` reads the USB at most once per `poll_interval_seconds`, default 30 s — never at the 1 Hz state-read rate; preserves last-known-good on a transient read error).
- **config** — `AmbientConfig` (`mode: disabled|yoctopuce`, **default `disabled`**; `device`; `poll_interval_seconds`) + `ambient:` yaml section + `COFFEE_AMBIENT_*` env overrides.
- **`mcp_server.py`** — `AmbientStatus` on `RoastSessionState.ambient_status`, riding the existing `get_roast_state` (**no new tool**); `_serialize_ambient_status` + `_process_ambient_runtime_for_active_session`; ambient stops on terminal session transitions.
- **`pyproject.toml`** — `yoctopuce>=2.0,<3`.
- **version bump 0.1.11 → 0.1.12** + changelog.

## Fail-soft invariant
An absent / unplugged / erroring probe — or a missing `yoctopuce` package — reports `unavailable` with null readings and **never blocks or faults a roast**. Default `mode: disabled` ⇒ zero behaviour change for existing configs.

## Tests / gates
31 new tests; **100 % line+branch coverage on `ambient.py` + `ambient_runtime.py`**; combined package coverage 92.5 % (gate 90 %). Missing-`yoctopuce` fail-soft, device-absent → `unavailable`, the staleness cache (read-count assertions), last-known-good preservation, all three serialization branches, config invalid/env, and the E2E `get_roast_state` key-set contract (`_EXPECTED_AMBIENT_STATUS_KEYS`). `ruff` / `ruff format` / `pyright` (strict, 0) / `pytest` (519 passed) all green.

## Review
Independent **qa** review — PASS: fail-soft verified on both layers (tests call directly + assert the returned snapshot), staleness + last-known-good genuinely asserted, no smoke tests. It independently confirmed the one uncovered `stop_for_session` line in `drop_beans`'s inactive branch is pre-existing dead code on the current session model (its sibling is already uncovered on `main`), unchanged by this PR.

## Release
Ships the version bump; **the tag + PyPI/registry publish is operator-approved** (per `docs/release.md`) — not triggered by this PR.

Closes #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)