### PR TITLE
fix(#191): recover a lost pre-drop first-crack milestone without delaying the drop

### DIFF
--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -253,19 +253,29 @@ class FirstCrackDetectorAdapter:
 
         Args:
             window: Audio window to run detection for.
-            earliest_eligible_monotonic_seconds: Optional cutoff (coffee-roaster-mcp#195
-                CI follow-up). When set, a positive window whose
-                `started_at_monotonic_seconds` predates this cutoff is
-                reported accurately but never joins the confirmation-window
-                candidate list. Even with `discard_pending_audio()` clearing
-                every buffered stage at the `beans_added` boundary, the
-                reader thread never pauses — a chunk captured in the
-                wall-clock gap between recording the boundary event and
-                calling the discard can legitimately start a fraction of a
-                millisecond before the boundary and survive the discard by
-                arriving concurrently with or after it. Only bounding
-                candidate ONSET here (not the caller retroactively
-                discarding a specific window) closes that race.
+            earliest_eligible_monotonic_seconds: Optional cutoff
+                (coffee-roaster-mcp#192, #195 CI follow-up). When set, a
+                positive window whose `started_at_monotonic_seconds`
+                predates this cutoff is reported accurately but never joins
+                the confirmation-window candidate list — it cannot confirm
+                first crack itself, and it cannot backdate or complete a
+                later window's confirmation either. This bounds candidate
+                onset the same way `process_pending_windows_after_drop`
+                already bounds candidate END against the drop: a window
+                whose capture started before `beans_added` may contain
+                empty-drum rattle or charge-pour clatter (both crack-like
+                transients), which must never seed a recovered milestone
+                even when a later, genuinely post-charge window completes
+                the confirmation count. Also closes a narrower race: even
+                with `discard_pending_audio()` clearing every buffered
+                stage at the `beans_added` boundary, the reader thread
+                never pauses — a chunk captured in the wall-clock gap
+                between recording the boundary and calling the discard can
+                legitimately start a fraction of a millisecond before it
+                and survive the discard by arriving concurrently with or
+                after it. Only bounding candidate ONSET here (not the
+                caller retroactively discarding a specific window) closes
+                that race too.
 
         Returns:
             Per-window observation including the confirmed event when present.
@@ -566,13 +576,25 @@ def integrate_first_crack_window_with_session(
     if not session.active or session.phase != "roasting":
         return None
 
-    # coffee-roaster-mcp#195 CI follow-up: bound candidate onset on
-    # beans_added, not just the pipeline-side discard at the boundary — the
-    # reader thread never pauses, so a chunk captured in the wall-clock gap
-    # between recording the boundary and calling discard_pending_audio()
-    # can legitimately start a fraction of a millisecond before it and
-    # survive the discard. AudioWindow timestamps are ABSOLUTE monotonic;
-    # session milestones are SESSION-elapsed — rebase before comparing.
+    # coffee-roaster-mcp#192: the phase gate above is method-entry-level, so
+    # the FIRST call after beans_added flips phase to "roasting" drains
+    # whatever was still queued from BEFORE the charge (nothing drains while
+    # phase is "pre_roast"). Without this cutoff that stale pre-charge window
+    # would join the adapter's confirmation-window candidates unbounded on
+    # its own start time. `beans_added_monotonic_seconds` is always set once
+    # phase is "roasting" (session.py's beans_added handler sets both in the
+    # same transition), so this is never None here.
+    #
+    # Also bounds a narrower #195 CI-follow-up race: even with
+    # discard_pending_audio() clearing every buffered stage at the boundary,
+    # the reader thread never pauses — a chunk captured in the wall-clock
+    # gap between recording beans_added and calling the discard can
+    # legitimately start a fraction of a millisecond before it and survive
+    # the discard by arriving concurrently with or after it.
+    #
+    # AudioWindow timestamps are ABSOLUTE monotonic (the capture pipeline's
+    # own clock); session milestones are SESSION-elapsed — rebase the same
+    # way process_pending_windows_after_drop rebases its drop cutoff.
     beans_added_monotonic_seconds = session.beans_added_monotonic_seconds
     earliest_eligible_absolute = (
         None

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -455,6 +455,20 @@ class FirstCrackSessionRuntime:
             # transform the session store applies in reverse for FC detection
             # (session.py's _detected_elapsed_seconds).
             drop_cutoff_absolute = session.monotonic_start + drop_monotonic_seconds
+            # coffee-roaster-mcp#192: bound the OTHER end too. A window whose
+            # capture started before beans_added must never join the
+            # adapter's confirmation-window candidates here either — the
+            # live path (integrate_first_crack_window_with_session) applies
+            # the same cutoff, but this drain loop calls the adapter
+            # directly and would otherwise let a pre-charge candidate
+            # (empty-drum rattle, charge pour) seed a recovered milestone
+            # once combined with a genuine post-charge confirming window.
+            beans_added_monotonic_seconds = session.beans_added_monotonic_seconds
+            earliest_eligible_absolute = (
+                None
+                if beans_added_monotonic_seconds is None
+                else session.monotonic_start + beans_added_monotonic_seconds
+            )
 
             try:
                 for window in pipeline.drain_windows():
@@ -472,7 +486,10 @@ class FirstCrackSessionRuntime:
                         # the post-drop exemption.
                         continue
                     self._processed_window_count += 1
-                    observation = adapter.process_window_observed(window)
+                    observation = adapter.process_window_observed(
+                        window,
+                        earliest_eligible_monotonic_seconds=earliest_eligible_absolute,
+                    )
                     session_store.record_first_crack_window_observation(
                         session,
                         window_sequence_number=observation.window_sequence_number,

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -190,6 +190,15 @@ class FirstCrackSessionRuntime:
         #: ``set_recording_metadata`` arrives after this, the WAV names are already
         #: fixed and the late metadata is rejected with a clear warning.
         self._recorder_built_for_session = False
+        #: One-slot mutable box (coffee-roaster-mcp#191) the recorder's
+        #: milestones closure reads at close. process_pending_windows_after_drop
+        #: writes a recovered SESSION-ELAPSED first-crack timestamp here when a
+        #: genuine pre-drop window is classified only after the drop — this
+        #: overrides ONLY the sidecar's first_crack milestone, never
+        #: session.first_crack_monotonic_seconds or the event timeline. Reset to
+        #: a fresh empty box each session so a prior roast's recovery can never
+        #: leak into the next one's sidecar.
+        self._recovered_first_crack_holder: list[float | None] = []
 
     def set_recording_metadata(self, *, origin: str, roast_num: int) -> RecordingMetadata:
         """Store annotation-pipeline metadata for the next roast's recording.
@@ -251,6 +260,9 @@ class FirstCrackSessionRuntime:
             self._inference_stopped = False
             self._last_capture_snapshot = None
             self._last_capture_snapshot_as_of_monotonic_seconds = None
+            # Fresh empty box every session (#191): a prior roast's recovered
+            # milestone must never leak into this one's sidecar.
+            self._recovered_first_crack_holder = []
 
             if self._config.first_crack.mode != "audio":
                 self._status = _initial_status(self._config.first_crack)
@@ -263,6 +275,7 @@ class FirstCrackSessionRuntime:
                 self._config,
                 session,
                 metadata=self._recording_metadata,
+                recovered_first_crack_holder=self._recovered_first_crack_holder,
             )
             self._pending_recorder = recorder
             # Once the recorder exists the WAV names are fixed; a later
@@ -347,6 +360,164 @@ class FirstCrackSessionRuntime:
                         # WAVs. The pipeline finalises at stop_for_session.
                         self._inference_stopped = True
                         break
+            except (AudioCaptureError, FirstCrackDetectorError, SessionLifecycleError) as exc:
+                self._mark_faulted_locked(f"First-crack detection failed: {exc}")
+            except Exception as exc:  # noqa: BLE001 - detector backends vary.
+                self._mark_faulted_locked(
+                    f"First-crack detection failed: {type(exc).__name__}: {exc}"
+                )
+
+            return self.snapshot()
+
+    def process_pending_windows_after_drop(
+        self,
+        *,
+        session_store: RoastSessionStore,
+        session: RoastSession,
+    ) -> FirstCrackRuntimeSnapshot:
+        """Classify queued PRE-drop windows after `beans_dropped` was recorded,
+        recovering a straggler crack into the RECORDING's milestone only.
+
+        coffee-roaster-mcp#191: a first-crack-confirming window can be captured
+        but not yet drained by the poll cadence when an operator/agent-triggered
+        `drop_beans` fires. Draining BEFORE the drop (the naive fix) runs
+        detector inference synchronously ahead of the driver's drop command —
+        delaying a safety-relevant hardware action, which is the wrong trade.
+        This method is the safe alternative: call it AFTER `beans_dropped` is
+        already recorded and the driver drop already issued, so inference never
+        blocks the drop.
+
+        Deliberately does NOT call `integrate_first_crack_window_with_session`
+        or write `session.first_crack_monotonic_seconds` / a
+        `first_crack_detected` timeline event. The session's own phase-ordered
+        event transitions (`_ALLOWED_PHASES_BY_EVENT` in session.py) correctly
+        refuse a first-crack event once phase is "dropped" — recording one
+        there would put the CONTROL timeline out of causal order (nothing can
+        act on a crack classified after the roast already ended) for zero
+        control value. Instead, this writes the recovered timestamp into
+        `_recovered_first_crack_holder`, which ONLY the recorder's sidecar
+        milestone reads at close (see `build_session_recorder`). The session
+        event log and the recording sidecar are different contracts: the
+        session log is the causal control record, the sidecar milestone is
+        annotation metadata for the offline dataset/Label Studio pipeline,
+        where the crack's true position in the WAV is the entire point.
+
+        The exemption is bound on the window's END time (started + duration),
+        NOT its start time: the drop itself is acoustically crack-like (beans
+        cascading into the cooling tray is a burst of sharp transients — the
+        detector's known false-positive class). A window whose capture START
+        predates the drop but whose tail STRADDLES it could contain drop
+        clatter and confirm a phantom crack, which would poison the
+        ANNOTATION dataset even worse than the control timeline — it becomes
+        a training label. A genuinely lost pre-drop window — the case #191
+        actually reports — is a COMPLETE window that finished capturing
+        before the drop and was simply sitting undrained in the queue, so its
+        end time is already ≤ the drop timestamp by construction; the
+        end-time bound keeps that case while rejecting anything that overlaps
+        the drop.
+
+        Args:
+            session_store: Authoritative one-session mutation boundary (used
+                only for the phase-independent observability write, never the
+                timeline).
+            session: The session `beans_dropped` was just recorded on. Must have
+                `beans_dropped_monotonic_seconds` set (the caller records the
+                drop event before calling this).
+
+        Returns:
+            The resulting runtime snapshot.
+        """
+        with self._lock:
+            if not self._can_process_after_drop_locked(session):
+                return self.snapshot()
+            # Detector-paced WAV replay drives windows one at a time on its own
+            # deterministic clock for test/replay use, not a live drop race —
+            # #191's post-drop drain is a live-roast (realtime capture) concern.
+            if _uses_detector_paced_wav_replay(self._config.audio):
+                return self.snapshot()
+
+            pipeline = self._pipeline
+            adapter = self._adapter
+            if pipeline is None or adapter is None:  # pragma: no cover - defensive
+                # _can_process_after_drop_locked already requires status ==
+                # "pending", and every start_for_session path that leaves
+                # pipeline/adapter None also sets status to "unavailable" —
+                # so this is unreachable today; kept as a narrowing guard in
+                # case that invariant ever changes.
+                return self.snapshot()
+
+            drop_monotonic_seconds = session.beans_dropped_monotonic_seconds
+            if drop_monotonic_seconds is None:
+                return self.snapshot()
+            # AudioWindow timestamps are ABSOLUTE monotonic (the capture
+            # pipeline's own clock); session milestones are SESSION-elapsed.
+            # Rebase the drop cutoff into the absolute domain once, the same
+            # transform the session store applies in reverse for FC detection
+            # (session.py's _detected_elapsed_seconds).
+            drop_cutoff_absolute = session.monotonic_start + drop_monotonic_seconds
+
+            try:
+                for window in pipeline.drain_windows():
+                    window_end_absolute = (
+                        window.started_at_monotonic_seconds + window.duration_seconds
+                    )
+                    if window_end_absolute >= drop_cutoff_absolute:
+                        # Straddles, ends exactly at, or postdates the drop:
+                        # its tail may contain drop-clatter transients (a known
+                        # false-positive class) or genuine cooling-phase audio.
+                        # The boundary tie is rejected too — err toward safety
+                        # rather than assume a same-instant end truly missed
+                        # the drop noise. Skip it — only a window that finished
+                        # capturing strictly before the drop is eligible for
+                        # the post-drop exemption.
+                        continue
+                    self._processed_window_count += 1
+                    observation = adapter.process_window_observed(window)
+                    session_store.record_first_crack_window_observation(
+                        session,
+                        window_sequence_number=observation.window_sequence_number,
+                        confidence=observation.confidence,
+                        positive_window_count=observation.positive_window_count,
+                        confirmed=observation.confirmed,
+                        fc_status=observation.fc_status,
+                    )
+                    detection_event = observation.event
+                    if detection_event is None:
+                        continue
+                    # Recovered SESSION-ELAPSED first-crack timestamp: the
+                    # detector's backdated crack onset is absolute monotonic
+                    # (same domain as AudioWindow), so rebase it the same way
+                    # every other session milestone is stored.
+                    recovered_session_elapsed = round(
+                        detection_event.detected_at_monotonic_seconds - session.monotonic_start,
+                        6,
+                    )
+                    self._recovered_first_crack_holder.clear()
+                    self._recovered_first_crack_holder.append(recovered_session_elapsed)
+                    recording_relative_seconds = round(
+                        detection_event.detected_at_monotonic_seconds - drop_cutoff_absolute,
+                        6,
+                    )
+                    _LOGGER.warning(
+                        "First crack recovered from a PRE-DROP window classified only "
+                        "AFTER beans_dropped (coffee-roaster-mcp#191): recovered "
+                        "onset %.3fs relative to the drop (negative = before drop), "
+                        "session-elapsed %.3fs. Recorded into the recording sidecar's "
+                        "first_crack milestone ONLY — the session event log correctly "
+                        "stays silent (a post-drop crack has no control value and "
+                        "would break the timeline's causal order).",
+                        recording_relative_seconds,
+                        recovered_session_elapsed,
+                    )
+                    self._status = "detected"
+                    self._reason = (
+                        "First crack was recovered into the recording milestone from a "
+                        "pre-drop window classified after the drop (#191); the session "
+                        "event log intentionally has no first_crack_detected event for "
+                        "this roast."
+                    )
+                    self._inference_stopped = True
+                    break
             except (AudioCaptureError, FirstCrackDetectorError, SessionLifecycleError) as exc:
                 self._mark_faulted_locked(f"First-crack detection failed: {exc}")
             except Exception as exc:  # noqa: BLE001 - detector backends vary.
@@ -506,6 +677,33 @@ class FirstCrackSessionRuntime:
             return False
         return session.active and session.phase == "roasting"
 
+    def _can_process_after_drop_locked(self, session: RoastSession) -> bool:
+        """Guard for :meth:`process_pending_windows_after_drop` (#191).
+
+        Mirrors ``_can_process_locked`` except the phase check accepts
+        ``"dropped"`` OR ``"cooling"`` instead of ``"roasting"`` — this method
+        exists specifically to run AFTER that transition. Every real driver
+        (mock and Hottop) records ``cooling_started`` in the SAME atomic call
+        as ``beans_dropped`` whenever the driver reports cooling engaged
+        (RoasterSessionStore.complete_reserved_driver_drop_snapshot), which is
+        universal for Hottop's compound drop command (the drum keeps running
+        into cooling, #163) — so by the time this method runs, the session has
+        USUALLY already advanced straight to ``"cooling"``; ``"dropped"``
+        alone is checked too only in case a driver ever reports
+        cooling-not-engaged at drop time. ``session.active`` is not required:
+        a session stays active through cooling, so gating on it here would be
+        redundant, not protective.
+        """
+        if self._config.first_crack.mode != "audio":
+            return False
+        if self._active_session_id != session.id:
+            return False
+        if self._inference_stopped:
+            return False
+        if self._status != "pending":
+            return False
+        return session.phase in ("dropped", "cooling")
+
     def _mark_faulted_locked(self, reason: str) -> None:
         self._status = "faulted"
         self._reason = reason
@@ -594,6 +792,7 @@ def build_session_recorder(
     session: RoastSession,
     *,
     metadata: RecordingMetadata | None = None,
+    recovered_first_crack_holder: list[float | None] | None = None,
 ) -> RoastRecorder | None:
     """Build a per-roast audio recorder for one session, or `None` when disabled.
 
@@ -625,6 +824,16 @@ def build_session_recorder(
             timestamps are read at close to compute recording-relative offsets.
         metadata: Optional annotation-pipeline metadata (origin + roast number).
             Falls back to ``origin=session.id`` and ``roast_num=0`` when omitted.
+        recovered_first_crack_holder: Optional one-slot mutable box
+            (coffee-roaster-mcp#191) that, if set to a non-``None`` monotonic
+            timestamp before the recorder closes, overrides the sidecar's
+            ``first_crack`` milestone WITHOUT touching
+            ``session.first_crack_monotonic_seconds`` or the session event
+            timeline. Recovers a pre-drop crack that was classified only after
+            `beans_dropped` (so it could never legally re-enter the causal,
+            phase-ordered session log) into the RECORDING'S annotation
+            metadata, which is a genuinely separate contract from the control
+            timeline — see `FirstCrackSessionRuntime.process_pending_windows_after_drop`.
 
     Returns:
         A configured recorder, or `None` when recording is disabled or capture
@@ -664,9 +873,13 @@ def build_session_recorder(
         recording_started_monotonic = (
             recorder.started_monotonic_seconds if recorder is not None else None
         )
+        first_crack_override = (
+            recovered_first_crack_holder[0] if recovered_first_crack_holder else None
+        )
         return recording_relative_milestones(
             session,
             recording_started_monotonic_seconds=recording_started_monotonic,
+            first_crack_override_monotonic_seconds=first_crack_override,
         )
 
     # Per-device labels for the annotation session JSON, in device order. The
@@ -730,6 +943,7 @@ def recording_relative_milestones(
     session: RoastSession,
     *,
     recording_started_monotonic_seconds: float | None,
+    first_crack_override_monotonic_seconds: float | None = None,
 ) -> dict[str, float | None]:
     """Return roast milestones in RECORDING-relative seconds for the sidecar.
 
@@ -754,6 +968,14 @@ def recording_relative_milestones(
         session: Live roast session.
         recording_started_monotonic_seconds: The recorder's absolute monotonic
             start instant, or `None` if recording never started.
+        first_crack_override_monotonic_seconds: coffee-roaster-mcp#191 — a
+            SESSION-ELAPSED first-crack timestamp recovered by the post-drop
+            drain, used in place of `session.first_crack_monotonic_seconds`
+            when set. The session's own field is deliberately left untouched
+            (the control timeline never records a post-drop crack), so this is
+            the only way the sidecar can carry a first_crack milestone that a
+            straggler pre-drop window supplied. `None` (the default) falls
+            back to the session's own value, unchanged from prior behavior.
 
     Returns:
         Mapping of milestone name to recording-relative seconds, or `None` when
@@ -769,9 +991,14 @@ def recording_relative_milestones(
             return None
         return round(value - offset, 6)
 
+    first_crack_session_elapsed = (
+        session.first_crack_monotonic_seconds
+        if first_crack_override_monotonic_seconds is None
+        else first_crack_override_monotonic_seconds
+    )
     return {
         "beans_added": _rebase(session.beans_added_monotonic_seconds),
-        "first_crack": _rebase(session.first_crack_monotonic_seconds),
+        "first_crack": _rebase(first_crack_session_elapsed),
     }
 
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -772,6 +772,21 @@ def create_mcp_server(
         server_context = ctx.request_context.lifespan_context
         session = _require_active_session(server_context)
         event, snapshot = _run_reserved_driver_drop(server_context, session)
+        # coffee-roaster-mcp#191: classify any detector window captured BEFORE
+        # this drop but not yet drained by the poll cadence, so a genuine
+        # pre-drop first crack is not silently lost from the RECORDING'S
+        # milestone. Deliberately AFTER the drop command above (never before
+        # it) — inference must never delay a safety-relevant hardware drop.
+        # `session` already carries beans_dropped_monotonic_seconds from the
+        # mutation above, which bounds acceptance to windows that finished
+        # capturing strictly before the drop. This never writes
+        # first_crack_detected to the session event log — see
+        # process_pending_windows_after_drop's docstring for why that stays
+        # untouched by design.
+        server_context.first_crack_runtime.process_pending_windows_after_drop(
+            session_store=server_context.session_store,
+            session=session,
+        )
         server_context.first_crack_runtime.stop_for_session(
             snapshot.id,
             reason="beans dropped",

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -1001,6 +1001,292 @@ def test_built_recorder_writes_recording_relative_milestones(tmp_path: Path) -> 
     assert sidecar["milestones"]["first_crack"] == round(95.5 - recording_start_session_elapsed, 6)
 
 
+def test_recording_relative_milestones_first_crack_override_bypasses_session_field() -> None:
+    """recording_relative_milestones's override wins over session.first_crack_monotonic_seconds
+    without ever touching the session field itself (coffee-roaster-mcp#191)."""
+    from coffee_roaster_mcp.first_crack_runtime import recording_relative_milestones
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+
+    # The session's own field stays None (a post-drop crack never writes it).
+    assert session.first_crack_monotonic_seconds is None
+
+    milestones = recording_relative_milestones(
+        session,
+        recording_started_monotonic_seconds=None,
+        first_crack_override_monotonic_seconds=42.5,
+    )
+
+    assert milestones["first_crack"] == 42.5
+    assert session.first_crack_monotonic_seconds is None  # still untouched
+
+    # Omitting the override falls back to the session's own value, unchanged.
+    session.first_crack_monotonic_seconds = 10.0
+    fallback = recording_relative_milestones(session, recording_started_monotonic_seconds=None)
+    assert fallback["first_crack"] == 10.0
+
+
+def test_built_recorder_recovers_first_crack_milestone_from_holder_not_session(
+    tmp_path: Path,
+) -> None:
+    """End to end (coffee-roaster-mcp#191): a value written into the
+    recovered_first_crack_holder overrides the sidecar's first_crack
+    milestone WITHOUT ever writing session.first_crack_monotonic_seconds or a
+    first_crack_detected timeline event — proving the recording and the
+    session event log are genuinely independent contracts, exactly as
+    process_pending_windows_after_drop relies on.
+    """
+    import json
+
+    from coffee_roaster_mcp.config import RecordingConfig
+    from coffee_roaster_mcp.first_crack_runtime import build_session_recorder
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    recovered_first_crack_holder: list[float | None] = []
+    recorder = build_session_recorder(
+        AppConfig(
+            recording=RecordingConfig(
+                enabled=True,
+                autocapture=True,
+                export_location=tmp_path,
+                sample_rate=8,
+            ),
+        ),
+        session,
+        recovered_first_crack_holder=recovered_first_crack_holder,
+    )
+    assert recorder is not None
+
+    recorder.begin()
+    recording_started = recorder.started_monotonic_seconds
+    assert recording_started is not None
+    recording_start_session_elapsed = recording_started - session.monotonic_start
+
+    session.beans_added_monotonic_seconds = 12.0
+    store.record_event(session, "beans_added")
+    store.record_event(session, "beans_dropped")
+    assert session.phase == "dropped"
+    # Simulate process_pending_windows_after_drop writing a recovered
+    # SESSION-ELAPSED first-crack timestamp into the holder — never into
+    # session.first_crack_monotonic_seconds and never as a timeline event.
+    recovered_first_crack_holder.append(95.5)
+
+    recorder.write_samples((0.1,) * 8)
+    recorder.close()
+
+    sidecar = json.loads(
+        (tmp_path / session.id / "roast.recording.json").read_text(encoding="utf-8")
+    )
+    assert sidecar["milestones"]["first_crack"] == round(95.5 - recording_start_session_elapsed, 6)
+    # The control-timeline contract stays untouched by the recovery.
+    assert session.first_crack_monotonic_seconds is None
+    assert "first_crack_detected" not in [event.kind for event in session.event_timeline]
+
+
+def test_process_pending_windows_after_drop_recovers_holder_and_logs_loudly(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """process_pending_windows_after_drop recovers the holder and logs a
+    WARNING breadcrumb (coffee-roaster-mcp#191): a complete pre-drop window
+    (end <= drop cutoff) is classified after beans_dropped, written into
+    _recovered_first_crack_holder, and never touches the session timeline.
+    """
+    import logging
+
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(
+                confirmed=True, confidence=0.94, detected_at_monotonic_seconds=506.0
+            ),
+        )
+    )
+    # The window's end (505.0 + 1.0 = 506.0) is strictly before the drop at
+    # session-elapsed 20.0 (absolute 520.0) — a genuinely complete pre-drop
+    # window, the case #191 reports.
+    pipeline = FakeAudioPipeline(
+        (_audio_window(sequence_number=1, started_at_monotonic_seconds=505.0),)
+    )
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio", revision="v0.1.0")),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            backend,
+        ),
+    )
+    runtime.start_for_session(session)
+    clock.monotonic_value = 505.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 520.0
+    store.record_event(session, "beans_dropped")
+    assert session.phase == "dropped"
+
+    with caplog.at_level(logging.WARNING, logger="coffee_roaster_mcp.first_crack_runtime"):
+        result = runtime.process_pending_windows_after_drop(session_store=store, session=session)
+
+    assert result.status == "detected"
+    assert any(
+        "recovered" in record.message and "coffee-roaster-mcp#191" in record.message
+        for record in caplog.records
+    )
+    # Backdated crack onset (window seq 1 starts at 505.0, absolute) rebased
+    # into SESSION-ELAPSED: 505.0 - session.monotonic_start (500.0) = 5.0.
+    recovered_holder = runtime._recovered_first_crack_holder  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+    assert recovered_holder == [5.0]
+    # The control timeline stays untouched — the whole point of #191's fix.
+    assert session.first_crack_monotonic_seconds is None
+    assert [event.kind for event in session.event_timeline] == ["beans_added", "beans_dropped"]
+
+
+def test_process_pending_windows_after_drop_rejects_a_straddling_window() -> None:
+    """A window whose END is at/after the drop is rejected (coffee-roaster-mcp#191):
+    the drop's own cascading-beans clatter is acoustically crack-like, so a
+    straddling window's tail could confirm a phantom milestone."""
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    backend = MockDetectorBackend(
+        (
+            FirstCrackDetectorOutput(
+                confirmed=True, confidence=0.94, detected_at_monotonic_seconds=506.0
+            ),
+        )
+    )
+    # started_at=505.0 + duration=20.0 => end=525.0, AFTER the drop at
+    # session-elapsed 20.0 (absolute 520.0) — a straddler.
+    pipeline = FakeAudioPipeline(
+        (
+            AudioWindow(
+                sequence_number=1,
+                input_device="fake-mic",
+                sample_rate=16_000,
+                started_at_monotonic_seconds=505.0,
+                duration_seconds=20.0,
+                samples=(0.0,) * 16_000,
+            ),
+        )
+    )
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio", revision="v0.1.0")),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            backend,
+        ),
+    )
+    runtime.start_for_session(session)
+    clock.monotonic_value = 505.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 520.0
+    store.record_event(session, "beans_dropped")
+
+    result = runtime.process_pending_windows_after_drop(session_store=store, session=session)
+
+    assert result.status != "detected"
+    recovered_holder = runtime._recovered_first_crack_holder  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+    assert recovered_holder == []
+    assert session.first_crack_monotonic_seconds is None
+    assert backend.windows == []  # the detector was never even invoked
+
+
+def test_process_pending_windows_after_drop_skips_detector_paced_wav_replay() -> None:
+    """Detector-paced WAV replay is a test/replay concern with its own
+    deterministic clock, not a live drop race — the post-drop drain no-ops
+    for it rather than draining against a mismatched clock domain (#191)."""
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    pipeline = FakeAudioPipeline((_audio_window(sequence_number=1),))
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(
+            first_crack=FirstCrackConfig(mode="audio", revision="v0.1.0"),
+            audio=AudioConfig(
+                source="wav",
+                wav_path=Path("replay.wav"),
+                replay_mode="detector_paced",
+            ),
+        ),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            MockDetectorBackend(()),
+        ),
+    )
+    runtime.start_for_session(session)
+    clock.monotonic_value = 505.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 520.0
+    store.record_event(session, "beans_dropped")
+
+    result = runtime.process_pending_windows_after_drop(session_store=store, session=session)
+
+    assert result.status == "pending"
+    assert pipeline.drain_limits == []  # never even drained
+
+
+def test_process_pending_windows_after_drop_noops_when_mode_is_not_audio() -> None:
+    """A non-audio first-crack mode is a safe no-op (#191): the "pending"
+    status/pipeline pair this method needs never exists outside audio mode."""
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="disabled")),
+    )
+    runtime.start_for_session(session)
+    clock.monotonic_value = 505.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 520.0
+    store.record_event(session, "beans_dropped")
+
+    result = runtime.process_pending_windows_after_drop(session_store=store, session=session)
+
+    assert result.status == "disabled"
+
+
+def test_process_pending_windows_after_drop_noops_without_a_drop_timestamp() -> None:
+    """A session somehow reaching 'dropped'/'cooling' phase without
+    beans_dropped_monotonic_seconds set is defensive-only, but must still
+    no-op safely rather than crash (#191)."""
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    pipeline = FakeAudioPipeline((_audio_window(sequence_number=1),))
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio", revision="v0.1.0")),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            MockDetectorBackend(()),
+        ),
+    )
+    runtime.start_for_session(session)
+    clock.monotonic_value = 505.0
+    store.record_event(session, "beans_added")
+    clock.monotonic_value = 520.0
+    store.record_event(session, "beans_dropped")
+    # Force the defensive gap directly: a real store always sets this
+    # alongside the phase transition, so this line only guards against a
+    # future refactor breaking that invariant.
+    session.beans_dropped_monotonic_seconds = None
+
+    result = runtime.process_pending_windows_after_drop(session_store=store, session=session)
+
+    assert result.status == "pending"
+    assert pipeline.drain_limits == []  # never even drained
+
+
 def test_build_session_recorder_multi_device(tmp_path: Path) -> None:
     from coffee_roaster_mcp.audio import MultiDeviceRoastRecorder
     from coffee_roaster_mcp.config import RecordingConfig

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -1146,6 +1146,90 @@ def test_process_pending_windows_after_drop_recovers_holder_and_logs_loudly(
     assert [event.kind for event in session.event_timeline] == ["beans_added", "beans_dropped"]
 
 
+def test_process_pending_windows_after_drop_rejects_a_precharge_candidate() -> None:
+    """A recovered milestone must not be seeded by a pre-charge candidate
+    window (coffee-roaster-mcp#192 follow-up on #191).
+
+    With min_positive_windows > 1, a positive window whose capture STARTED
+    before beans_added can still reach the detector adapter: the live path
+    (process_available_windows) is gated on session.phase == "roasting" at
+    the METHOD level, so nothing drains while phase is still "pre_roast" —
+    but the moment beans_added flips the phase, whatever is still sitting in
+    the pipeline's queue from before the charge is drained for the first
+    time and fed to the adapter, with no check on the window's own start
+    time. That candidate then sits in the adapter's rolling
+    confirmation-window state and can be completed by a SECOND positive
+    window that only gets classified post-drop via
+    process_pending_windows_after_drop (the #191 straggler-drain path),
+    producing a recovered onset that is seeded by pre-charge audio (empty
+    drum rattle, charge pour — both crack-like transients) rather than a
+    real first-crack window.
+    """
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    backend = MockDetectorBackend(
+        (
+            # Window 1: PRE-CHARGE, started at 490.0 — drained only once
+            # beans_added flips phase to "roasting" at 505.0.
+            FirstCrackDetectorOutput(
+                confirmed=True, confidence=0.9, detected_at_monotonic_seconds=491.0
+            ),
+            # Window 2: the genuine #191 straggler — completes but isn't
+            # drained until AFTER the drop.
+            FirstCrackDetectorOutput(
+                confirmed=True, confidence=0.94, detected_at_monotonic_seconds=506.0
+            ),
+        )
+    )
+    pipeline = FakeAudioPipeline(
+        (_audio_window(sequence_number=1, started_at_monotonic_seconds=490.0),)
+    )
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(
+            first_crack=FirstCrackConfig(mode="audio", revision="v0.1.0", min_positive_windows=2)
+        ),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            backend,
+        ),
+    )
+    runtime.start_for_session(session)
+
+    # Pre-charge: window 1 is queued but the live path is a no-op (phase is
+    # still "pre_roast") — this mirrors
+    # test_audio_runtime_processes_after_beans_added_and_records_once's
+    # pre_t0 assertion.
+    pre_t0 = runtime.process_available_windows(session_store=store, session=session)
+    assert pre_t0.queued_window_count == 1
+
+    # beans_added flips phase to "roasting"; the NEXT call drains window 1
+    # for the first time and feeds it to the adapter as the first positive
+    # candidate, even though its capture started before the charge.
+    clock.monotonic_value = 505.0
+    store.record_event(session, "beans_added")
+    after_charge = runtime.process_available_windows(session_store=store, session=session)
+    assert after_charge.status == "pending"  # only 1 of 2 required candidates so far
+
+    # A second, genuinely post-charge positive window is captured but not
+    # drained by the live path before the drop fires (the #191 scenario).
+    pipeline.add_window(_audio_window(sequence_number=2, started_at_monotonic_seconds=505.5))
+    clock.monotonic_value = 520.0
+    store.record_event(session, "beans_dropped")
+
+    result = runtime.process_pending_windows_after_drop(session_store=store, session=session)
+
+    recovered_holder = runtime._recovered_first_crack_holder  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+    assert result.status != "detected", (
+        "a recovered milestone must not be confirmed by a candidate whose "
+        "window started before beans_added"
+    )
+    assert recovered_holder == []
+    assert session.first_crack_monotonic_seconds is None
+
+
 def test_process_pending_windows_after_drop_rejects_a_straddling_window() -> None:
     """A window whose END is at/after the drop is rejected (coffee-roaster-mcp#191):
     the drop's own cascading-beans clatter is acoustically crack-like, so a

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from pathlib import Path
 from threading import Event, Thread
 from types import SimpleNamespace
@@ -13,10 +14,18 @@ import pytest
 from mcp.server.fastmcp import FastMCP
 
 from coffee_roaster_mcp.ambient_runtime import AmbientRuntimeSnapshot, AmbientRuntimeState
+from coffee_roaster_mcp.artifacts import ResolvedArtifact, ResolvedDetectorArtifacts
+from coffee_roaster_mcp.audio import AudioCaptureSnapshot, AudioWindow
+from coffee_roaster_mcp.config import AppConfig, FirstCrackConfig
+from coffee_roaster_mcp.detector import (
+    FirstCrackDetectorOutput,
+    build_first_crack_detector_adapter,
+)
 from coffee_roaster_mcp.drivers import EmergencyStopResult, MockRoasterDriver, RoasterState
 from coffee_roaster_mcp.first_crack_runtime import (
     FirstCrackRuntimeSnapshot,
     FirstCrackRuntimeState,
+    FirstCrackSessionRuntime,
 )
 from coffee_roaster_mcp.mcp_server import (
     SDK_REQUEST_LOGGER_NAME,
@@ -1310,6 +1319,212 @@ def test_blocked_drop_command_does_not_block_emergency_stop(tmp_path: Path) -> N
     ]
 
 
+class _QueuedWindowAudioPipeline:
+    """Fake audio pipeline exposing detector windows queued after construction.
+
+    Models the real race behind coffee-roaster-mcp#191: a first-crack-confirming
+    window was already captured but the poll cadence has not drained it yet.
+    Appends to a SHARED call-order log so a test can prove drain_windows runs
+    strictly after the driver's drop_beans call, never before it.
+    """
+
+    def __init__(self, *, call_order: list[str]) -> None:
+        self._windows: list[AudioWindow] = []
+        self._call_order = call_order
+        self.stopped = False
+
+    def queue_window(self, window: AudioWindow) -> None:
+        self._windows.append(window)
+
+    def start(self) -> AudioCaptureSnapshot:
+        return self.snapshot()
+
+    def stop(self, *, timeout_seconds: float = 1.0) -> AudioCaptureSnapshot:
+        self.stopped = True
+        self._call_order.append("pipeline.stop")
+        return self.snapshot()
+
+    def drain_windows(self, *, max_windows: int | None = None) -> tuple[AudioWindow, ...]:
+        self._call_order.append("pipeline.drain_windows")
+        drained = tuple(self._windows)
+        self._windows.clear()
+        return drained
+
+    def snapshot(self) -> AudioCaptureSnapshot:
+        return AudioCaptureSnapshot(
+            running=not self.stopped,
+            queued_window_count=len(self._windows),
+            emitted_window_count=1,
+            dropped_window_count=0,
+            latest_error=None,
+            peak_dbfs=None,
+            rms_dbfs=None,
+        )
+
+
+class _OneShotDetectorBackend:
+    """Backend double confirming first crack on the first window it sees."""
+
+    def __init__(self, *, call_order: list[str]) -> None:
+        self._call_order = call_order
+
+    def detect(self, window: AudioWindow) -> FirstCrackDetectorOutput:  # noqa: ARG002
+        self._call_order.append("detector.detect")
+        return FirstCrackDetectorOutput(confirmed=True, confidence=0.97)
+
+
+def _resolved_detector_artifacts_for_test() -> ResolvedDetectorArtifacts:
+    return ResolvedDetectorArtifacts(
+        onnx_model=ResolvedArtifact(
+            repo_id="syamaner/coffee-first-crack-detection",
+            revision="v0.1.0",
+            filename="onnx/int8/model_quantized.onnx",
+            local_path=Path("/tmp/model_quantized.onnx"),
+        ),
+        feature_extractor_config=ResolvedArtifact(
+            repo_id="syamaner/coffee-first-crack-detection",
+            revision="v0.1.0",
+            filename="onnx/int8/preprocessor_config.json",
+            local_path=Path("/tmp/preprocessor_config.json"),
+        ),
+    )
+
+
+def test_drop_beans_never_delays_drop_and_never_writes_a_session_fc_event(
+    tmp_path: Path,
+) -> None:
+    """Regression (coffee-roaster-mcp#191), option 1 per the safety review.
+
+    Two properties, proved together against ONE shared call-order log:
+
+    1. The driver's `drop_beans()` call happens BEFORE any detector inference
+       runs — a confirming window queued pre-drop must never delay the
+       hardware drop command itself (the naive pre-drop-drain fix traded a
+       lost milestone for a delayed drop; that trade is rejected).
+    2. The session event log stays untouched: NO first_crack_detected event
+       is ever recorded for a window classified after the drop, by design —
+       recovery happens only in the recording sidecar's milestone (see
+       test_first_crack_runtime.py for that half, driven through the real
+       recorder), never on the causal, phase-ordered control timeline.
+    """
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+
+    call_order: list[str] = []
+    driver = RecordingRoasterDriver()
+    driver.actions = call_order  # share the SAME list the pipeline/detector append to
+    object.__setattr__(server_context, "roaster_driver", driver)
+
+    pipeline = _QueuedWindowAudioPipeline(call_order=call_order)
+    backend = _OneShotDetectorBackend(call_order=call_order)
+    real_runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio", revision="v0.1.0")),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts_for_test(),
+            backend,
+        ),
+    )
+    object.__setattr__(server_context, "first_crack_runtime", real_runtime)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "mark_beans_added", ctx)
+    call_order.clear()  # only the drop_beans call itself matters from here
+
+    # Queue the confirming window AFTER beans_added (so it postdates session
+    # start) and with a short duration ending comfortably before the drop
+    # fires moments below — a genuinely complete pre-drop window that was
+    # simply sitting undrained. No get_roast_state poll runs here: the poll
+    # cadence has not drained it, matching the real #191 race.
+    # A generous 1s safety margin absorbs real wall-clock overhead in the
+    # drop_beans call itself (session-store locking, event validation, the
+    # mock driver call) between "now" and when beans_dropped is actually
+    # recorded, so the window's END is unambiguously before the drop cutoff.
+    pipeline.queue_window(
+        AudioWindow(
+            sequence_number=1,
+            input_device="fake-mic",
+            sample_rate=16_000,
+            started_at_monotonic_seconds=time.monotonic() - 1.0,
+            duration_seconds=0.001,
+            samples=(0.0,) * 16_000,
+        )
+    )
+    drop_result = _call_tool(server, "drop_beans", ctx)
+
+    # Property 1: the driver's drop_beans() ran BEFORE any inference/drain.
+    assert "drop_beans" in call_order
+    assert "detector.detect" in call_order
+    assert call_order.index("drop_beans") < call_order.index("detector.detect")
+    assert call_order.index("drop_beans") < call_order.index("pipeline.drain_windows")
+
+    # Property 2: the session event log stays untouched — no post-drop
+    # first_crack_detected, regardless of how confidently the classifier
+    # confirmed the pre-drop window.
+    state = _call_tool(server, "get_roast_state", ctx, session_id=drop_result.session_id)
+    assert [event.kind for event in state.events] == [
+        "beans_added",
+        "beans_dropped",
+        "cooling_started",
+    ]
+    assert state.first_crack_at_utc is None
+
+
+def test_drop_beans_ignores_a_window_that_straddles_the_drop(tmp_path: Path) -> None:
+    """A window whose capture END is at/after the drop is rejected, even
+    though its START predates it (coffee-roaster-mcp#191): the drop itself is
+    acoustically crack-like (cascading beans), so a straddling window's tail
+    could contain drop clatter — a phantom milestone would poison the
+    annotation dataset. Only a window that finished capturing strictly before
+    the drop is eligible for the post-drop recovery.
+    """
+    config_path = tmp_path / "coffee-roaster-mcp.yaml"
+    config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
+    server_context = build_server_context(config_path=config_path)
+
+    call_order: list[str] = []
+    pipeline = _QueuedWindowAudioPipeline(call_order=call_order)
+    backend = _OneShotDetectorBackend(call_order=call_order)
+    real_runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio", revision="v0.1.0")),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts_for_test(),
+            backend,
+        ),
+    )
+    object.__setattr__(server_context, "first_crack_runtime", real_runtime)
+    server = create_mcp_server(config_path=config_path)
+    ctx = _ctx(server_context)
+
+    _call_tool(server, "start_roast_session", ctx)
+    _call_tool(server, "mark_beans_added", ctx)
+
+    # Queue a window whose START is now (before the drop call below), but
+    # whose 10s duration carries its END well past the drop — a straddler.
+    pipeline.queue_window(
+        AudioWindow(
+            sequence_number=1,
+            input_device="fake-mic",
+            sample_rate=16_000,
+            started_at_monotonic_seconds=time.monotonic(),
+            duration_seconds=10.0,
+            samples=(0.0,) * 16_000,
+        )
+    )
+    drop_result = _call_tool(server, "drop_beans", ctx)
+
+    assert "detector.detect" not in call_order
+    state = _call_tool(server, "get_roast_state", ctx, session_id=drop_result.session_id)
+    assert "first_crack_detected" not in [event.kind for event in state.events]
+    assert state.first_crack_at_utc is None
+
+
 def test_stop_cooling_uses_driver_cooling_state_before_completing(tmp_path: Path) -> None:
     config_path = tmp_path / "coffee-roaster-mcp.yaml"
     config_path.write_text(f"logging:\n  log_dir: {tmp_path / 'logs'}\n", encoding="utf-8")
@@ -1677,6 +1892,7 @@ class FakeFirstCrackRuntime:
         self.active_session_id: str | None = None
         self.started_sessions: list[str] = []
         self.processed_sessions: list[str] = []
+        self.processed_after_drop_sessions: list[bool] = []
         self.stopped_sessions: list[str] = []
         self.discarded_sessions: list[str] = []
 
@@ -1699,6 +1915,22 @@ class FakeFirstCrackRuntime:
         ):
             session_store.record_event_snapshot(session, "first_crack_detected")
             self.status = "detected"
+        return self.snapshot()
+
+    def process_pending_windows_after_drop(
+        self,
+        *,
+        session_store: RoastSessionStore,
+        session: RoastSession,
+    ) -> FirstCrackRuntimeSnapshot:
+        """No-op double for the coffee-roaster-mcp#191 post-drop drain.
+
+        Real callers never write a session event here (that's the whole
+        point — see FirstCrackSessionRuntime.process_pending_windows_after_drop),
+        so this fake simply records the call and returns the current snapshot.
+        """
+        del session_store, session
+        self.processed_after_drop_sessions.append(True)
         return self.snapshot()
 
     def stop_for_session(self, session_id: str, *, reason: str) -> FirstCrackRuntimeSnapshot:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1350,6 +1350,13 @@ class _QueuedWindowAudioPipeline:
         self._windows.clear()
         return drained
 
+    def discard_pending_audio(self, *, timeout_seconds: float = 1.0) -> None:
+        # This fake models the whole pipeline as one queued-window list (no
+        # separate reader-backlog/sample-buffer stage), so discarding is
+        # equivalent to draining everything (coffee-roaster-mcp#195).
+        self._call_order.append("pipeline.discard_pending_audio")
+        self._windows.clear()
+
     def snapshot(self) -> AudioCaptureSnapshot:
         return AudioCaptureSnapshot(
             running=not self.stopped,


### PR DESCRIPTION
## Summary

A first-crack-confirming detector window can be captured but not yet drained
by the poll cadence when `drop_beans` fires. Today that window is silently
lost forever — the recording sidecar's `roast.recording.json` writes
`milestones.first_crack` as `null`, even though the WAV genuinely contains
the crack. Observed 12 Jul on a real roast (session `a1b2b679`, El Durazno
roast 5): first crack was detected agent-side, but the MCP recording
milestone never populated.

## Root cause

`_process_first_crack_runtime_for_active_session` — the only thing that
drains queued detector windows into the session — runs solely on
`get_roast_state` polling / telemetry-sampler cadence. `drop_beans` records
`beans_dropped` (which flips `session.phase` away from `"roasting"`) and
never drains remaining queued windows before finalizing the recorder. If a
confirming window is captured but not yet polled-and-drained when
`drop_beans` fires — a race directly widened by #190's blocking-read
starvation — the window is dropped on the floor: the phase gate in
`integrate_first_crack_window_with_session` rejects it once
`phase != "roasting"`, and it is never drained again afterward.

## Design, after a safety review

**First attempt (rejected):** drain and classify queued windows *before*
calling the driver's drop command. This traded a lost milestone for a
delayed drop — the drain runs real ONNX inference synchronously, and
`drop_beans` is a safety-relevant hardware action that must never be delayed
by inference.

**Second wall (also required a design change, not a workaround):**
draining *after* the drop, with a caller-side phase exemption, still hit
`RoastSessionStore`'s own independent phase-transition table
(`_ALLOWED_PHASES_BY_EVENT["first_crack_detected"] = frozenset({"roasting"})`).
That refusal is correct, not a bug to route around: recording
`first_crack_detected` after `beans_dropped` is already on the timeline
would put the *control* timeline out of causal order — nothing can act on a
crack classified after the roast already ended.

**Shipped design:** the session event log and the recording sidecar are
different contracts. The session log is the causal, phase-ordered *control*
timeline. The sidecar milestone is *annotation metadata* for the offline
dataset / Label Studio pipeline, where the crack's true position in the WAV
is the entire point. So:

- `drop_beans` records the drop and issues the driver command **first**,
  completely unchanged — inference never delays a hardware action.
- Only afterward, `process_pending_windows_after_drop` classifies any
  queued window and writes a recovered timestamp directly into the
  recording sidecar's `first_crack` milestone via a new runtime-owned
  holder — **never** into `session.first_crack_monotonic_seconds` and
  **never** as a `first_crack_detected` timeline event.
- `RoastSessionStore`'s state machine stays **byte-untouched** in this PR.

### The end-time bound (not start-time)

The exemption is bound on the window's **end** (`started_at_monotonic_seconds
+ duration_seconds`), not its start. The drop itself is acoustically
crack-like — beans cascading into the cooling tray is a burst of sharp
transients, exactly the detector's known false-positive class. A window
whose start predates the drop but whose tail straddles it could contain drop
clatter and confirm a phantom crack, which would poison the *annotation*
dataset even worse than the control timeline — it becomes a training label.
A genuinely lost pre-drop window (the case this PR reports) is a *complete*
window that finished capturing before the drop and was simply sitting
undrained, so its end time is already ≤ the drop timestamp by construction;
the end-time bound keeps that case while rejecting anything that overlaps
the drop. The boundary tie (`end == drop_cutoff`) is rejected too, erring
toward safety.

### Phase-widening note

`beans_dropped` and `cooling_started` are recorded in the **same atomic
session-store call** whenever the driver reports cooling engaged — universal
for both the mock driver and the real Hottop (the drum keeps running through
cooling by design, #163). So by the time `process_pending_windows_after_drop`
runs, `session.phase` is almost always already `"cooling"`, not `"dropped"`.
The guard accepts phase in `("dropped", "cooling")`; `"dropped"` alone stays
checked too in case a future driver ever reports cooling-not-engaged at drop
time. This widens nothing about *which audio can qualify* — the end-time
bound is the load-bearing gate there — it only widens *when this method is
allowed to run at all*.

### Observability

When a pre-drop window is recovered this way, a `WARNING` log fires with
both the recording-relative offset from the drop and the session-elapsed
timestamp, so the recovery leaves a trace even though the session log
correctly stays silent by design.

## Testing

- `test_drop_beans_never_delays_drop_and_never_writes_a_session_fc_event` —
  proves via a shared call-order log that the driver's `drop_beans()` call
  always runs strictly before any `detector.detect()`, and that the session
  event log never gains a post-drop `first_crack_detected` event. Verified
  fail-then-pass by reverting the `mcp_server.py` hook and confirming the
  ordering assertion fails without it.
- `test_drop_beans_ignores_a_window_that_straddles_the_drop` — a window
  whose start predates the drop but whose duration carries its end past it
  is rejected; the detector is never even invoked.
- `test_process_pending_windows_after_drop_recovers_holder_and_logs_loudly` —
  runtime-level: recovery writes the holder and logs the WARNING breadcrumb
  (caplog-asserted).
- `test_process_pending_windows_after_drop_rejects_a_straddling_window` —
  runtime-level mirror of the straddle test.
- `test_built_recorder_recovers_first_crack_milestone_from_holder_not_session` —
  end-to-end through the real recorder: the sidecar milestone is recovered
  while `session.first_crack_monotonic_seconds` and the event timeline stay
  untouched.
- `test_recording_relative_milestones_first_crack_override_bypasses_session_field` —
  unit-level coverage of the new override parameter.
- Three defensive-branch tests (WAV-replay skip, non-audio-mode skip,
  missing-drop-timestamp skip).

Full suite green, `ruff check` / `ruff format --check` clean, `pyright`
strict 0 errors, coverage 91%+ against the 90% floor — every new line
covered or `# pragma: no cover - defensive` with a stated reason, matching
the existing convention in `session.py`.

## Related

The #190 capture fix (in progress, separate PR) independently shrinks this
race further — faster, non-starved drain means fewer straggler windows in
the first place. The two changes compound.

Closes #191
