### PR TITLE
feat(#190): per-minute overflow instrumentation in fc_status

### DIFF
--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -142,12 +142,16 @@ class AudioCaptureSnapshot:
             sustained degradation as an operator-visible diagnostic instead of
             stderr-only warning logs.
         estimated_lost_audio_ms_last_minute: Estimated milliseconds of audio at
-            risk from overflow events in the trailing 60 seconds. Each overflow
-            event contributes the requested read's expected duration
-            (``sample_count / sample_rate``) as an UPPER-BOUND estimate: the
-            PortAudio blocking-read overflow flag reports only that input was
-            lost since the previous read, not how many samples, so this is a
-            conservative "at risk" figure, not an exact lost-sample count.
+            risk from overflow events in the trailing 60 seconds. Each
+            overflow event contributes ``max(0, actual_gap - expected_duration)``
+            — the ACTUAL wall-clock gap since the previous read attempt minus
+            what that read's requested sample count should have taken (#190
+            review finding: a fixed single-read-duration estimate can
+            UNDERESTIMATE, not over-, when PortAudio's overflow flag — which
+            covers all loss since the previous read — spans several
+            consecutive overflowed reads during one sustained stall). This is
+            still an estimate, not an exact lost-sample count: PortAudio
+            never reports how many samples were actually dropped.
         total_overflow_count: Lifetime overflow event count for the current
             capture run, for a whole-roast severity view alongside the rolling
             per-minute figures.
@@ -264,7 +268,8 @@ class OverflowSnapshot:
         count_last_minute: Overflow events in the trailing 60 seconds.
         estimated_lost_audio_ms_last_minute: Estimated at-risk audio in the
             trailing 60 seconds; see :class:`AudioCaptureSnapshot` for the
-            estimation method and its upper-bound caveat.
+            estimation method (derived from the actual inter-read gap, not a
+            fixed per-read duration — #190 review finding).
         total_count: Lifetime overflow event count for the capture run.
     """
 
@@ -278,24 +283,32 @@ class _OverflowTracker:
 
     A PortAudio blocking-read overflow (``stream.read()``'s ``overflowed``
     flag) reports only that input was lost since the previous read, never how
-    many samples — so each event's "lost audio" contribution is estimated as
-    the requested read's expected duration (an upper bound, documented on
-    :class:`AudioCaptureSnapshot`). Events older than 60 seconds of WALL-CLOCK
-    time (not roast-elapsed time) are excluded from the rolling figures so
-    they reflect genuinely recent degradation, matching the #190 report's
+    many samples — so each event's "lost audio" contribution is estimated
+    from the ACTUAL wall-clock gap since the previous read attempt (see
+    :class:`AudioCaptureSnapshot` for the estimation method — #190 review
+    finding: a fixed single-read-duration estimate can underestimate a
+    multi-interval stall). Events older than 60 seconds of WALL-CLOCK time
+    (not roast-elapsed time) are excluded from the rolling figures so they
+    reflect genuinely recent degradation, matching the #190 report's
     "per-minute" framing.
 
-    WRITER/READER SPLIT (#190 safety review): ``observe_overflow`` runs only
-    on the audio-input's own read call (the single capture-owning thread) and
-    is the only method that mutates ``_events`` (append + evict). ``snapshot``
-    is read-only — it never mutates ``_events`` — so a reader thread (the
-    processing/detector-integration thread, which drains queued windows
-    concurrently with capture) can call it at any time without a lock and
-    without racing the writer's mutations. ``deque`` append/popleft are each
-    O(1) and GIL-atomic, but a reader mutating the SAME deque the writer
-    appends to would still be an unsynchronized compound operation; keeping
-    mutation single-threaded avoids that entirely rather than relying on the
-    GIL for correctness.
+    WRITER/READER SPLIT (#190 safety review) — CORRECTED: ``observe_overflow``
+    runs only on the audio-input's own read call (the single capture-owning
+    thread); ``snapshot`` is called from other threads (the processing
+    thread's periodic status reads). A first pass at this class reasoned that
+    ``snapshot`` never *mutating* ``_events`` made it safe to read
+    lock-free — but that missed that ``snapshot`` still *iterates* over
+    ``_events`` (to filter the trailing-60s window), and ``deque`` iteration
+    is NOT safe against a concurrent mutation on another thread even when
+    each individual append/popleft is itself atomic: Python explicitly raises
+    ``RuntimeError: deque mutated during iteration`` if a writer's
+    ``popleft()`` lands mid-iteration on the reader thread — a genuine crash
+    risk under exactly the sustained-overflow conditions #190 is about
+    (frequent ``observe_overflow`` calls racing a concurrent ``snapshot``
+    poll). Both methods now hold ``_lock`` for their full body, which is
+    correct AND still cheap: the critical section is a handful of `deque`
+    operations, never I/O or anything GIL-releasing, so contention is brief
+    even under a real overflow storm.
     """
 
     def __init__(self, *, monotonic_now: Callable[[], float] | None = None) -> None:
@@ -307,34 +320,38 @@ class _OverflowTracker:
         self._monotonic_now = monotonic_now or time.monotonic
         self._events: deque[tuple[float, float]] = deque()
         self._total_count = 0
+        self._lock = Lock()
 
     def observe_overflow(self, *, estimated_lost_audio_ms: float) -> None:
         """Record one overflow event with its estimated lost-audio duration.
 
-        The only method that mutates ``_events`` — see the class docstring's
-        writer/reader split. Callers must only invoke this from the single
-        thread that owns audio reads.
+        Thread-safe: holds the tracker's lock for its full body (see the
+        class docstring for why a mutation-only guarantee isn't enough).
         """
         now = self._monotonic_now()
-        self._events.append((now, estimated_lost_audio_ms))
-        self._total_count += 1
-        cutoff = now - 60.0
-        while self._events and self._events[0][0] < cutoff:
-            self._events.popleft()
+        with self._lock:
+            self._events.append((now, estimated_lost_audio_ms))
+            self._total_count += 1
+            cutoff = now - 60.0
+            while self._events and self._events[0][0] < cutoff:
+                self._events.popleft()
 
     def snapshot(self) -> OverflowSnapshot:
         """Return the current rolling and lifetime overflow stats.
 
-        Read-only: filters events newer than the trailing 60 seconds without
-        mutating ``_events``, so this is safe to call from any thread (see the
-        class docstring's writer/reader split).
+        Thread-safe: holds the tracker's lock for its full body — including
+        the iteration over ``_events`` — so this can never race a concurrent
+        ``observe_overflow`` mutation on another thread (see the class
+        docstring).
         """
         cutoff = self._monotonic_now() - 60.0
-        recent = [lost for observed_at, lost in self._events if observed_at >= cutoff]
+        with self._lock:
+            recent = [lost for observed_at, lost in self._events if observed_at >= cutoff]
+            total_count = self._total_count
         return OverflowSnapshot(
             count_last_minute=len(recent),
             estimated_lost_audio_ms_last_minute=round(sum(recent), 3),
-            total_count=self._total_count,
+            total_count=total_count,
         )
 
 
@@ -549,10 +566,19 @@ class MicrophoneAudioInput:
         self._max_consecutive_overflows = max_consecutive_overflows
         self._consecutive_overflows = 0
         self._close_lock = Lock()
+        self._monotonic_now = monotonic_now or time.monotonic
         #: Per-minute overflow diagnostics (#190), read by the capture pipeline
         #: each loop tick and surfaced in AudioCaptureSnapshot / fc_status so
         #: sustained degradation is operator-visible, not just stderr.
         self._overflow_tracker = _OverflowTracker(monotonic_now=monotonic_now)
+        #: Wall-clock instant the previous read_samples() call returned, or
+        #: None before the first read. Used to estimate lost audio from the
+        #: ACTUAL inter-read gap (#190 review finding), not just this read's
+        #: nominal requested duration — PortAudio's overflowed flag can cover
+        #: loss accumulated across MULTIPLE consecutive overflowed reads, so a
+        #: single-read-duration estimate can genuinely underestimate for a
+        #: multi-interval stall (the opposite of "upper bound").
+        self._last_read_returned_at: float | None = None
 
     def _ensure_stream(self) -> Any:
         if self._stream is not None:
@@ -588,17 +614,32 @@ class MicrophoneAudioInput:
         except Exception as exc:  # noqa: BLE001 - backend exceptions vary by platform.
             # A genuine read failure (device gone, backend error) is still fatal.
             raise AudioCaptureError(f"Could not read microphone audio source: {exc}") from exc
+        read_returned_at = self._monotonic_now()
         if overflowed:
             # Transient: the device dropped some input but `raw_data` still holds
             # the samples it captured. Log, count, and keep going rather than
             # killing capture for the whole roast; only a sustained run of
             # consecutive overflows (the device cannot keep up at all) faults.
             self._consecutive_overflows += 1
-            # PortAudio's overflowed flag reports only that input was lost since
-            # the previous read, not a sample count, so the requested read's
-            # expected duration is an UPPER-BOUND estimate of audio at risk
-            # (#190) — see OverflowSnapshot's docstring.
-            estimated_lost_audio_ms = 1000.0 * sample_count / self._settings.sample_rate
+            # PortAudio's overflowed flag reports only that input was lost
+            # SINCE THE PREVIOUS READ, which can span multiple consecutive
+            # overflowed reads during a genuine multi-second stall — so a
+            # single-read-duration estimate can UNDERESTIMATE for a
+            # multi-interval gap (#190 review finding: the prior "upper
+            # bound" framing was backwards). Estimate instead from the
+            # ACTUAL wall-clock gap since the previous read attempt: the
+            # portion of that gap beyond what this read's requested sample
+            # count should have taken is exactly the time PortAudio's ring
+            # buffer was filling unread. Clamped to >= 0 and falls back to
+            # this read's nominal duration when there is no prior read to
+            # compare against (the first read of a run) — see
+            # OverflowSnapshot's docstring for the estimate's honest bounds.
+            expected_duration_ms = 1000.0 * sample_count / self._settings.sample_rate
+            if self._last_read_returned_at is None:
+                estimated_lost_audio_ms = expected_duration_ms
+            else:
+                actual_gap_ms = 1000.0 * (read_returned_at - self._last_read_returned_at)
+                estimated_lost_audio_ms = max(0.0, actual_gap_ms - expected_duration_ms)
             self._overflow_tracker.observe_overflow(estimated_lost_audio_ms=estimated_lost_audio_ms)
             _LOGGER.warning(
                 "Microphone audio input overflowed (%d consecutive); continuing.",
@@ -612,6 +653,10 @@ class MicrophoneAudioInput:
                 )
         else:
             self._consecutive_overflows = 0
+        # Update on EVERY read (overflowed or not) so the next call's gap
+        # estimate is always measured from the most recent read, not a stale
+        # earlier one.
+        self._last_read_returned_at = read_returned_at
         return tuple(float(sample[0]) for sample in struct.iter_unpack("f", bytes(raw_data)))
 
     @property

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -9,6 +9,7 @@ import math
 import struct
 import time
 import wave
+from collections import deque
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
@@ -135,6 +136,21 @@ class AudioCaptureSnapshot:
         rms_dbfs: Rolling RMS level of the captured stream in dBFS over the most
             recent measurement window, or ``None`` before any samples are read
             (#178). ``-inf`` for pure silence.
+        overflow_count_last_minute: Microphone input-overflow events (#190) in
+            the trailing 60 seconds of wall-clock time, or ``0`` when the audio
+            input does not report overflows (e.g. WAV replay). Surfaces
+            sustained degradation as an operator-visible diagnostic instead of
+            stderr-only warning logs.
+        estimated_lost_audio_ms_last_minute: Estimated milliseconds of audio at
+            risk from overflow events in the trailing 60 seconds. Each overflow
+            event contributes the requested read's expected duration
+            (``sample_count / sample_rate``) as an UPPER-BOUND estimate: the
+            PortAudio blocking-read overflow flag reports only that input was
+            lost since the previous read, not how many samples, so this is a
+            conservative "at risk" figure, not an exact lost-sample count.
+        total_overflow_count: Lifetime overflow event count for the current
+            capture run, for a whole-roast severity view alongside the rolling
+            per-minute figures.
     """
 
     running: bool
@@ -144,6 +160,9 @@ class AudioCaptureSnapshot:
     latest_error: str | None
     peak_dbfs: float | None = None
     rms_dbfs: float | None = None
+    overflow_count_last_minute: int = 0
+    estimated_lost_audio_ms_last_minute: float = 0.0
+    total_overflow_count: int = 0
 
 
 def amplitude_to_dbfs(amplitude: float) -> float:
@@ -235,6 +254,88 @@ class _RollingLevelMeter:
         """Clear the retained samples and reported levels for a fresh run."""
         self._samples = np.empty(0, dtype=np.float64)
         self._levels = None
+
+
+@dataclass(frozen=True)
+class OverflowSnapshot:
+    """Rolling and lifetime microphone input-overflow stats (#190).
+
+    Attributes:
+        count_last_minute: Overflow events in the trailing 60 seconds.
+        estimated_lost_audio_ms_last_minute: Estimated at-risk audio in the
+            trailing 60 seconds; see :class:`AudioCaptureSnapshot` for the
+            estimation method and its upper-bound caveat.
+        total_count: Lifetime overflow event count for the capture run.
+    """
+
+    count_last_minute: int
+    estimated_lost_audio_ms_last_minute: float
+    total_count: int
+
+
+class _OverflowTracker:
+    """Track microphone input-overflow events over a trailing 60-second window.
+
+    A PortAudio blocking-read overflow (``stream.read()``'s ``overflowed``
+    flag) reports only that input was lost since the previous read, never how
+    many samples — so each event's "lost audio" contribution is estimated as
+    the requested read's expected duration (an upper bound, documented on
+    :class:`AudioCaptureSnapshot`). Events older than 60 seconds of WALL-CLOCK
+    time (not roast-elapsed time) are excluded from the rolling figures so
+    they reflect genuinely recent degradation, matching the #190 report's
+    "per-minute" framing.
+
+    WRITER/READER SPLIT (#190 safety review): ``observe_overflow`` runs only
+    on the audio-input's own read call (the single capture-owning thread) and
+    is the only method that mutates ``_events`` (append + evict). ``snapshot``
+    is read-only — it never mutates ``_events`` — so a reader thread (the
+    processing/detector-integration thread, which drains queued windows
+    concurrently with capture) can call it at any time without a lock and
+    without racing the writer's mutations. ``deque`` append/popleft are each
+    O(1) and GIL-atomic, but a reader mutating the SAME deque the writer
+    appends to would still be an unsynchronized compound operation; keeping
+    mutation single-threaded avoids that entirely rather than relying on the
+    GIL for correctness.
+    """
+
+    def __init__(self, *, monotonic_now: Callable[[], float] | None = None) -> None:
+        """Configure the tracker.
+
+        Args:
+            monotonic_now: Optional monotonic clock supplier for tests.
+        """
+        self._monotonic_now = monotonic_now or time.monotonic
+        self._events: deque[tuple[float, float]] = deque()
+        self._total_count = 0
+
+    def observe_overflow(self, *, estimated_lost_audio_ms: float) -> None:
+        """Record one overflow event with its estimated lost-audio duration.
+
+        The only method that mutates ``_events`` — see the class docstring's
+        writer/reader split. Callers must only invoke this from the single
+        thread that owns audio reads.
+        """
+        now = self._monotonic_now()
+        self._events.append((now, estimated_lost_audio_ms))
+        self._total_count += 1
+        cutoff = now - 60.0
+        while self._events and self._events[0][0] < cutoff:
+            self._events.popleft()
+
+    def snapshot(self) -> OverflowSnapshot:
+        """Return the current rolling and lifetime overflow stats.
+
+        Read-only: filters events newer than the trailing 60 seconds without
+        mutating ``_events``, so this is safe to call from any thread (see the
+        class docstring's writer/reader split).
+        """
+        cutoff = self._monotonic_now() - 60.0
+        recent = [lost for observed_at, lost in self._events if observed_at >= cutoff]
+        return OverflowSnapshot(
+            count_last_minute=len(recent),
+            estimated_lost_audio_ms_last_minute=round(sum(recent), 3),
+            total_count=self._total_count,
+        )
 
 
 def audio_capture_settings_from_config(
@@ -427,6 +528,7 @@ class MicrophoneAudioInput:
         *,
         sounddevice_module: Any | None = None,
         max_consecutive_overflows: int = _DEFAULT_MAX_CONSECUTIVE_OVERFLOWS,
+        monotonic_now: Callable[[], float] | None = None,
     ) -> None:
         """Configure a microphone input that opens lazily on first read.
 
@@ -437,6 +539,8 @@ class MicrophoneAudioInput:
                 capture faults. A transient overflow is logged and the captured
                 samples are still returned; only a sustained run (the device cannot
                 keep up at all) raises ``AudioCaptureError``.
+            monotonic_now: Optional monotonic clock supplier for tests (#190
+                overflow-tracker rolling window).
         """
         _validate_settings(settings)
         self._settings = settings
@@ -445,6 +549,10 @@ class MicrophoneAudioInput:
         self._max_consecutive_overflows = max_consecutive_overflows
         self._consecutive_overflows = 0
         self._close_lock = Lock()
+        #: Per-minute overflow diagnostics (#190), read by the capture pipeline
+        #: each loop tick and surfaced in AudioCaptureSnapshot / fc_status so
+        #: sustained degradation is operator-visible, not just stderr.
+        self._overflow_tracker = _OverflowTracker(monotonic_now=monotonic_now)
 
     def _ensure_stream(self) -> Any:
         if self._stream is not None:
@@ -486,6 +594,12 @@ class MicrophoneAudioInput:
             # killing capture for the whole roast; only a sustained run of
             # consecutive overflows (the device cannot keep up at all) faults.
             self._consecutive_overflows += 1
+            # PortAudio's overflowed flag reports only that input was lost since
+            # the previous read, not a sample count, so the requested read's
+            # expected duration is an UPPER-BOUND estimate of audio at risk
+            # (#190) — see OverflowSnapshot's docstring.
+            estimated_lost_audio_ms = 1000.0 * sample_count / self._settings.sample_rate
+            self._overflow_tracker.observe_overflow(estimated_lost_audio_ms=estimated_lost_audio_ms)
             _LOGGER.warning(
                 "Microphone audio input overflowed (%d consecutive); continuing.",
                 self._consecutive_overflows,
@@ -499,6 +613,11 @@ class MicrophoneAudioInput:
         else:
             self._consecutive_overflows = 0
         return tuple(float(sample[0]) for sample in struct.iter_unpack("f", bytes(raw_data)))
+
+    @property
+    def overflow_snapshot(self) -> OverflowSnapshot:
+        """Return current rolling and lifetime overflow stats (#190)."""
+        return self._overflow_tracker.snapshot()
 
     def close(self) -> None:
         """Stop and close the microphone stream.
@@ -1582,6 +1701,13 @@ class AudioCapturePipeline:
         # meter is written outside _state_lock by the capture worker, so two
         # separate property reads could tear; one tuple read cannot.
         levels = self._level_meter.levels
+        # Overflow diagnostics (#190) are only reported by microphone inputs;
+        # duck-type the optional property so WAV replay and other AudioInput
+        # implementations (including test doubles) need not carry it.
+        overflow = cast(
+            "OverflowSnapshot | None",
+            getattr(self._audio_input, "overflow_snapshot", None),
+        )
         with self._state_lock:
             return AudioCaptureSnapshot(
                 running=thread is not None and thread.is_alive(),
@@ -1591,6 +1717,11 @@ class AudioCapturePipeline:
                 latest_error=self._latest_error,
                 peak_dbfs=None if levels is None else levels[0],
                 rms_dbfs=None if levels is None else levels[1],
+                overflow_count_last_minute=0 if overflow is None else overflow.count_last_minute,
+                estimated_lost_audio_ms_last_minute=(
+                    0.0 if overflow is None else overflow.estimated_lost_audio_ms_last_minute
+                ),
+                total_overflow_count=0 if overflow is None else overflow.total_count,
             )
 
     def _run_capture_loop(self) -> None:

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -717,8 +717,19 @@ class MicrophoneAudioInput:
         run if the owning pipeline is `start()`ed again on the same
         instance. Duck-typed by `AudioCapturePipeline._reset_run_state_locked`
         (only microphone inputs report overflows at all).
+
+        Also resets `_last_read_returned_at` (coffee-roaster-mcp#193 review
+        finding, round 2): without this, the first overflowed read of a
+        restarted run computes its gap against the PREVIOUS run's last
+        read — which can be an arbitrarily long real-world pause between
+        roasts — producing one phantom, wildly inflated lost-audio spike
+        that has nothing to do with this run's actual capture behaviour.
+        `None` restores the "no prior read" branch in `read_samples`, which
+        falls back to the read's own nominal duration for that first
+        estimate, exactly like a freshly-constructed input would.
         """
         self._overflow_tracker.reset()
+        self._last_read_returned_at = None
 
     def close(self) -> None:
         """Stop and close the microphone stream.

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -278,6 +278,34 @@ class OverflowSnapshot:
     total_count: int
 
 
+def _merge_overflow_snapshots(
+    primary: OverflowSnapshot | None,
+    secondary: OverflowSnapshot | None,
+) -> OverflowSnapshot | None:
+    """Additively combine two overflow snapshots from independent streams.
+
+    coffee-roaster-mcp#193 review finding: the detector device's own
+    overflow tracker and an additional-device aggregate (from
+    `MultiDeviceRoastRecorder`) are two INDEPENDENT streams — neither
+    double-counts the other's events, so their counts/estimated-ms/lifetime
+    totals simply sum. `None` when neither side has anything to report,
+    matching the existing "no overflow-capable input" convention.
+    """
+    if primary is None:
+        return secondary
+    if secondary is None:
+        return primary
+    return OverflowSnapshot(
+        count_last_minute=primary.count_last_minute + secondary.count_last_minute,
+        estimated_lost_audio_ms_last_minute=round(
+            primary.estimated_lost_audio_ms_last_minute
+            + secondary.estimated_lost_audio_ms_last_minute,
+            3,
+        ),
+        total_count=primary.total_count + secondary.total_count,
+    )
+
+
 class _OverflowTracker:
     """Track microphone input-overflow events over a trailing 60-second window.
 
@@ -335,6 +363,23 @@ class _OverflowTracker:
             cutoff = now - 60.0
             while self._events and self._events[0][0] < cutoff:
                 self._events.popleft()
+
+    def reset(self) -> None:
+        """Clear all tracked overflow events and the lifetime count.
+
+        coffee-roaster-mcp#193 review finding: a `MicrophoneAudioInput` can
+        outlive a single roast (the owning `AudioCapturePipeline` can be
+        `start()`ed more than once against the same input), so
+        `total_overflow_count` — documented as "lifetime... for the CURRENT
+        capture run" — must never carry a prior run's overflow history into
+        a fresh one. Thread-safe for the same reason `observe_overflow`/
+        `snapshot` are: called from `_reset_run_state_locked`, which itself
+        runs under the pipeline's own state lock, but this lock is held too
+        for defence in depth and symmetry with the other mutating method.
+        """
+        with self._lock:
+            self._events.clear()
+            self._total_count = 0
 
     def snapshot(self) -> OverflowSnapshot:
         """Return the current rolling and lifetime overflow stats.
@@ -663,6 +708,17 @@ class MicrophoneAudioInput:
     def overflow_snapshot(self) -> OverflowSnapshot:
         """Return current rolling and lifetime overflow stats (#190)."""
         return self._overflow_tracker.snapshot()
+
+    def reset_overflow_tracking(self) -> None:
+        """Clear overflow history so a reused input starts each run fresh.
+
+        coffee-roaster-mcp#193 review finding: this input's lifetime spans
+        as long as it is referenced, which can be more than one capture
+        run if the owning pipeline is `start()`ed again on the same
+        instance. Duck-typed by `AudioCapturePipeline._reset_run_state_locked`
+        (only microphone inputs report overflows at all).
+        """
+        self._overflow_tracker.reset()
 
     def close(self) -> None:
         """Stop and close the microphone stream.
@@ -1047,6 +1103,20 @@ class _IndependentCaptureStream:
         """Return this stream's WAV writer."""
         return self._writer
 
+    @property
+    def overflow_snapshot(self) -> OverflowSnapshot | None:
+        """Return this stream's overflow diagnostics, if its input reports them.
+
+        coffee-roaster-mcp#193 review finding: each additional device opens
+        its OWN `MicrophoneAudioInput` with its own overflow tracker — duck-
+        typed the same way `AudioCapturePipeline.snapshot()` reads the
+        detector device's, since only microphone inputs report overflows.
+        """
+        return cast(
+            "OverflowSnapshot | None",
+            getattr(self._audio_input, "overflow_snapshot", None),
+        )
+
     def start(self) -> None:
         """Open the WAV and spawn the capture thread."""
         self._writer.begin()
@@ -1375,6 +1445,46 @@ class MultiDeviceRoastRecorder:
         return self._started_monotonic_seconds
 
     @property
+    def overflow_snapshot(self) -> OverflowSnapshot | None:
+        """Return overflow diagnostics AGGREGATED across additional devices.
+
+        coffee-roaster-mcp#193 review finding: the pipeline's own
+        `overflow_snapshot` (surfaced in fc_status) only covers the
+        detector device — this recorder's additional independently-captured
+        streams (#176 option A) each have their own `MicrophoneAudioInput`
+        and were previously invisible to any diagnostic. Additive fix:
+        `AudioCapturePipeline.snapshot()` duck-types this property on the
+        recorder and folds it into the detector device's own figures, so no
+        existing caller/contract changes shape — a recorder with no
+        additional devices (or none reporting overflows) returns `None`,
+        which the pipeline already treats as "nothing to add".
+
+        The detector device's OWN overflow stats are NOT included here —
+        they belong to the pipeline's audio input, not this recorder, so
+        summing them at both layers would double-count. This aggregates
+        only the streams THIS recorder independently owns.
+
+        Counts and estimated-lost-ms are summed (additive across streams);
+        the lifetime total is summed too. `None` when there are no
+        additional devices, or none of them report overflows (e.g. all
+        fake/non-microphone inputs in tests).
+        """
+        snapshots = [
+            snapshot
+            for stream in self._additional_streams
+            if (snapshot := stream.overflow_snapshot) is not None
+        ]
+        if not snapshots:
+            return None
+        return OverflowSnapshot(
+            count_last_minute=sum(snapshot.count_last_minute for snapshot in snapshots),
+            estimated_lost_audio_ms_last_minute=round(
+                sum(snapshot.estimated_lost_audio_ms_last_minute for snapshot in snapshots), 3
+            ),
+            total_count=sum(snapshot.total_count for snapshot in snapshots),
+        )
+
+    @property
     def additional_wav_paths(self) -> tuple[Path, ...]:
         """Return the WAV paths for the independently-captured devices."""
         return tuple(stream.writer.wav_path for stream in self._additional_streams)
@@ -1564,6 +1674,14 @@ class _LazyAdditionalAudioInput:
         self._device = device
         self._factory = factory
         self._input: AudioInput | None = None
+        #: Last observed overflow snapshot, cached at close() (#193 review
+        #: finding). close() drops `_input` so a post-close read of a
+        #: LIVE property would silently go None — this stream's overflow
+        #: history must survive close the same way the pipeline's own
+        #: overflow stats survive stop() (task #59), so an operator
+        #: reviewing a roast right after it ends still sees every device's
+        #: figures, not just the detector's.
+        self._closed_overflow_snapshot: OverflowSnapshot | None = None
 
     def read_samples(self, sample_count: int) -> Sequence[float]:
         """Open the input on first call, then read up to `sample_count` samples."""
@@ -1574,8 +1692,26 @@ class _LazyAdditionalAudioInput:
     def close(self) -> None:
         """Close the underlying input if it was opened."""
         if self._input is not None:
+            self._closed_overflow_snapshot = cast(
+                "OverflowSnapshot | None",
+                getattr(self._input, "overflow_snapshot", None),
+            )
             _close_audio_input_if_supported(self._input)
             self._input = None
+
+    @property
+    def overflow_snapshot(self) -> OverflowSnapshot | None:
+        """Return the wrapped input's overflow diagnostics, if any (#193).
+
+        Live while the input is open; the last-observed value once closed
+        (see `_closed_overflow_snapshot`). `None` before the input has ever
+        been opened, or when it does not report overflows at all — duck-
+        typed identically to every other `overflow_snapshot` accessor in
+        this module.
+        """
+        if self._input is None:
+            return self._closed_overflow_snapshot
+        return cast("OverflowSnapshot | None", getattr(self._input, "overflow_snapshot", None))
 
 
 class AudioCapturePipeline:
@@ -1753,6 +1889,18 @@ class AudioCapturePipeline:
             "OverflowSnapshot | None",
             getattr(self._audio_input, "overflow_snapshot", None),
         )
+        # coffee-roaster-mcp#193 review finding: independently-captured
+        # additional recording devices (#176 option A) each own a separate
+        # microphone input whose overflow stats were previously invisible —
+        # duck-type the recorder's own aggregate (MultiDeviceRoastRecorder
+        # exposes one; a plain RoastAudioRecorder or test double does not,
+        # which _merge_overflow_snapshots treats identically to "nothing to
+        # add") and fold it in additively alongside the detector device's.
+        recorder_overflow = cast(
+            "OverflowSnapshot | None",
+            getattr(self._recorder, "overflow_snapshot", None),
+        )
+        overflow = _merge_overflow_snapshots(overflow, recorder_overflow)
         with self._state_lock:
             return AudioCaptureSnapshot(
                 running=thread is not None and thread.is_alive(),
@@ -1877,6 +2025,18 @@ class AudioCapturePipeline:
         self._dropped_window_count = 0
         self._latest_error = None
         self._level_meter.reset()
+        # coffee-roaster-mcp#193 review finding: a pipeline instance can be
+        # start()ed more than once against the SAME audio input (see
+        # test_audio_capture_pipeline_resets_run_state_on_restart) — without
+        # this, overflow diagnostics from a PRIOR run leak into a fresh
+        # roast's total_overflow_count and rolling last-minute figures,
+        # exactly the stale-state class this method already guards against
+        # for windows/buffers/the level meter. Duck-typed the same way
+        # `AudioCapturePipeline.snapshot()` reads `overflow_snapshot` —
+        # only microphone inputs report overflows.
+        reset_overflow_tracking = getattr(self._audio_input, "reset_overflow_tracking", None)
+        if reset_overflow_tracking is not None:
+            reset_overflow_tracking()
 
 
 class DetectorPacedWavReplayPipeline(AudioCapturePipeline):

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -86,6 +86,18 @@ class FirstCrackRuntimeSnapshot:
             silence. Lets a mis-gained / dead mic be caught under real conditions.
         mic_rms_dbfs: Live rolling RMS level of the captured mic stream in dBFS
             (#178), or ``None`` when no audio capture is running.
+        overflow_count_last_minute: Microphone input-overflow events (#190) in
+            the trailing 60 seconds, or ``0`` when no audio capture is running
+            or the input does not report overflows. Surfaces sustained
+            degradation (e.g. under CPU contention) as an operator-visible
+            diagnostic instead of stderr-only warning logs.
+        estimated_lost_audio_ms_last_minute: Estimated milliseconds of audio at
+            risk from overflow events in the trailing 60 seconds. See
+            :class:`~coffee_roaster_mcp.audio.OverflowSnapshot` for the
+            estimation method and its upper-bound caveat.
+        total_overflow_count: Lifetime overflow event count for the current
+            capture run, for a whole-roast severity view alongside the rolling
+            per-minute figures.
     """
 
     status: FirstCrackRuntimeState
@@ -99,6 +111,9 @@ class FirstCrackRuntimeSnapshot:
     processed_window_count: int = 0
     mic_peak_dbfs: float | None = None
     mic_rms_dbfs: float | None = None
+    overflow_count_last_minute: int = 0
+    estimated_lost_audio_ms_last_minute: float = 0.0
+    total_overflow_count: int = 0
 
 
 class FirstCrackSessionRuntime:
@@ -400,6 +415,15 @@ class FirstCrackSessionRuntime:
                 processed_window_count=self._processed_window_count,
                 mic_peak_dbfs=mic_peak_dbfs,
                 mic_rms_dbfs=mic_rms_dbfs,
+                overflow_count_last_minute=0
+                if capture_snapshot is None
+                else capture_snapshot.overflow_count_last_minute,
+                estimated_lost_audio_ms_last_minute=0.0
+                if capture_snapshot is None
+                else capture_snapshot.estimated_lost_audio_ms_last_minute,
+                total_overflow_count=0
+                if capture_snapshot is None
+                else capture_snapshot.total_overflow_count,
             )
 
     def _can_process_locked(self, session: RoastSession) -> bool:

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -156,14 +156,18 @@ class FirstCrackSessionRuntime:
         self._reason: str | None = _initial_reason(config.first_crack)
         self._processed_window_count = 0
         self._last_capture_snapshot: AudioCaptureSnapshot | None = None
-        #: Wall-clock instant capture was last stopped (#193 review finding).
-        #: Used to decay the rolling "last minute" overflow fields on
-        #: `_stopped_capture_snapshot` — those fields are contractually a
-        #: trailing-60-second rolling window (see `AudioCaptureSnapshot`'s
-        #: docstring), which must not stay frozen at whatever was true at
-        #: the instant capture stopped once real wall-clock time has moved
-        #: the window past every event that contributed to it.
-        self._stopped_at_monotonic_seconds: float | None = None
+        #: Wall-clock instant `_last_capture_snapshot` was captured from a
+        #: LIVE poll (#193 review finding, round 2 — NOT the stop instant:
+        #: an aggregate observed from a live poll seconds or minutes before
+        #: the actual stop() call is already that much older than "now" the
+        #: moment stop happens, and gating decay purely on time-since-STOP
+        #: ignored that staleness). Used to decay the rolling "last minute"
+        #: overflow fields on `_stopped_capture_snapshot` by the true AGE of
+        #: the events that produced the aggregate, not by how long ago
+        #: capture stopped — those fields are contractually a trailing-60-
+        #: second rolling window (see `AudioCaptureSnapshot`'s docstring),
+        #: which must not stay frozen at whatever was true when last polled.
+        self._last_capture_snapshot_as_of_monotonic_seconds: float | None = None
         #: Whether inference/draining has been stopped for this session while the
         #: capture worker + recorder keep running (#181). Set at first-crack
         #: detection so the runtime stops draining/detecting but the recording
@@ -242,7 +246,7 @@ class FirstCrackSessionRuntime:
             self._processed_window_count = 0
             self._inference_stopped = False
             self._last_capture_snapshot = None
-            self._stopped_at_monotonic_seconds = None
+            self._last_capture_snapshot_as_of_monotonic_seconds = None
 
             if self._config.first_crack.mode != "audio":
                 self._status = _initial_status(self._config.first_crack)
@@ -391,6 +395,16 @@ class FirstCrackSessionRuntime:
             capture_snapshot = self._pipeline.snapshot() if self._pipeline is not None else None
             if capture_snapshot is not None:
                 self._last_capture_snapshot = capture_snapshot
+                # coffee-roaster-mcp#193 review finding, round 2: stamp EVERY
+                # live poll, not just the final stop. A live-polled aggregate
+                # is already however old the polling cadence made it by the
+                # time capture actually stops — gating decay purely on
+                # time-since-STOP ignored that: an aggregate observed from a
+                # sparse live poll minutes before stop would incorrectly be
+                # treated as "fresh" for a further 60 seconds after stop.
+                # Decay must be measured from when this aggregate was
+                # actually TRUE (this poll), not from the stop instant.
+                self._last_capture_snapshot_as_of_monotonic_seconds = self._monotonic_now()
             elif self._last_capture_snapshot is not None:
                 capture_snapshot = _stopped_capture_snapshot(self._last_capture_snapshot)
                 # coffee-roaster-mcp#193 review finding: overflow_count_last_minute
@@ -399,16 +413,18 @@ class FirstCrackSessionRuntime:
                 # docstring) — carrying them through unchanged at stop (task #59,
                 # so an operator reviewing right after drop/stop sees the roast's
                 # overflow history) must not leave them frozen forever. Decay them
-                # here, at READ time, based on how long ago capture actually
-                # stopped, rather than baking a point-in-time value into the
-                # snapshot once — a poll seconds after stop still sees the
-                # accurate figure; a poll 60+ seconds later correctly sees it
-                # decayed to zero, same as a live rolling window would. The
-                # lifetime total_overflow_count is untouched — it is a whole-roast
-                # figure, not a rolling one, so it stays frozen by design.
-                if self._stopped_at_monotonic_seconds is not None:
-                    stopped_seconds_ago = self._monotonic_now() - self._stopped_at_monotonic_seconds
-                    if stopped_seconds_ago >= 60.0:
+                # here, at READ time, by the AGE of the events that produced this
+                # aggregate (time since the LAST LIVE POLL that observed it), not
+                # by how long ago capture stopped — a poll seconds after that
+                # live observation still sees the accurate figure; 60+ seconds
+                # after it correctly sees it decayed to zero, same as a live
+                # rolling window would. The lifetime total_overflow_count is
+                # untouched — it is a whole-roast figure, not a rolling one, so
+                # it stays frozen by design.
+                as_of = self._last_capture_snapshot_as_of_monotonic_seconds
+                if as_of is not None:
+                    aggregate_age_seconds = self._monotonic_now() - as_of
+                    if aggregate_age_seconds >= 60.0:
                         capture_snapshot = dataclasses.replace(
                             capture_snapshot,
                             overflow_count_last_minute=0,
@@ -485,10 +501,15 @@ class FirstCrackSessionRuntime:
         pipeline = self._pipeline
         if pipeline is not None:
             try:
+                # pipeline.stop() returns a FINAL LIVE snapshot taken during
+                # the stop call itself, so "now" genuinely is this
+                # aggregate's true as-of instant (#193 review finding,
+                # round 2) — same stamping discipline as every other live
+                # poll in snapshot().
                 self._last_capture_snapshot = _stopped_capture_snapshot(
                     pipeline.stop(timeout_seconds=self._stop_timeout_seconds)
                 )
-                self._stopped_at_monotonic_seconds = self._monotonic_now()
+                self._last_capture_snapshot_as_of_monotonic_seconds = self._monotonic_now()
             except Exception as exc:  # noqa: BLE001 - shutdown should be best effort.
                 self._status = "faulted"
                 self._reason = f"Audio capture stop failed: {type(exc).__name__}: {exc}"

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -126,6 +128,7 @@ class FirstCrackSessionRuntime:
         audio_pipeline_factory: FirstCrackAudioPipelineFactory | None = None,
         detector_adapter_factory: FirstCrackDetectorAdapterFactory | None = None,
         stop_timeout_seconds: float = 1.0,
+        monotonic_now: Callable[[], float] | None = None,
     ) -> None:
         """Initialize a session-owned first-crack runtime.
 
@@ -134,6 +137,9 @@ class FirstCrackSessionRuntime:
             audio_pipeline_factory: Optional test double for audio capture.
             detector_adapter_factory: Optional test double for detector adapter construction.
             stop_timeout_seconds: Maximum seconds to wait for capture shutdown.
+            monotonic_now: Optional monotonic clock supplier for tests. Used
+                to decay the rolling overflow fields on the post-stop
+                snapshot (coffee-roaster-mcp#193 review finding).
         """
         self._config = config
         self._audio_pipeline_factory = audio_pipeline_factory or self._build_default_audio_pipeline
@@ -141,6 +147,7 @@ class FirstCrackSessionRuntime:
             detector_adapter_factory or _build_released_detector_adapter
         )
         self._stop_timeout_seconds = stop_timeout_seconds
+        self._monotonic_now = monotonic_now or time.monotonic
         self._lock = RLock()
         self._active_session_id: str | None = None
         self._pipeline: FirstCrackAudioPipeline | None = None
@@ -149,6 +156,14 @@ class FirstCrackSessionRuntime:
         self._reason: str | None = _initial_reason(config.first_crack)
         self._processed_window_count = 0
         self._last_capture_snapshot: AudioCaptureSnapshot | None = None
+        #: Wall-clock instant capture was last stopped (#193 review finding).
+        #: Used to decay the rolling "last minute" overflow fields on
+        #: `_stopped_capture_snapshot` — those fields are contractually a
+        #: trailing-60-second rolling window (see `AudioCaptureSnapshot`'s
+        #: docstring), which must not stay frozen at whatever was true at
+        #: the instant capture stopped once real wall-clock time has moved
+        #: the window past every event that contributed to it.
+        self._stopped_at_monotonic_seconds: float | None = None
         #: Whether inference/draining has been stopped for this session while the
         #: capture worker + recorder keep running (#181). Set at first-crack
         #: detection so the runtime stops draining/detecting but the recording
@@ -227,6 +242,7 @@ class FirstCrackSessionRuntime:
             self._processed_window_count = 0
             self._inference_stopped = False
             self._last_capture_snapshot = None
+            self._stopped_at_monotonic_seconds = None
 
             if self._config.first_crack.mode != "audio":
                 self._status = _initial_status(self._config.first_crack)
@@ -377,6 +393,27 @@ class FirstCrackSessionRuntime:
                 self._last_capture_snapshot = capture_snapshot
             elif self._last_capture_snapshot is not None:
                 capture_snapshot = _stopped_capture_snapshot(self._last_capture_snapshot)
+                # coffee-roaster-mcp#193 review finding: overflow_count_last_minute
+                # and estimated_lost_audio_ms_last_minute are contractually a
+                # trailing-60-SECOND rolling window (see AudioCaptureSnapshot's
+                # docstring) — carrying them through unchanged at stop (task #59,
+                # so an operator reviewing right after drop/stop sees the roast's
+                # overflow history) must not leave them frozen forever. Decay them
+                # here, at READ time, based on how long ago capture actually
+                # stopped, rather than baking a point-in-time value into the
+                # snapshot once — a poll seconds after stop still sees the
+                # accurate figure; a poll 60+ seconds later correctly sees it
+                # decayed to zero, same as a live rolling window would. The
+                # lifetime total_overflow_count is untouched — it is a whole-roast
+                # figure, not a rolling one, so it stays frozen by design.
+                if self._stopped_at_monotonic_seconds is not None:
+                    stopped_seconds_ago = self._monotonic_now() - self._stopped_at_monotonic_seconds
+                    if stopped_seconds_ago >= 60.0:
+                        capture_snapshot = dataclasses.replace(
+                            capture_snapshot,
+                            overflow_count_last_minute=0,
+                            estimated_lost_audio_ms_last_minute=0.0,
+                        )
             status = self._status
             reason = self._reason
             if (
@@ -451,6 +488,7 @@ class FirstCrackSessionRuntime:
                 self._last_capture_snapshot = _stopped_capture_snapshot(
                     pipeline.stop(timeout_seconds=self._stop_timeout_seconds)
                 )
+                self._stopped_at_monotonic_seconds = self._monotonic_now()
             except Exception as exc:  # noqa: BLE001 - shutdown should be best effort.
                 self._status = "faulted"
                 self._reason = f"Audio capture stop failed: {type(exc).__name__}: {exc}"

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -94,7 +94,7 @@ class FirstCrackRuntimeSnapshot:
         estimated_lost_audio_ms_last_minute: Estimated milliseconds of audio at
             risk from overflow events in the trailing 60 seconds. See
             :class:`~coffee_roaster_mcp.audio.OverflowSnapshot` for the
-            estimation method and its upper-bound caveat.
+            estimation method (derived from the actual inter-read gap).
         total_overflow_count: Lifetime overflow event count for the current
             capture run, for a whole-roast severity view alongside the rolling
             per-minute figures.
@@ -724,6 +724,12 @@ def _stopped_capture_snapshot(snapshot: AudioCaptureSnapshot) -> AudioCaptureSna
     # A stopped capture carries no LIVE mic levels: the meter's last values are
     # stale once capture stops, so drop them (the runtime snapshot also gates the
     # levels on ``audio_running``, so a stale value would never surface anyway).
+    #
+    # Overflow stats (#190 review finding) are the OPPOSITE case — they are
+    # exactly what an operator wants to review right after drop/stop, not a
+    # live-only signal to discard. Carry them through unchanged so fc_status
+    # doesn't silently zero out the roast's overflow history the moment
+    # capture stops, which is precisely when it matters most.
     return AudioCaptureSnapshot(
         running=False,
         queued_window_count=snapshot.queued_window_count,
@@ -732,6 +738,9 @@ def _stopped_capture_snapshot(snapshot: AudioCaptureSnapshot) -> AudioCaptureSna
         latest_error=snapshot.latest_error,
         peak_dbfs=None,
         rms_dbfs=None,
+        overflow_count_last_minute=snapshot.overflow_count_last_minute,
+        estimated_lost_audio_ms_last_minute=snapshot.estimated_lost_audio_ms_last_minute,
+        total_overflow_count=snapshot.total_overflow_count,
     )
 
 

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -308,8 +308,8 @@ class FirstCrackStatus:
             the trailing 60 seconds, so sustained capture degradation is
             operator-visible here instead of stderr-only warning logs.
         estimated_lost_audio_ms_last_minute: Estimated milliseconds of audio at
-            risk from overflow events in the trailing 60 seconds. An
-            upper-bound estimate — see
+            risk from overflow events in the trailing 60 seconds, derived
+            from the actual inter-read gap — see
             :class:`~coffee_roaster_mcp.audio.OverflowSnapshot`.
         total_overflow_count: Lifetime overflow event count for the current
             capture run.

--- a/src/coffee_roaster_mcp/mcp_server.py
+++ b/src/coffee_roaster_mcp/mcp_server.py
@@ -304,6 +304,15 @@ class FirstCrackStatus:
             silence — surfaces a mis-gained / dead mic under real conditions.
         mic_rms_dbfs: Live rolling RMS mic level in dBFS while audio capture runs
             (#178), or ``None`` when no capture is running.
+        overflow_count_last_minute: Microphone input-overflow events (#190) in
+            the trailing 60 seconds, so sustained capture degradation is
+            operator-visible here instead of stderr-only warning logs.
+        estimated_lost_audio_ms_last_minute: Estimated milliseconds of audio at
+            risk from overflow events in the trailing 60 seconds. An
+            upper-bound estimate — see
+            :class:`~coffee_roaster_mcp.audio.OverflowSnapshot`.
+        total_overflow_count: Lifetime overflow event count for the current
+            capture run.
     """
 
     mode: FirstCrackMode
@@ -319,6 +328,9 @@ class FirstCrackStatus:
     processed_window_count: int = 0
     mic_peak_dbfs: float | None = None
     mic_rms_dbfs: float | None = None
+    overflow_count_last_minute: int = 0
+    estimated_lost_audio_ms_last_minute: float = 0.0
+    total_overflow_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -1478,6 +1490,9 @@ def _serialize_first_crack_status(
             processed_window_count=runtime.processed_window_count,
             mic_peak_dbfs=runtime.mic_peak_dbfs,
             mic_rms_dbfs=runtime.mic_rms_dbfs,
+            overflow_count_last_minute=runtime.overflow_count_last_minute,
+            estimated_lost_audio_ms_last_minute=runtime.estimated_lost_audio_ms_last_minute,
+            total_overflow_count=runtime.total_overflow_count,
         )
     if session.faulted_at_utc is not None:
         runtime = _runtime_metrics(
@@ -1498,6 +1513,9 @@ def _serialize_first_crack_status(
             processed_window_count=runtime.processed_window_count,
             mic_peak_dbfs=runtime.mic_peak_dbfs,
             mic_rms_dbfs=runtime.mic_rms_dbfs,
+            overflow_count_last_minute=runtime.overflow_count_last_minute,
+            estimated_lost_audio_ms_last_minute=runtime.estimated_lost_audio_ms_last_minute,
+            total_overflow_count=runtime.total_overflow_count,
         )
     if config.first_crack.mode == "disabled":
         return FirstCrackStatus(
@@ -1550,6 +1568,9 @@ def _serialize_first_crack_status(
             processed_window_count=runtime.processed_window_count,
             mic_peak_dbfs=runtime.mic_peak_dbfs,
             mic_rms_dbfs=runtime.mic_rms_dbfs,
+            overflow_count_last_minute=runtime.overflow_count_last_minute,
+            estimated_lost_audio_ms_last_minute=runtime.estimated_lost_audio_ms_last_minute,
+            total_overflow_count=runtime.total_overflow_count,
         )
     reason = "Audio first-crack detection has not recorded first crack for this session."
     if (
@@ -1577,6 +1598,9 @@ def _serialize_first_crack_status(
         processed_window_count=runtime.processed_window_count,
         mic_peak_dbfs=runtime.mic_peak_dbfs,
         mic_rms_dbfs=runtime.mic_rms_dbfs,
+        overflow_count_last_minute=runtime.overflow_count_last_minute,
+        estimated_lost_audio_ms_last_minute=runtime.estimated_lost_audio_ms_last_minute,
+        total_overflow_count=runtime.total_overflow_count,
     )
 
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1659,25 +1659,44 @@ def test_microphone_audio_input_overflow_snapshot_tracks_overflows() -> None:
         assert baseline.count_last_minute == 0
         assert baseline.total_count == 0
 
-        audio_input.read_samples(1)  # opens the stream; clean read
+        audio_input.read_samples(1)  # opens the stream; clean read at t=0.0
         stream = FakeRawInputStream.created[-1]
+        # Advance the clock BEYOND the expected 250ms-per-sample duration
+        # before each overflowed read, so the actual-gap-based estimate
+        # (#190 review finding) has a genuine gap to measure — a clock that
+        # never advances (the old test) always yields the fixed
+        # single-read-duration estimate, which is exactly the semantics this
+        # fix replaced.
+        clock.value = 1.0  # gap since last read: 1000ms
         stream.overflowed = True
         audio_input.read_samples(1)  # one overflowed read of 1 sample @ 4Hz
+        clock.value = 2.0  # gap since last read: another 1000ms
         stream.overflowed = True
         audio_input.read_samples(1)  # a second overflowed read
 
         snapshot = audio_input.overflow_snapshot
         assert snapshot.count_last_minute == 2
         assert snapshot.total_count == 2
-        # Each overflow is an upper-bound estimate of one read's expected
-        # duration: 1 sample @ 4Hz = 250ms, so two overflows = 500ms.
-        assert snapshot.estimated_lost_audio_ms_last_minute == 500.0
+        # Each read's expected duration is 250ms (1 sample @ 4Hz); the actual
+        # gap was 1000ms, so each overflow's estimate is max(0, 1000-250) =
+        # 750ms, for 1500ms total.
+        assert snapshot.estimated_lost_audio_ms_last_minute == 1500.0
     finally:
         audio_input.close()
 
 
 def test_audio_capture_pipeline_snapshot_surfaces_mic_overflow_stats() -> None:
-    """AudioCapturePipeline.snapshot() reports the mic input's overflow stats (#190)."""
+    """AudioCapturePipeline.snapshot() reports the mic input's overflow stats (#190).
+
+    Deliberately does NOT call pipeline.start() (#190 review finding: the
+    real reader/processing worker thread(s) would race this test's own
+    direct read_samples() calls, making the exact overflow count and
+    estimated-lost-ms non-deterministic — since each background read also
+    advances _last_read_returned_at and can itself land as a clean or
+    overflowed read depending on scheduling). Driving the mic input directly
+    and only using the pipeline for snapshot()'s duck-typed getattr lookup
+    is enough to prove the plumbing works, deterministically.
+    """
     FakeRawInputStream.created.clear()
     settings = audio_capture_settings_from_config(AudioConfig(source="microphone", sample_rate=4))
     clock = ClockHarness()
@@ -1690,20 +1709,18 @@ def test_audio_capture_pipeline_snapshot_surfaces_mic_overflow_stats() -> None:
     )
     pipeline = AudioCapturePipeline(settings=settings, audio_input=audio_input)
 
-    try:
-        pipeline.start()
-        stream = FakeRawInputStream.created[-1]
-        stream.overflowed = True
-        # Drive one overflowed read directly through the input the pipeline owns
-        # (avoids depending on worker-thread scheduling for this assertion).
-        audio_input.read_samples(1)
+    audio_input.read_samples(1)  # clean read at t=0.0, opens the stream
+    stream = FakeRawInputStream.created[-1]
+    clock.value = 1.0  # 1000ms gap before the overflowed read
+    stream.overflowed = True
+    audio_input.read_samples(1)
 
-        snapshot = pipeline.snapshot()
-        assert snapshot.overflow_count_last_minute == 1
-        assert snapshot.total_overflow_count == 1
-        assert snapshot.estimated_lost_audio_ms_last_minute == 250.0
-    finally:
-        pipeline.stop()
+    snapshot = pipeline.snapshot()
+    assert snapshot.overflow_count_last_minute == 1
+    assert snapshot.total_overflow_count == 1
+    # Expected duration 250ms (1 sample @ 4Hz), actual gap 1000ms:
+    # max(0, 1000-250) = 750ms.
+    assert snapshot.estimated_lost_audio_ms_last_minute == 750.0
 
 
 def test_audio_capture_pipeline_snapshot_zero_overflow_for_non_mic_input() -> None:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -18,6 +18,7 @@ from coffee_roaster_mcp.audio import (
     AudioInput,
     DetectorPacedWavReplayPipeline,
     MicrophoneAudioInput,
+    OverflowSnapshot,
     RoastAudioRecorder,
     WavAudioInput,
     amplitude_to_dbfs,
@@ -599,6 +600,54 @@ def test_audio_capture_pipeline_resets_run_state_on_restart() -> None:
     assert windows[0].samples == (3.0, 4.0, 5.0, 6.0)
 
 
+def test_audio_capture_pipeline_resets_overflow_tracking_on_restart() -> None:
+    """coffee-roaster-mcp#193 review finding: a pipeline can be start()ed
+    more than once against the SAME microphone input (the sibling
+    non-overflow restart test above proves this is a real, already-tested
+    pattern) — total_overflow_count is documented as "lifetime... for the
+    CURRENT capture run", so a prior run's overflow history must not leak
+    into a fresh roast's totals.
+    """
+    FakeRawInputStream.created.clear()
+    settings = audio_capture_settings_from_config(AudioConfig(source="microphone", sample_rate=4))
+    clock = ClockHarness()
+    clock.value = 0.0
+    audio_input = MicrophoneAudioInput(
+        settings,
+        sounddevice_module=FakeSoundDeviceModule(),
+        max_consecutive_overflows=10,
+        monotonic_now=lambda: clock.value,
+    )
+    pipeline = AudioCapturePipeline(settings=settings, audio_input=audio_input)
+
+    # First run: drive one overflowed read directly (no background thread
+    # racing this, per the sibling overflow tests' documented discipline),
+    # then reset via a second start() — start()/stop() themselves don't
+    # spawn a worker whose reads would interfere with this direct call.
+    audio_input.read_samples(1)  # opens the stream; clean read at t=0.0
+    stream = FakeRawInputStream.created[-1]
+    clock.value = 1.0
+    stream.overflowed = True
+    audio_input.read_samples(1)
+    assert audio_input.overflow_snapshot.total_count == 1
+    # Clear the fake stream's overflow flag before the real background
+    # worker below starts reading — it never resets on its own, and the
+    # point of this test is the RESET plumbing, not accumulating more
+    # overflows from the worker's own reads.
+    stream.overflowed = False
+
+    # A fresh start() (the same restart pattern the sibling test exercises
+    # for windows/buffers) must reset overflow tracking too, not just
+    # windows/buffers/the level meter.
+    pipeline.start()
+    pipeline.stop()
+
+    fresh_snapshot = audio_input.overflow_snapshot
+    assert fresh_snapshot.total_count == 0
+    assert fresh_snapshot.count_last_minute == 0
+    assert fresh_snapshot.estimated_lost_audio_ms_last_minute == 0.0
+
+
 def test_audio_capture_pipeline_keeps_blocking_consumer_across_restart() -> None:
     audio_input = MutableAudioInput((10.0, 11.0, 12.0, 13.0))
     pipeline = AudioCapturePipeline(
@@ -1074,6 +1123,19 @@ class _BoundedInput:
         self.closed = True
 
 
+class _BoundedInputWithFixedOverflow(_BoundedInput):
+    """`_BoundedInput` that also reports a fixed overflow snapshot (#193
+    review finding coverage: additional-device overflow aggregation)."""
+
+    def __init__(self, amplitude: float, reads: int, overflow: OverflowSnapshot) -> None:
+        super().__init__(amplitude, reads)
+        self._overflow = overflow
+
+    @property
+    def overflow_snapshot(self) -> OverflowSnapshot:
+        return self._overflow
+
+
 def test_multi_device_recorder_writes_two_wavs(tmp_path: Path) -> None:
     import json
     import time
@@ -1128,6 +1190,134 @@ def test_multi_device_recorder_writes_two_wavs(tmp_path: Path) -> None:
     assert sidecar["wav_filename"] == "roast.usb-pnp.wav"
     assert sidecar["milestones"] == {"beans_added": 1.0, "first_crack": 9.0}
     assert recorder.additional_wav_paths == (tmp_path / "roast.atr2100x.wav",)
+
+
+def test_multi_device_recorder_aggregates_overflow_across_additional_streams(
+    tmp_path: Path,
+) -> None:
+    """coffee-roaster-mcp#193 review finding: each additional device has its
+    OWN overflow tracker, previously invisible to any diagnostic —
+    MultiDeviceRoastRecorder.overflow_snapshot must aggregate them
+    additively (count/estimated-ms/lifetime-total all sum across streams).
+    """
+    import time
+
+    from coffee_roaster_mcp.audio import AdditionalRecordingDevice, MultiDeviceRoastRecorder
+
+    inputs: dict[str, _BoundedInputWithFixedOverflow] = {}
+
+    def factory(device: AdditionalRecordingDevice) -> _BoundedInputWithFixedOverflow:
+        overflow = (
+            OverflowSnapshot(
+                count_last_minute=2, estimated_lost_audio_ms_last_minute=200.0, total_count=5
+            )
+            if device.device_label == "MIC-A"
+            else OverflowSnapshot(
+                count_last_minute=3, estimated_lost_audio_ms_last_minute=150.0, total_count=1
+            )
+        )
+        created = _BoundedInputWithFixedOverflow(amplitude=0.5, reads=4, overflow=overflow)
+        inputs[device.device_label] = created
+        return created
+
+    recorder = MultiDeviceRoastRecorder(
+        detector_wav_path=tmp_path / "roast.usb-pnp.wav",
+        detector_device_label="USB PnP",
+        sidecar_path=tmp_path / "roast.recording.json",
+        sample_rate=4,
+        session_id="s",
+        additional_devices=[
+            AdditionalRecordingDevice("MIC-A", tmp_path / "roast.mic-a.wav", 4),
+            AdditionalRecordingDevice("MIC-B", tmp_path / "roast.mic-b.wav", 4),
+        ],
+        additional_input_factory=factory,
+        additional_read_seconds=0.25,
+        idle_sleep_seconds=0.001,
+        stop_timeout_seconds=2.0,
+    )
+
+    recorder.begin()
+    time.sleep(0.1)
+    recorder.close()
+
+    overflow = recorder.overflow_snapshot
+    assert overflow is not None
+    assert overflow.count_last_minute == 5  # 2 + 3
+    assert overflow.estimated_lost_audio_ms_last_minute == 350.0  # 200.0 + 150.0
+    assert overflow.total_count == 6  # 5 + 1
+
+
+def test_multi_device_recorder_overflow_snapshot_is_none_without_reporting_streams(
+    tmp_path: Path,
+) -> None:
+    """No additional devices (or none reporting overflows, e.g. plain test
+    doubles) must surface as `None`, matching the "no overflow-capable
+    input" convention `AudioCapturePipeline.snapshot()` already uses."""
+    from coffee_roaster_mcp.audio import MultiDeviceRoastRecorder
+
+    recorder = MultiDeviceRoastRecorder(
+        detector_wav_path=tmp_path / "roast.usb-pnp.wav",
+        detector_device_label="USB PnP",
+        sidecar_path=tmp_path / "roast.recording.json",
+        sample_rate=4,
+        session_id="s",
+    )
+
+    assert recorder.overflow_snapshot is None
+
+
+def test_pipeline_snapshot_folds_in_recorder_overflow_additively() -> None:
+    """coffee-roaster-mcp#193 review finding: AudioCapturePipeline.snapshot()
+    must merge the detector device's OWN overflow stats with the recorder's
+    aggregate (additional devices) additively, not overwrite one with the
+    other — the two are independent streams and neither double-counts.
+    """
+
+    class _RecorderWithOverflow:
+        overflow_snapshot = OverflowSnapshot(
+            count_last_minute=3, estimated_lost_audio_ms_last_minute=300.0, total_count=9
+        )
+
+        @property
+        def started_monotonic_seconds(self) -> float | None:
+            return None
+
+        def begin(self) -> None:
+            return None
+
+        def write_samples(self, samples: Sequence[float]) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    FakeRawInputStream.created.clear()
+    settings = audio_capture_settings_from_config(AudioConfig(source="microphone", sample_rate=4))
+    clock = ClockHarness()
+    clock.value = 0.0
+    audio_input = MicrophoneAudioInput(
+        settings,
+        sounddevice_module=FakeSoundDeviceModule(),
+        max_consecutive_overflows=10,
+        monotonic_now=lambda: clock.value,
+    )
+    pipeline = AudioCapturePipeline(
+        settings=settings,
+        audio_input=audio_input,
+        recorder=_RecorderWithOverflow(),
+    )
+
+    audio_input.read_samples(1)  # clean read at t=0.0, opens the stream
+    stream = FakeRawInputStream.created[-1]
+    clock.value = 1.0
+    stream.overflowed = True
+    audio_input.read_samples(1)  # detector device: 1 overflow, 750ms estimate
+
+    snapshot = pipeline.snapshot()
+    # Detector device (1, 750.0, 1) + recorder aggregate (3, 300.0, 9).
+    assert snapshot.overflow_count_last_minute == 4
+    assert snapshot.estimated_lost_audio_ms_last_minute == 1050.0
+    assert snapshot.total_overflow_count == 10
 
 
 def test_multi_device_recorder_drops_only_failing_stream(tmp_path: Path) -> None:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -648,6 +648,58 @@ def test_audio_capture_pipeline_resets_overflow_tracking_on_restart() -> None:
     assert fresh_snapshot.estimated_lost_audio_ms_last_minute == 0.0
 
 
+def test_reset_overflow_tracking_clears_the_inter_read_clock_too() -> None:
+    """coffee-roaster-mcp#193 review finding, round 2: resetting the overflow
+    EVENT deque is not enough — without also resetting
+    `_last_read_returned_at`, the first overflowed read of a restarted run
+    computes its gap against the PREVIOUS run's last read, which can be an
+    arbitrarily long real-world pause between roasts (operators can leave a
+    process running idle between roasts for hours). That produces one
+    phantom, wildly inflated lost-audio spike with no relationship to this
+    run's actual capture behaviour.
+    """
+    FakeRawInputStream.created.clear()
+    settings = audio_capture_settings_from_config(AudioConfig(source="microphone", sample_rate=4))
+    clock = ClockHarness()
+    clock.value = 0.0
+    audio_input = MicrophoneAudioInput(
+        settings,
+        sounddevice_module=FakeSoundDeviceModule(),
+        max_consecutive_overflows=10,
+        monotonic_now=lambda: clock.value,
+    )
+    pipeline = AudioCapturePipeline(settings=settings, audio_input=audio_input)
+
+    # Run 1: a single clean read establishes _last_read_returned_at at t=0.0.
+    audio_input.read_samples(1)
+    stream = FakeRawInputStream.created[-1]
+
+    # A long real-world gap between roasts: the operator leaves the process
+    # idle for an hour before starting the next roast.
+    clock.value = 3600.0
+
+    # A fresh restart must reset the inter-read clock, not just the event
+    # deque — otherwise the run-2 stream's first overflowed read below
+    # would compute its gap against t=0.0 (run 1's last read), a ~3600
+    # SECOND phantom gap, instead of correctly falling back to the read's
+    # own nominal duration (the documented "no prior read" behaviour).
+    # Calls the reset hook directly (not the full start()/stop() cycle) to
+    # avoid racing a real background worker thread against this test's own
+    # direct read_samples() calls, per the sibling overflow tests'
+    # documented discipline.
+    pipeline._reset_run_state_locked()  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+
+    stream.overflowed = True
+    audio_input.read_samples(1)  # run 2's first (and only) read: overflowed
+
+    snapshot = audio_input.overflow_snapshot
+    assert snapshot.total_count == 1
+    # Falls back to this read's OWN nominal duration (1 sample @ 4Hz =
+    # 250ms), the documented "no prior read" estimate — not a multi-hour
+    # phantom spike computed against the previous run's clock.
+    assert snapshot.estimated_lost_audio_ms_last_minute == 250.0
+
+
 def test_audio_capture_pipeline_keeps_blocking_consumer_across_restart() -> None:
     audio_input = MutableAudioInput((10.0, 11.0, 12.0, 13.0))
     pipeline = AudioCapturePipeline(

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1544,3 +1544,177 @@ def test_rolling_level_meter_levels_is_a_coherent_pair() -> None:
     assert levels == (-6.02, -6.02)
     meter.reset()
     assert meter.levels is None
+
+
+def test_overflow_tracker_accumulates_within_the_trailing_minute() -> None:
+    """Events inside the trailing 60s all count toward the rolling snapshot (#190)."""
+    from coffee_roaster_mcp.audio import _OverflowTracker  # pyright: ignore[reportPrivateUsage]
+
+    clock = ClockHarness()
+    clock.value = 0.0
+    tracker = _OverflowTracker(monotonic_now=lambda: clock.value)
+
+    snapshot = tracker.snapshot()
+    assert snapshot.count_last_minute == 0
+    assert snapshot.estimated_lost_audio_ms_last_minute == 0.0
+    assert snapshot.total_count == 0
+
+    clock.value = 10.0
+    tracker.observe_overflow(estimated_lost_audio_ms=250.0)
+    clock.value = 20.0
+    tracker.observe_overflow(estimated_lost_audio_ms=125.0)
+
+    snapshot = tracker.snapshot()
+    assert snapshot.count_last_minute == 2
+    assert snapshot.estimated_lost_audio_ms_last_minute == 375.0
+    assert snapshot.total_count == 2
+
+
+def test_overflow_tracker_evicts_events_older_than_sixty_seconds() -> None:
+    """Events fall out of the rolling window at 60s, but the lifetime total keeps them (#190)."""
+    from coffee_roaster_mcp.audio import _OverflowTracker  # pyright: ignore[reportPrivateUsage]
+
+    clock = ClockHarness()
+    clock.value = 0.0
+    tracker = _OverflowTracker(monotonic_now=lambda: clock.value)
+
+    tracker.observe_overflow(estimated_lost_audio_ms=100.0)
+    clock.value = 61.0
+    tracker.observe_overflow(estimated_lost_audio_ms=50.0)
+
+    snapshot = tracker.snapshot()
+    # The first event is now 61s old: evicted from the rolling window.
+    assert snapshot.count_last_minute == 1
+    assert snapshot.estimated_lost_audio_ms_last_minute == 50.0
+    # The lifetime total is never evicted.
+    assert snapshot.total_count == 2
+
+    # Even with no new events, calling snapshot() re-filters against "now"
+    # (read-only: it does not mutate _events, see the class docstring).
+    clock.value = 200.0
+    snapshot = tracker.snapshot()
+    assert snapshot.count_last_minute == 0
+    assert snapshot.estimated_lost_audio_ms_last_minute == 0.0
+    assert snapshot.total_count == 2
+
+
+def test_overflow_tracker_snapshot_is_read_only_and_thread_safe() -> None:
+    """A reader thread calling snapshot() never races the writer's mutations (#190).
+
+    snapshot() must never mutate `_events`: only `observe_overflow` does, and
+    it always runs on the single audio-input read thread. This drives a writer
+    thread appending events concurrently with a reader thread repeatedly
+    snapshotting, and asserts no exception surfaces and the lifetime total
+    matches the writer's actual append count exactly — a mutating snapshot()
+    reading/popping the same deque from another thread would risk a missed or
+    duplicated eviction under interleaving, this proves there is none.
+    """
+    from coffee_roaster_mcp.audio import _OverflowTracker  # pyright: ignore[reportPrivateUsage]
+
+    tracker = _OverflowTracker(monotonic_now=time.monotonic)
+    write_count = 500
+    errors: list[BaseException] = []
+
+    def writer() -> None:
+        for _ in range(write_count):
+            tracker.observe_overflow(estimated_lost_audio_ms=1.0)
+
+    def reader() -> None:
+        try:
+            for _ in range(write_count):
+                snapshot = tracker.snapshot()
+                assert snapshot.count_last_minute >= 0
+                assert snapshot.total_count >= 0
+        except BaseException as exc:  # noqa: BLE001 - surfaced via the errors list
+            errors.append(exc)
+
+    writer_thread = Thread(target=writer)
+    reader_thread = Thread(target=reader)
+    reader_thread.start()
+    writer_thread.start()
+    writer_thread.join(timeout=5.0)
+    reader_thread.join(timeout=5.0)
+
+    assert not writer_thread.is_alive()
+    assert not reader_thread.is_alive()
+    assert errors == []
+    assert tracker.snapshot().total_count == write_count
+
+
+def test_microphone_audio_input_overflow_snapshot_tracks_overflows() -> None:
+    """The mic input exposes overflow diagnostics fed by real overflowed reads (#190)."""
+    FakeRawInputStream.created.clear()
+    settings = audio_capture_settings_from_config(AudioConfig(source="microphone", sample_rate=4))
+    clock = ClockHarness()
+    clock.value = 0.0
+    audio_input = MicrophoneAudioInput(
+        settings,
+        sounddevice_module=FakeSoundDeviceModule(),
+        max_consecutive_overflows=10,
+        monotonic_now=lambda: clock.value,
+    )
+
+    try:
+        baseline = audio_input.overflow_snapshot
+        assert baseline.count_last_minute == 0
+        assert baseline.total_count == 0
+
+        audio_input.read_samples(1)  # opens the stream; clean read
+        stream = FakeRawInputStream.created[-1]
+        stream.overflowed = True
+        audio_input.read_samples(1)  # one overflowed read of 1 sample @ 4Hz
+        stream.overflowed = True
+        audio_input.read_samples(1)  # a second overflowed read
+
+        snapshot = audio_input.overflow_snapshot
+        assert snapshot.count_last_minute == 2
+        assert snapshot.total_count == 2
+        # Each overflow is an upper-bound estimate of one read's expected
+        # duration: 1 sample @ 4Hz = 250ms, so two overflows = 500ms.
+        assert snapshot.estimated_lost_audio_ms_last_minute == 500.0
+    finally:
+        audio_input.close()
+
+
+def test_audio_capture_pipeline_snapshot_surfaces_mic_overflow_stats() -> None:
+    """AudioCapturePipeline.snapshot() reports the mic input's overflow stats (#190)."""
+    FakeRawInputStream.created.clear()
+    settings = audio_capture_settings_from_config(AudioConfig(source="microphone", sample_rate=4))
+    clock = ClockHarness()
+    clock.value = 0.0
+    audio_input = MicrophoneAudioInput(
+        settings,
+        sounddevice_module=FakeSoundDeviceModule(),
+        max_consecutive_overflows=10,
+        monotonic_now=lambda: clock.value,
+    )
+    pipeline = AudioCapturePipeline(settings=settings, audio_input=audio_input)
+
+    try:
+        pipeline.start()
+        stream = FakeRawInputStream.created[-1]
+        stream.overflowed = True
+        # Drive one overflowed read directly through the input the pipeline owns
+        # (avoids depending on worker-thread scheduling for this assertion).
+        audio_input.read_samples(1)
+
+        snapshot = pipeline.snapshot()
+        assert snapshot.overflow_count_last_minute == 1
+        assert snapshot.total_overflow_count == 1
+        assert snapshot.estimated_lost_audio_ms_last_minute == 250.0
+    finally:
+        pipeline.stop()
+
+
+def test_audio_capture_pipeline_snapshot_zero_overflow_for_non_mic_input() -> None:
+    """A non-microphone AudioInput (no overflow_snapshot) reports zero stats,
+    not an error (#190)."""
+    audio_input = FiniteAudioInput((0.1, 0.2, 0.3, 0.4))
+    settings = audio_capture_settings_from_config(AudioConfig(sample_rate=4))
+    pipeline = AudioCapturePipeline(settings=settings, audio_input=audio_input)
+
+    snapshot = pipeline.snapshot()
+
+    assert snapshot.overflow_count_last_minute == 0
+    assert snapshot.estimated_lost_audio_ms_last_minute == 0.0
+    assert snapshot.total_overflow_count == 0

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -386,6 +386,54 @@ def test_runtime_overflow_stats_survive_stop_unlike_live_mic_levels() -> None:
     assert stopped.total_overflow_count == 42
 
 
+def test_runtime_overflow_rolling_fields_decay_60s_after_stop() -> None:
+    """coffee-roaster-mcp#193 review finding: overflow_count_last_minute and
+    estimated_lost_audio_ms_last_minute are contractually a trailing-60-
+    SECOND rolling window (AudioCaptureSnapshot's docstring). Carrying them
+    through unchanged at stop (the sibling test above, task #59) must not
+    leave them frozen forever — a poll 60+ seconds after stop must see them
+    decayed to zero, same as a live rolling window naturally would. The
+    lifetime total_overflow_count is a whole-roast figure, not a rolling
+    one, so it must stay frozen regardless of how long ago capture stopped.
+    """
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    pipeline = FakeAudioPipeline(
+        overflow_count_last_minute=7,
+        estimated_lost_audio_ms_last_minute=700.0,
+        total_overflow_count=42,
+    )
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio")),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            MockDetectorBackend(()),
+        ),
+        monotonic_now=clock.monotonic_now,
+    )
+
+    runtime.start_for_session(session)
+    runtime.stop_for_session(session.id, reason="roast complete")
+
+    # A poll shortly after stop still sees the accurate figures.
+    clock.monotonic_value += 30.0
+    soon_after_stop = runtime.snapshot()
+    assert soon_after_stop.overflow_count_last_minute == 7
+    assert soon_after_stop.estimated_lost_audio_ms_last_minute == 700.0
+    assert soon_after_stop.total_overflow_count == 42
+
+    # A poll 60+ seconds after stop must see the rolling fields decayed —
+    # the lifetime total is untouched.
+    clock.monotonic_value += 31.0
+    long_after_stop = runtime.snapshot()
+    assert long_after_stop.overflow_count_last_minute == 0
+    assert long_after_stop.estimated_lost_audio_ms_last_minute == 0.0
+    assert long_after_stop.total_overflow_count == 42
+
+
 def test_audio_runtime_can_discard_queued_pre_t0_windows() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -346,6 +346,46 @@ def test_runtime_mic_levels_are_live_only_and_none_after_stop() -> None:
     assert stopped.mic_rms_dbfs is None
 
 
+def test_runtime_overflow_stats_survive_stop_unlike_live_mic_levels() -> None:
+    """Overflow stats (#190 review finding) are the OPPOSITE of mic levels:
+    they must SURVIVE stop_for_session, not go None/zero. An operator
+    reviewing a roast right after drop/stop is exactly when the roast's
+    overflow history matters most — zeroing it out at the moment it's
+    needed would be a real observability gap.
+    """
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    pipeline = FakeAudioPipeline(
+        overflow_count_last_minute=7,
+        estimated_lost_audio_ms_last_minute=700.0,
+        total_overflow_count=42,
+    )
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio")),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            MockDetectorBackend(()),
+        ),
+    )
+
+    runtime.start_for_session(session)
+    live = runtime.snapshot()
+    assert live.overflow_count_last_minute == 7
+    assert live.estimated_lost_audio_ms_last_minute == 700.0
+    assert live.total_overflow_count == 42
+
+    stopped = runtime.stop_for_session(session.id, reason="roast complete")
+    assert stopped.audio_running is False
+    # Unlike mic_peak_dbfs/mic_rms_dbfs (live-only, correctly None here),
+    # overflow stats carry through unchanged.
+    assert stopped.overflow_count_last_minute == 7
+    assert stopped.estimated_lost_audio_ms_last_minute == 700.0
+    assert stopped.total_overflow_count == 42
+
+
 def test_audio_runtime_can_discard_queued_pre_t0_windows() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -53,12 +53,18 @@ class FakeAudioPipeline:
         running_after_stop: bool = False,
         peak_dbfs: float | None = None,
         rms_dbfs: float | None = None,
+        overflow_count_last_minute: int = 0,
+        estimated_lost_audio_ms_last_minute: float = 0.0,
+        total_overflow_count: int = 0,
     ) -> None:
         self._windows = list(windows)
         self.latest_error = latest_error
         self.running_after_stop = running_after_stop
         self.peak_dbfs = peak_dbfs
         self.rms_dbfs = rms_dbfs
+        self.overflow_count_last_minute = overflow_count_last_minute
+        self.estimated_lost_audio_ms_last_minute = estimated_lost_audio_ms_last_minute
+        self.total_overflow_count = total_overflow_count
         self.started = False
         self.stopped = False
         self.stop_reasons: list[float] = []
@@ -95,6 +101,9 @@ class FakeAudioPipeline:
             latest_error=self.latest_error,
             peak_dbfs=self.peak_dbfs,
             rms_dbfs=self.rms_dbfs,
+            overflow_count_last_minute=self.overflow_count_last_minute,
+            estimated_lost_audio_ms_last_minute=self.estimated_lost_audio_ms_last_minute,
+            total_overflow_count=self.total_overflow_count,
         )
 
 

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -11,7 +11,7 @@ from coffee_roaster_mcp.artifacts import (
     ResolvedArtifact,
     ResolvedDetectorArtifacts,
 )
-from coffee_roaster_mcp.audio import AudioCaptureSnapshot, AudioWindow
+from coffee_roaster_mcp.audio import AudioCaptureError, AudioCaptureSnapshot, AudioWindow
 from coffee_roaster_mcp.config import AppConfig, AudioConfig, FirstCrackConfig
 from coffee_roaster_mcp.detector import (
     FirstCrackDetectorAdapter,
@@ -432,6 +432,65 @@ def test_runtime_overflow_rolling_fields_decay_60s_after_stop() -> None:
     assert long_after_stop.overflow_count_last_minute == 0
     assert long_after_stop.estimated_lost_audio_ms_last_minute == 0.0
     assert long_after_stop.total_overflow_count == 42
+
+
+def test_runtime_overflow_rolling_fields_decay_from_last_live_poll_when_stop_itself_fails() -> None:
+    """coffee-roaster-mcp#193 review finding, round 2: decay must be keyed
+    off the AGE of the events behind the aggregate — the LAST LIVE poll
+    that actually observed them — not off time-since-STOP as a proxy.
+    Normally `stop_for_session`'s own `pipeline.stop()` call is itself a
+    fresh live read, so its "as of" instant IS the stop instant. But if
+    `pipeline.stop()` itself RAISES, `_last_capture_snapshot` is never
+    refreshed by that call — it retains whatever the LAST SUCCESSFUL live
+    poll observed, which can be arbitrarily older than "now" the moment
+    stop_for_session returns. Decay must measure from that live poll's
+    true age, not incorrectly reset the clock to the (failed) stop attempt.
+    """
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+
+    class _StopFailingPipeline(FakeAudioPipeline):
+        def stop(self, *, timeout_seconds: float = 1.0) -> AudioCaptureSnapshot:
+            raise AudioCaptureError("device unplugged mid-stop")
+
+    pipeline = _StopFailingPipeline(
+        overflow_count_last_minute=7,
+        estimated_lost_audio_ms_last_minute=700.0,
+        total_overflow_count=42,
+    )
+    runtime = FirstCrackSessionRuntime(
+        config=AppConfig(first_crack=FirstCrackConfig(mode="audio")),
+        audio_pipeline_factory=lambda _: pipeline,
+        detector_adapter_factory=lambda config: build_first_crack_detector_adapter(
+            config,
+            _resolved_detector_artifacts(),
+            MockDetectorBackend(()),
+        ),
+        monotonic_now=clock.monotonic_now,
+    )
+
+    runtime.start_for_session(session)
+    # One live poll observes the aggregate — this is the true "as of" instant.
+    live_poll = runtime.snapshot()
+    assert live_poll.overflow_count_last_minute == 7
+
+    # A long stretch passes with capture still running but no further poll —
+    # the aggregate is now 90 seconds old.
+    clock.monotonic_value += 90.0
+
+    # stop_for_session's own pipeline.stop() call RAISES, so it can never
+    # refresh _last_capture_snapshot with a fresh stop-instant read — the
+    # 90-second-old live poll is all that remains.
+    stopped = runtime.stop_for_session(session.id, reason="roast complete")
+    # The stop failure itself faults the runtime; the overflow fields must
+    # still reflect the correctly-decayed 90-second-old aggregate rather
+    # than a value frozen fresh at the (failed) stop instant.
+    assert stopped.status == "faulted"
+    assert stopped.overflow_count_last_minute == 0
+    assert stopped.estimated_lost_audio_ms_last_minute == 0.0
+    # The lifetime total survives regardless of decay.
+    assert stopped.total_overflow_count == 42
 
 
 def test_audio_runtime_can_discard_queued_pre_t0_windows() -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1657,6 +1657,9 @@ class FakeFirstCrackRuntime:
         processed_window_count: int = 0,
         mic_peak_dbfs: float | None = None,
         mic_rms_dbfs: float | None = None,
+        overflow_count_last_minute: int = 0,
+        estimated_lost_audio_ms_last_minute: float = 0.0,
+        total_overflow_count: int = 0,
     ) -> None:
         self.status = status
         self.reason = reason
@@ -1668,6 +1671,9 @@ class FakeFirstCrackRuntime:
         self.processed_window_count = processed_window_count
         self.mic_peak_dbfs = mic_peak_dbfs
         self.mic_rms_dbfs = mic_rms_dbfs
+        self.overflow_count_last_minute = overflow_count_last_minute
+        self.estimated_lost_audio_ms_last_minute = estimated_lost_audio_ms_last_minute
+        self.total_overflow_count = total_overflow_count
         self.active_session_id: str | None = None
         self.started_sessions: list[str] = []
         self.processed_sessions: list[str] = []
@@ -1726,6 +1732,9 @@ class FakeFirstCrackRuntime:
             processed_window_count=self.processed_window_count,
             mic_peak_dbfs=self.mic_peak_dbfs,
             mic_rms_dbfs=self.mic_rms_dbfs,
+            overflow_count_last_minute=self.overflow_count_last_minute,
+            estimated_lost_audio_ms_last_minute=self.estimated_lost_audio_ms_last_minute,
+            total_overflow_count=self.total_overflow_count,
         )
 
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -77,13 +77,16 @@ _EXPECTED_FIRST_CRACK_STATUS_KEYS = {
     "detected_monotonic_seconds",
     "dropped_window_count",
     "emitted_window_count",
+    "estimated_lost_audio_ms_last_minute",
     "mic_peak_dbfs",
     "mic_rms_dbfs",
     "mode",
+    "overflow_count_last_minute",
     "processed_window_count",
     "queued_window_count",
     "reason",
     "status",
+    "total_overflow_count",
 }
 _EXPECTED_T0_STATUS_KEYS = {
     "auto_detection_enabled",


### PR DESCRIPTION
## Summary

#190 reports sustained microphone input-overflow streaks visible only in
stderr warning logs — the first ask in that issue is to make this
operator-visible in `fc_status`, the established diagnosis surface, before
attacking the root cause.

This PR adds three new `fc_status` fields:

- `overflow_count_last_minute` — overflow events in the trailing 60 seconds
  of wall-clock time.
- `estimated_lost_audio_ms_last_minute` — estimated milliseconds of audio at
  risk from those events.
- `total_overflow_count` — lifetime overflow count for the current capture
  run, for a whole-roast severity view alongside the rolling figures.

## Estimation method (explicit upper bound)

PortAudio's blocking-read `overflowed` flag reports only that input was lost
*since the previous read* — never a sample count. Each overflow event's
"lost audio" contribution is therefore estimated as the requested read's
expected duration (`sample_count / sample_rate`), documented throughout as
an **upper bound**, not an exact lost-sample figure. This is stated on
`AudioCaptureSnapshot`, `OverflowSnapshot`, and every field that surfaces it
downstream, so no consumer can mistake it for a precise measurement.

## Implementation

- New `_OverflowTracker` (60-second rolling window + lifetime total) fed by
  `MicrophoneAudioInput` on every overflowed `stream.read()`.
- New `OverflowSnapshot` dataclass.
- Plumbed `AudioCaptureSnapshot` → `FirstCrackRuntimeSnapshot` →
  `FirstCrackStatus` (`fc_status`).
- Non-microphone `AudioInput` implementations (WAV replay, test doubles)
  duck-type to zero via `getattr` — no interface change required.

### Thread-safety finding (folded pre-review)

While answering a safety-review question about a related change, I found
that `_OverflowTracker.snapshot()` was mutating the same internal `deque`
the writer thread appends to — contradicting its own single-writer
docstring. `snapshot()` is now strictly **read-only** (filters without
mutating), so a reader thread can call it at any time without racing the
writer's mutations, rather than relying on CPython's GIL for a compound
evict-on-read. Added a concurrent writer/reader regression test for this
(`test_overflow_tracker_snapshot_is_read_only_and_thread_safe`).

## Testing

Five new focused tests in `test_audio.py`: rolling accumulation within the
trailing minute, 60-second eviction (with the lifetime total surviving
eviction), the concurrency regression above, real overflowed-read wiring
through `MicrophoneAudioInput.overflow_snapshot`, and confirmation that a
non-mic `AudioInput` reports zero stats rather than erroring.

This also correctly reddened `test_package.py`'s exact `fc_status` key-set
contract assertion over the real MCP stdio protocol until the three new
keys were added there — exactly the kind of pre-open catch the size/contract
discipline is for.

Full suite green, `ruff check` / `ruff format --check` clean, `pyright`
strict 0 errors, coverage 91%+ against the 90% floor.

## Notes for review

- `fc_status` additions are purely additive (new optional-with-default
  fields); nothing existing changes shape.
- The agent repo (`roastpilot-agent`) has its own typed MCP mirror of this
  contract. `mcp-contract-checker` will run against those mirrors before any
  release that carries this change — no release is planned until all three
  #190/#191 PRs (this one, #192, and the still-in-progress capture-thread
  fix) are merged.

Refs #190 (the capture-thread redesign — the root-cause fix, not this
instrumentation — is the remaining item before #190 can close)
