### PR TITLE
fix(#190): dedicated capture thread to eliminate blocking-read starvation

### DIFF
--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -1541,10 +1541,31 @@ class AudioCapturePipeline:
         return self._settings
 
     def start(self) -> AudioCaptureSnapshot:
-        """Start background audio capture and return the current status snapshot."""
+        """Start background audio capture and return the current status snapshot.
+
+        Raises:
+            AudioCaptureError: If the processing thread is still running, OR
+                if the reader thread is still running (coffee-roaster-mcp#195
+                review finding, final fold). `stop()` joins each thread
+                against its own `timeout_seconds` budget — the processing
+                thread is never blocked in a syscall so it exits quickly,
+                but the reader thread CAN still be mid-blocking-read and
+                genuinely time out. Checking only the processing thread
+                here would let a caller start a SECOND reader thread
+                against the same still-alive `_audio_input` — two threads
+                racing the same native PortAudio stream, which is exactly
+                the class of corruption the single-reader-owns-reads
+                invariant (#190) exists to prevent.
+        """
         with self._state_lock:
             if self._thread is not None and self._thread.is_alive():
                 raise AudioCaptureError("Audio capture pipeline is already running.")
+            if self._reader_thread is not None and self._reader_thread.is_alive():
+                raise AudioCaptureError(
+                    "Audio capture pipeline's reader thread from a previous "
+                    "stop() is still running (it likely timed out mid-read); "
+                    "cannot start a second reader against the same input."
+                )
             self._reset_run_state_locked()
             self._stop_requested.clear()
             # Two threads (#190): the reader does ONLY stream.read() + enqueue,
@@ -1604,6 +1625,28 @@ class AudioCapturePipeline:
             processing_thread.join(timeout=timeout_seconds)
         if reader_thread is not None:
             reader_thread.join(timeout=timeout_seconds)
+        # coffee-roaster-mcp#195 review finding (final fold): the processing
+        # thread's stop-drain above uses timeout=0 once _stop_requested is
+        # set, so it can observe an EMPTY _raw_reads and exit while the
+        # reader thread is still mid-blocking-read — the reader's one
+        # remaining chunk (queued in its own finally, or via the shutdown
+        # sentinel put) then has no consumer, the same class of gap the
+        # earlier drain-on-stop fix closed for the processing thread's OWN
+        # queue drain, just one chunk narrower. By this point both threads
+        # have joined (or the join timed out, in which case a thread still
+        # racing this drain is itself the documented fallback-finalize
+        # case below), so draining and processing whatever landed in
+        # _raw_reads after the processing thread's own loop exited is safe:
+        # no other thread is writing to _sample_buffer/_buffered_chunk_bounds
+        # or the recorder at this point.
+        while True:
+            try:
+                chunk = self._raw_reads.get_nowait()
+            except Empty:
+                break
+            if chunk is not None:
+                with suppress(Exception):
+                    self._process_captured_chunk(chunk)
         snapshot = self.snapshot()
         if reader_thread is None:
             # No reader thread ever ran (e.g. start() failed before spawning
@@ -1765,12 +1808,24 @@ class AudioCapturePipeline:
         try:
             while not self._stop_requested.is_set():
                 raw_samples = self._audio_input.read_samples(self._reader_chunk_sample_count)
-                # Stamp the capture instant IMMEDIATELY on read() returning —
-                # before normalize/queue work — so it reflects when the
-                # device actually produced this audio, not when the
-                # processing thread eventually gets to it (#190 review
-                # finding: under backlog the two can differ by seconds).
-                captured_at = self._monotonic_now()
+                # Stamp IMMEDIATELY on read() returning — before
+                # normalize/queue work — so it reflects when the device
+                # actually produced this audio, not when the processing
+                # thread eventually gets to it (#190 review finding: under
+                # backlog the two can differ by seconds).
+                #
+                # read_samples() is a BLOCKING call that returns once the
+                # requested samples have been captured, so `monotonic_now()`
+                # here is the instant capture of this chunk FINISHED (block
+                # END), not when it started (coffee-roaster-mcp#195 review
+                # finding, final fold) — a systematic ~one-chunk-duration
+                # late bias (~100ms at the default 0.1s reader chunk) on
+                # every capture timestamp in the system, since every
+                # downstream window/drop/T0 bound derives from this stamp.
+                # Back-date by the ACTUAL returned sample count's duration
+                # (not the requested count — a short/partial read genuinely
+                # took less time) to recover the true block-START instant.
+                completed_at = self._monotonic_now()
                 # Explicit len() check, not `if not raw_samples:` (#190
                 # review finding P3) — see _normalize_samples_block's
                 # docstring for why a numpy-array-returning AudioInput would
@@ -1778,6 +1833,7 @@ class AudioCapturePipeline:
                 if len(raw_samples) == 0:
                     time.sleep(self._settings.idle_sleep_seconds)
                     continue
+                captured_at = round(completed_at - len(raw_samples) / self._settings.sample_rate, 6)
                 samples = _normalize_samples_block(raw_samples)
                 # Blocking put with no timeout is intentional: a full queue
                 # means the processing thread has fallen far behind (30
@@ -1984,9 +2040,18 @@ class AudioCapturePipeline:
 
         Mirrors ``del self._sample_buffer[:sample_count]`` so the two stay in
         lockstep: full chunks entirely consumed by the trim are dropped, and
-        a chunk only partially consumed has its recorded length reduced (its
-        capture instant is unchanged — capture time is per-chunk, not
-        re-derived per sample).
+        a chunk only partially consumed has its recorded length reduced AND
+        its capture instant advanced by the trimmed portion's duration
+        (coffee-roaster-mcp#195 review finding, final fold) — samples within
+        one chunk were captured back-to-back at the configured sample rate
+        (the same assumption `_chunk_capture_time_at_offset` already makes),
+        so the remainder's first sample was captured
+        ``trimmed_samples / sample_rate`` seconds AFTER the chunk's original
+        ``captured_at``, not at the same instant as the whole original
+        chunk. Leaving the timestamp unadvanced understated every
+        subsequent window's start by up to one chunk's duration whenever a
+        partial trim landed inside it (the overlapping-windows case, since a
+        non-overlapping hop always trims whole chunks or nothing).
         """
         remaining = sample_count
         while remaining > 0 and self._buffered_chunk_bounds:
@@ -1995,7 +2060,10 @@ class AudioCapturePipeline:
                 self._buffered_chunk_bounds.popleft()
                 remaining -= chunk_length
             else:
-                self._buffered_chunk_bounds[0] = (captured_at, chunk_length - remaining)
+                advanced_captured_at = round(
+                    captured_at + remaining / self._settings.sample_rate, 6
+                )
+                self._buffered_chunk_bounds[0] = (advanced_captured_at, chunk_length - remaining)
                 remaining = 0
 
     def _publish_window(self, window: AudioWindow) -> None:

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -1484,6 +1484,16 @@ class AudioCapturePipeline:
         self._windows: Queue[AudioWindow] = Queue(maxsize=settings.queue_limit)
         self._sample_buffer: list[float] = []
         self._stop_requested = Event()
+        # coffee-roaster-mcp#195 CI follow-up: a runtime-boundary discard
+        # (charge/T0) must drop audio buffered ANYWHERE in the pipeline, not
+        # just already-emitted windows. _sample_buffer/_buffered_chunk_bounds
+        # are single-writer state owned by the processing thread — this flag
+        # asks that thread to clear them itself on its next iteration rather
+        # than mutating them from the caller's thread, which would race the
+        # same way #193's un-locked deque did. The ack Event lets the caller
+        # wait deterministically instead of guessing a sleep duration.
+        self._discard_pending_audio_requested = Event()
+        self._discard_pending_audio_acknowledged = Event()
         self._state_lock = Lock()
         self._thread: Thread | None = None
         self._next_sequence_number = 0
@@ -1652,6 +1662,51 @@ class AudioCapturePipeline:
         except Empty:
             return None
 
+    def discard_pending_audio(self, *, timeout_seconds: float = 1.0) -> None:
+        """Drop every window/chunk/sample buffered anywhere in the pipeline.
+
+        coffee-roaster-mcp#195 CI follow-up: `drain_windows()` alone only
+        clears already-emitted windows. Audio captured before a runtime
+        boundary (e.g. `beans_added`) can still be sitting unprocessed in
+        the reader thread's backlog or the processing thread's partial
+        sample buffer at the moment the boundary is recorded — and with
+        accurate capture-time window stamps (#190/#195), that stale audio
+        can later be assembled into a window whose `started_at_monotonic_seconds`
+        predates the boundary. Call this immediately after recording the
+        boundary event to guarantee no pre-boundary audio survives into a
+        later window.
+
+        When the processing thread is running, the discard is requested and
+        this method blocks (bounded by `timeout_seconds`) until that thread
+        acknowledges having cleared its own single-writer state — mutating
+        `_sample_buffer` from this thread instead would race the processing
+        thread's own writes to it. When the thread is not running, there is
+        no concurrent writer, so the buffers are cleared directly.
+
+        Args:
+            timeout_seconds: Maximum time to wait for the processing thread
+                to acknowledge the discard. A timeout is a defensive
+                fallback only (e.g. a wedged worker) — normal operation
+                acknowledges in well under a millisecond since the discard
+                check runs at the top of every loop iteration.
+        """
+        thread = self._thread
+        if thread is None or not thread.is_alive():
+            self._clear_buffered_audio()
+            return
+        self._discard_pending_audio_acknowledged.clear()
+        self._discard_pending_audio_requested.set()
+        if not self._discard_pending_audio_acknowledged.wait(timeout=timeout_seconds):
+            _LOGGER.warning(
+                "Audio capture discard request was not acknowledged within "
+                "%.1fs; the processing thread may be wedged. Falling back to "
+                "a direct clear, which races that thread's writes but is "
+                "safer than leaving stale pre-boundary audio buffered.",
+                timeout_seconds,
+            )
+            self._clear_buffered_audio()
+            self._discard_pending_audio_requested.clear()
+
     def drain_windows(self, *, max_windows: int | None = None) -> tuple[AudioWindow, ...]:
         """Return all currently queued detector windows without blocking."""
         if max_windows is not None and max_windows < 0:
@@ -1766,6 +1821,20 @@ class AudioCapturePipeline:
                 self._disable_recorder()
         try:
             while True:
+                if self._discard_pending_audio_requested.is_set():
+                    # coffee-roaster-mcp#195 CI follow-up: a runtime boundary
+                    # (e.g. beans_added) was just recorded and the caller
+                    # wants every window/chunk/sample buffered anywhere in
+                    # this pipeline dropped — not just the already-emitted
+                    # windows drain_windows() can see. Clear from THIS
+                    # thread (the single writer of _sample_buffer /
+                    # _buffered_chunk_bounds) so no pre-boundary audio can
+                    # survive into the next emitted window with an
+                    # accurate-but-stale capture-time stamp.
+                    self._clear_buffered_audio()
+                    self._discard_pending_audio_requested.clear()
+                    self._discard_pending_audio_acknowledged.set()
+                    continue
                 stop_was_requested = self._stop_requested.is_set()
                 try:
                     # #190 review finding (P1): once stop() sets
@@ -1939,15 +2008,23 @@ class AudioCapturePipeline:
         with self._state_lock:
             self._emitted_window_count += 1
 
-    def _reset_run_state_locked(self) -> None:
+    def _clear_buffered_audio(self) -> None:
+        """Drop every window/chunk/sample currently buffered anywhere in the
+        pipeline: the emitted-window queue, the reader's raw-chunk backlog,
+        and the processing thread's own partial sample buffer.
+
+        Safe to call from `start()` before either worker thread exists. Once
+        the processing thread is running, `_sample_buffer` and
+        `_buffered_chunk_bounds` are its single-writer state — only that
+        thread may call this (see `_run_processing_loop`'s discard check);
+        `_windows` and `_raw_reads` are thread-safe `Queue`s so draining them
+        from any thread is fine.
+        """
         while True:
             try:
                 self._windows.get_nowait()
             except Empty:
                 break
-        # Also drain any raw sample blocks left over from a prior run (#190):
-        # a fresh start() must never process stale audio queued before this
-        # restart.
         while True:
             try:
                 self._raw_reads.get_nowait()
@@ -1955,6 +2032,12 @@ class AudioCapturePipeline:
                 break
         self._sample_buffer.clear()
         self._buffered_chunk_bounds.clear()
+
+    def _reset_run_state_locked(self) -> None:
+        # Also drain any raw sample blocks left over from a prior run (#190):
+        # a fresh start() must never process stale audio queued before this
+        # restart.
+        self._clear_buffered_audio()
         self._next_sequence_number = 0
         self._emitted_window_count = 0
         self._dropped_window_count = 0

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -26,6 +26,13 @@ DEFAULT_AUDIO_WINDOW_SECONDS = 1.0
 DEFAULT_AUDIO_WINDOW_QUEUE_LIMIT = 8
 DEFAULT_AUDIO_IDLE_SLEEP_SECONDS = 0.01
 
+#: Bounded queue between the dedicated reader thread and the processing
+#: thread (#190). ~3s of headroom at the default 100ms reader chunk size —
+#: enough to absorb a genuine processing stall without unbounded memory
+#: growth; a reader that outpaces processing this much for this long
+#: indicates the processing thread itself is starved for a different reason.
+_READER_QUEUE_MAXSIZE = 30
+
 
 class AudioCaptureError(RuntimeError):
     """Raised when audio capture cannot be configured or run."""
@@ -1461,6 +1468,26 @@ class AudioCapturePipeline:
         # is visible under real roasting conditions, where the quiet pre-roast
         # floor differs from the in-roast level.
         self._level_meter = _RollingLevelMeter(window_sample_count=settings.window_sample_count)
+        # Dedicated capture thread (#190): the ONLY job of this thread is
+        # stream.read() + enqueue. Metering, recording (numpy PCM16 encode),
+        # windowing, and detector-queue publish all run on the SEPARATE
+        # processing thread below, draining this queue. Before this split, a
+        # single thread did all of that work between successive read() calls,
+        # and PortAudio's input ring buffer has no slack for that — under CPU
+        # contention (concurrent ONNX inference + dual recording writers) the
+        # gap between reads exceeded the buffer and the OS reported overflow.
+        # A bounded queue here (not unbounded) still lets read() run far more
+        # often than the processing work does, while capping memory if the
+        # processing thread ever falls meaningfully behind.
+        self._raw_reads: Queue[tuple[float, ...] | None] = Queue(maxsize=_READER_QUEUE_MAXSIZE)
+        self._reader_thread: Thread | None = None
+        # Fixed small read chunk (independent of the processing thread's
+        # buffer state) so read() cadence never depends on how much work the
+        # processing thread still has queued up — the two loops are fully
+        # decoupled. ~100ms at the configured sample rate: small enough to
+        # keep PortAudio's buffer well-drained, large enough not to spin on
+        # syscalls.
+        self._reader_chunk_sample_count = max(1, round(settings.sample_rate * 0.1))
 
     @property
     def settings(self) -> AudioCaptureSettings:
@@ -1474,27 +1501,47 @@ class AudioCapturePipeline:
                 raise AudioCaptureError("Audio capture pipeline is already running.")
             self._reset_run_state_locked()
             self._stop_requested.clear()
+            # Two threads (#190): the reader does ONLY stream.read() + enqueue,
+            # so PortAudio's ring buffer is drained on a cadence that never
+            # depends on metering/recording/windowing work. The processing
+            # thread does everything else, pulling from the reader's queue.
+            self._reader_thread = Thread(
+                target=self._run_reader_loop,
+                name="coffee-roaster-audio-reader",
+                daemon=True,
+            )
             self._thread = Thread(
-                target=self._run_capture_loop,
+                target=self._run_processing_loop,
                 name="coffee-roaster-audio-capture",
                 daemon=True,
             )
+            self._reader_thread.start()
             self._thread.start()
         return self.snapshot()
 
     def stop(self, *, timeout_seconds: float = 1.0) -> AudioCaptureSnapshot:
-        """Request capture stop and wait briefly for the worker to finish.
+        """Request capture stop and wait briefly for both threads to finish.
 
-        The audio input is closed by the worker thread itself once its read loop
-        exits, so its native (PortAudio) stream is never freed while a read is in
-        flight on the worker. This method only closes the input directly as a
-        fallback when no worker thread is (still) running — for example, when
-        ``start`` failed or the worker already finished without closing. Closing
-        from this caller thread while the worker is still alive would free the
-        ring buffer under an in-flight ``read`` and crash the process.
+        The audio input is closed by the READER thread itself once its read
+        loop exits, so its native (PortAudio) stream is never freed while a
+        read is in flight (#190: reading is now the reader thread's ONLY
+        job). This method only closes the input directly as a fallback when
+        no reader thread is (still) running — for example, when ``start``
+        failed before spawning it. Closing from this caller thread while the
+        reader is still alive would free the ring buffer under an in-flight
+        ``read`` and crash the process.
+
+        Join order: the PROCESSING thread first (it is never blocked in a
+        syscall — once it observes the stop signal it drains whatever the
+        reader already enqueued and exits quickly), then the READER thread
+        (which may still be mid-blocking-read and can take up to
+        ``timeout_seconds`` to notice the stop signal on its next loop
+        iteration). Each gets its own ``timeout_seconds`` budget rather than
+        splitting one budget between them, so a slow reader join never
+        starves the processing thread's join of time it needs.
 
         Args:
-            timeout_seconds: Maximum time to wait for the worker thread to exit.
+            timeout_seconds: Maximum time to wait for EACH thread to exit.
 
         Returns:
             The capture status snapshot taken after the stop request.
@@ -1505,31 +1552,38 @@ class AudioCapturePipeline:
         if timeout_seconds < 0:
             raise AudioCaptureError("timeout_seconds must be >= 0.")
         self._stop_requested.set()
-        thread = self._thread
-        if thread is not None:
-            thread.join(timeout=timeout_seconds)
+        processing_thread = self._thread
+        reader_thread = self._reader_thread
+        if processing_thread is not None:
+            processing_thread.join(timeout=timeout_seconds)
+        if reader_thread is not None:
+            reader_thread.join(timeout=timeout_seconds)
         snapshot = self.snapshot()
-        if thread is None:
-            # No worker thread ever ran (e.g. start() failed before spawning the
-            # worker): close the input here as a fallback. Whenever a worker DID
-            # run it closes the input itself in its loop finally — on the thread
-            # that owns reads — whether it has already exited or is still draining
-            # a blocking read. So stop() must not also close it: that would double
-            # free / free under an in-flight read. (close() is idempotent anyway,
-            # but correctness here does not depend on that.)
+        if reader_thread is None:
+            # No reader thread ever ran (e.g. start() failed before spawning
+            # it): close the input here as a fallback. Whenever a reader DID
+            # run it closes the input itself in its loop finally — on the
+            # thread that owns reads — whether it has already exited or is
+            # still draining a blocking read. So stop() must not also close
+            # it: that would double free / free under an in-flight read.
+            # (close() is idempotent anyway, but correctness here does not
+            # depend on that.)
             _close_audio_input_if_supported(self._audio_input)
-        elif thread.is_alive():
-            # The worker did not exit within the join timeout — typically blocked
-            # in a read while the detector's first samples are still pending (AST
-            # model load). Its `finally` (which closes the recorder) will not run
-            # before this caller returns, and on process/lifespan shutdown the
-            # daemon worker can be killed before it ever does, leaving the WAV at
-            # 0 bytes and no sidecars (#176 hardware bug 2). Finalise the recorder
-            # HERE as a fallback: the recorder is thread-safe (its writer lock
-            # serialises this close against any in-flight worker write), and
-            # close() is idempotent, so the worker's later close() is a no-op. We
-            # do NOT touch the audio input — only the worker may free its native
-            # ring buffer.
+        if processing_thread is not None and processing_thread.is_alive():
+            # The processing thread did not exit within the join timeout —
+            # e.g. a genuinely slow recorder write (disk contention) still in
+            # flight at the exact moment stop() was called; #190's split
+            # means it is never blocked in stream.read() itself anymore, so
+            # this should now be rare. Its `finally` (which closes the
+            # recorder) will not run before this caller returns, and on
+            # process/lifespan shutdown the daemon thread can be killed
+            # before it ever does, leaving the WAV at 0 bytes and no
+            # sidecars (#176 hardware bug 2). Finalise the recorder HERE as a
+            # fallback: the recorder is thread-safe (its writer lock
+            # serialises this close against any in-flight processing-thread
+            # write), and close() is idempotent, so the processing thread's
+            # later close() is a no-op. We do NOT touch the audio input —
+            # only the reader thread may free its native ring buffer.
             self._finalize_recorder()
         return snapshot
 
@@ -1577,14 +1631,26 @@ class AudioCapturePipeline:
     def snapshot(self) -> AudioCaptureSnapshot:
         """Return a thread-safe capture status snapshot."""
         thread = self._thread
+        reader_thread = self._reader_thread
         # Read the coherent (peak, rms) pair in a single access so the snapshot
         # never mixes a peak and RMS from different meter updates (#178). The
         # meter is written outside _state_lock by the capture worker, so two
         # separate property reads could tear; one tuple read cannot.
         levels = self._level_meter.levels
         with self._state_lock:
+            # Both threads must be alive for capture to be genuinely running
+            # (#190): if the reader thread has died (e.g. a fatal overflow
+            # AudioCaptureError) while the processing thread is still
+            # draining a now-stale queue, reporting running=True would hide
+            # a real capture failure.
+            running = (
+                thread is not None
+                and thread.is_alive()
+                and reader_thread is not None
+                and reader_thread.is_alive()
+            )
             return AudioCaptureSnapshot(
-                running=thread is not None and thread.is_alive(),
+                running=running,
                 queued_window_count=self._windows.qsize(),
                 emitted_window_count=self._emitted_window_count,
                 dropped_window_count=self._dropped_window_count,
@@ -1593,7 +1659,53 @@ class AudioCapturePipeline:
                 rms_dbfs=None if levels is None else levels[1],
             )
 
-    def _run_capture_loop(self) -> None:
+    def _run_reader_loop(self) -> None:
+        """Drain the audio input as fast as possible; do nothing else (#190).
+
+        This thread's ONLY job is ``stream.read()`` + enqueue, so PortAudio's
+        input ring buffer is drained on a cadence independent of whatever the
+        processing thread (metering, recording, windowing) is doing. It is
+        also the thread that owns the audio input's lifecycle: it opens the
+        input implicitly on first read and closes it in ``finally``, exactly
+        preserving the pre-#190 invariant that only the thread performing
+        reads may free the native ring buffer — just moved to this thread
+        instead of the (former, now-processing-only) capture loop.
+        """
+        try:
+            while not self._stop_requested.is_set():
+                raw_samples = self._audio_input.read_samples(self._reader_chunk_sample_count)
+                if not raw_samples:
+                    time.sleep(self._settings.idle_sleep_seconds)
+                    continue
+                samples = _normalize_samples_block(raw_samples)
+                # Blocking put with no timeout is intentional: a full queue
+                # means the processing thread has fallen far behind (30
+                # chunks / ~3s at the default chunk size), at which point
+                # slowing the reader down is correct back-pressure rather
+                # than silently dropping raw audio the recorder/detector
+                # would otherwise never see at all.
+                self._raw_reads.put(samples)
+        except Exception as exc:  # noqa: BLE001 - backend/validation exceptions vary.
+            # Covers both a genuine read failure (device gone, backend error)
+            # and a validation failure (_normalize_sample rejecting a
+            # non-finite sample) — both are fatal to this capture run,
+            # exactly matching the pre-#190 single-loop error handling.
+            with self._state_lock:
+                self._latest_error = str(exc)
+            self._stop_requested.set()
+        finally:
+            # Close the audio input on the same thread that owns its reads —
+            # see the docstring above; this is the load-bearing invariant
+            # #190 must not disturb.
+            _close_audio_input_if_supported(self._audio_input)
+            # Sentinel: wake a processing thread that is blocked waiting for
+            # the next chunk so it notices shutdown promptly even if
+            # _stop_requested was set for a reason other than the caller's
+            # normal stop() (e.g. a read error above).
+            with suppress(Full):
+                self._raw_reads.put_nowait(None)
+
+    def _run_processing_loop(self) -> None:
         # Recording is strictly best-effort: a recorder error (including a
         # recording-START failure here) must NEVER kill detection. begin() runs
         # outside the main try below, so it gets its own fail-soft guard: on
@@ -1606,10 +1718,13 @@ class AudioCapturePipeline:
                 self._disable_recorder()
         try:
             while not self._stop_requested.is_set():
-                samples = self._read_next_samples()
-                if not samples:
-                    time.sleep(self._settings.idle_sleep_seconds)
+                try:
+                    samples = self._raw_reads.get(timeout=self._settings.idle_sleep_seconds)
+                except Empty:
                     continue
+                if samples is None:
+                    # Reader-thread shutdown sentinel (see _run_reader_loop).
+                    break
                 self._sample_buffer.extend(samples)
                 # Update the live mic-levels meter from the SAME samples the
                 # detector consumes (#178). Cheap, vectorised, and never raises;
@@ -1635,11 +1750,9 @@ class AudioCapturePipeline:
                 self._latest_error = str(exc)
             self._stop_requested.set()
         finally:
-            # Close the audio input on the same thread that owns its reads. This
-            # guarantees the underlying PortAudio stream's ring buffer is never
-            # freed while a read is in flight, which would otherwise segfault the
-            # process at end of roast (worker mid-read while the caller closes).
-            _close_audio_input_if_supported(self._audio_input)
+            # Unlike before #190, this thread never reads from the audio
+            # input, so it must NOT close it — only the reader thread may
+            # free the native ring buffer (see _run_reader_loop).
             if self._recorder is not None:
                 with suppress(Exception):
                     self._recorder.close()
@@ -1657,11 +1770,6 @@ class AudioCapturePipeline:
         if recorder is not None:
             with suppress(Exception):
                 recorder.close()
-
-    def _read_next_samples(self) -> tuple[float, ...]:
-        needed_samples = self._settings.window_sample_count - len(self._sample_buffer)
-        raw_samples = self._audio_input.read_samples(max(1, needed_samples))
-        return tuple(_normalize_sample(sample) for sample in raw_samples)
 
     def _emit_complete_windows(self) -> None:
         window_sample_count = self._settings.window_sample_count
@@ -1693,6 +1801,14 @@ class AudioCapturePipeline:
         while True:
             try:
                 self._windows.get_nowait()
+            except Empty:
+                break
+        # Also drain any raw sample blocks left over from a prior run (#190):
+        # a fresh start() must never process stale audio queued before this
+        # restart.
+        while True:
+            try:
+                self._raw_reads.get_nowait()
             except Empty:
                 break
         self._sample_buffer.clear()
@@ -1856,6 +1972,36 @@ def _normalize_sample(sample: float) -> float:
     if not math.isfinite(normalized):
         raise AudioCaptureError("audio samples must be finite numbers.")
     return normalized
+
+
+def _normalize_samples_block(raw_samples: Sequence[float]) -> tuple[float, ...]:
+    """Validate and normalize a full block of samples in one vectorised pass.
+
+    coffee-roaster-mcp#190: the per-sample Python-level ``_normalize_sample``
+    generator this replaces on the reader thread's hot path held the GIL for
+    every sample between successive ``stream.read()`` calls — at 16kHz with a
+    ~100ms reader chunk that is ~1,600 Python function calls per read,
+    exactly the class of per-read overhead that caused the original overflow
+    streaks, just relocated onto the reader thread instead of eliminated.
+    numpy does the finiteness check and float64 cast in C and releases the
+    GIL, so this no longer competes with concurrent inference/recording work
+    for read cadence.
+
+    Args:
+        raw_samples: Raw samples as returned by an ``AudioInput``.
+
+    Returns:
+        The validated samples as a tuple of Python floats.
+
+    Raises:
+        AudioCaptureError: If any sample is not finite.
+    """
+    if not raw_samples:
+        return ()
+    array = np.asarray(raw_samples, dtype=np.float64)
+    if not np.isfinite(array).all():
+        raise AudioCaptureError("audio samples must be finite numbers.")
+    return tuple(array.tolist())
 
 
 def _load_sounddevice() -> Any:

--- a/src/coffee_roaster_mcp/audio.py
+++ b/src/coffee_roaster_mcp/audio.py
@@ -9,6 +9,7 @@ import math
 import struct
 import time
 import wave
+from collections import deque
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
@@ -32,6 +33,33 @@ DEFAULT_AUDIO_IDLE_SLEEP_SECONDS = 0.01
 #: growth; a reader that outpaces processing this much for this long
 #: indicates the processing thread itself is starved for a different reason.
 _READER_QUEUE_MAXSIZE = 30
+
+
+@dataclass(frozen=True)
+class _CapturedChunk:
+    """One raw sample block plus the monotonic instant it was CAPTURED.
+
+    coffee-roaster-mcp#190 review finding: under reader/processing backlog
+    (the ``_raw_reads`` queue can hold up to ``_READER_QUEUE_MAXSIZE``
+    chunks), a chunk's samples can sit queued for up to several seconds
+    before the processing thread ever sees them. Stamping capture time in
+    the READER thread — at the ``stream.read()`` call itself, not at
+    eventual window emission — is what lets
+    :class:`AudioWindow`.started_at_monotonic_seconds reflect when the
+    audio was actually captured off the device rather than when the
+    processing thread got around to assembling a window from it. This is
+    the timestamp provenance the coffee-roaster-mcp#191 post-drop drain's
+    end-time bound (and every other consumer of window timestamps) depends
+    on being accurate.
+
+    Attributes:
+        samples: Normalized mono float samples for this chunk.
+        captured_at_monotonic_seconds: Monotonic instant the reader thread's
+            ``stream.read()`` call returned this chunk.
+    """
+
+    samples: tuple[float, ...]
+    captured_at_monotonic_seconds: float
 
 
 class AudioCaptureError(RuntimeError):
@@ -1479,7 +1507,7 @@ class AudioCapturePipeline:
         # A bounded queue here (not unbounded) still lets read() run far more
         # often than the processing work does, while capping memory if the
         # processing thread ever falls meaningfully behind.
-        self._raw_reads: Queue[tuple[float, ...] | None] = Queue(maxsize=_READER_QUEUE_MAXSIZE)
+        self._raw_reads: Queue[_CapturedChunk | None] = Queue(maxsize=_READER_QUEUE_MAXSIZE)
         self._reader_thread: Thread | None = None
         # Fixed small read chunk (independent of the processing thread's
         # buffer state) so read() cadence never depends on how much work the
@@ -1488,6 +1516,14 @@ class AudioCapturePipeline:
         # keep PortAudio's buffer well-drained, large enough not to spin on
         # syscalls.
         self._reader_chunk_sample_count = max(1, round(settings.sample_rate * 0.1))
+        # Chunk-boundary metadata for samples currently sitting in
+        # _sample_buffer, oldest first (#190 review finding). Each entry
+        # covers a contiguous run of samples with a known capture instant;
+        # _emit_complete_windows consults this to derive a window's true
+        # capture-time start instead of stamping it at emission time, which
+        # would drift from reality by however long the chunk sat queued in
+        # _raw_reads under processing backlog.
+        self._buffered_chunk_bounds: deque[tuple[float, int]] = deque()
 
     @property
     def settings(self) -> AudioCaptureSettings:
@@ -1674,7 +1710,17 @@ class AudioCapturePipeline:
         try:
             while not self._stop_requested.is_set():
                 raw_samples = self._audio_input.read_samples(self._reader_chunk_sample_count)
-                if not raw_samples:
+                # Stamp the capture instant IMMEDIATELY on read() returning —
+                # before normalize/queue work — so it reflects when the
+                # device actually produced this audio, not when the
+                # processing thread eventually gets to it (#190 review
+                # finding: under backlog the two can differ by seconds).
+                captured_at = self._monotonic_now()
+                # Explicit len() check, not `if not raw_samples:` (#190
+                # review finding P3) — see _normalize_samples_block's
+                # docstring for why a numpy-array-returning AudioInput would
+                # otherwise crash this thread on a truthiness check.
+                if len(raw_samples) == 0:
                     time.sleep(self._settings.idle_sleep_seconds)
                     continue
                 samples = _normalize_samples_block(raw_samples)
@@ -1684,7 +1730,9 @@ class AudioCapturePipeline:
                 # slowing the reader down is correct back-pressure rather
                 # than silently dropping raw audio the recorder/detector
                 # would otherwise never see at all.
-                self._raw_reads.put(samples)
+                self._raw_reads.put(
+                    _CapturedChunk(samples=samples, captured_at_monotonic_seconds=captured_at)
+                )
         except Exception as exc:  # noqa: BLE001 - backend/validation exceptions vary.
             # Covers both a genuine read failure (device gone, backend error)
             # and a validation failure (_normalize_sample rejecting a
@@ -1717,34 +1765,34 @@ class AudioCapturePipeline:
                 _LOGGER.warning("Roast audio recording start failed; continuing: %s", exc)
                 self._disable_recorder()
         try:
-            while not self._stop_requested.is_set():
+            while True:
+                stop_was_requested = self._stop_requested.is_set()
                 try:
-                    samples = self._raw_reads.get(timeout=self._settings.idle_sleep_seconds)
+                    # #190 review finding (P1): once stop() sets
+                    # _stop_requested, still drain whatever the reader
+                    # already queued rather than exiting immediately —
+                    # otherwise up to _READER_QUEUE_MAXSIZE chunks (~3s of
+                    # audio, e.g. the drop clatter / final crack the
+                    # annotation workflow cares about) are silently
+                    # abandoned. Once stop is requested, poll non-blockingly
+                    # (timeout=0) instead of the normal idle-sleep wait, so
+                    # a genuinely empty queue exits promptly rather than
+                    # waiting out one more idle_sleep_seconds for nothing.
+                    chunk = self._raw_reads.get(
+                        timeout=0 if stop_was_requested else self._settings.idle_sleep_seconds
+                    )
                 except Empty:
+                    if stop_was_requested:
+                        break
                     continue
-                if samples is None:
-                    # Reader-thread shutdown sentinel (see _run_reader_loop).
-                    break
-                self._sample_buffer.extend(samples)
-                # Update the live mic-levels meter from the SAME samples the
-                # detector consumes (#178). Cheap, vectorised, and never raises;
-                # purely observational so it cannot affect detection.
-                self._level_meter.observe(samples)
-                # Tee the SAME samples the detector consumes into the recording
-                # WAV right after the buffer extend (#176). This is the verified
-                # non-disturbing tee point: the detector still windows the buffer
-                # below, untouched. Recording failures must never kill detection,
-                # so a recorder error is logged and capture continues.
-                if self._recorder is not None:
-                    try:
-                        self._recorder.write_samples(samples)
-                    except Exception as exc:  # noqa: BLE001 - recording is best effort.
-                        _LOGGER.warning("Roast audio recording write failed; continuing: %s", exc)
-                        # Finalize what was captured (flush the WAV + write the
-                        # sidecar) BEFORE dropping the recorder, so the partial
-                        # recording is not leaked or lost.
-                        self._disable_recorder()
-                self._emit_complete_windows()
+                if chunk is None:
+                    # Reader-thread shutdown sentinel (see _run_reader_loop):
+                    # the reader is done producing chunks. Keep draining any
+                    # chunks that arrived before the sentinel — put_nowait
+                    # from the reader's finally can still land after a
+                    # backlog, so this is not necessarily the last item.
+                    continue
+                self._process_captured_chunk(chunk)
         except Exception as exc:  # noqa: BLE001 - worker stores error for caller inspection.
             with self._state_lock:
                 self._latest_error = str(exc)
@@ -1756,6 +1804,42 @@ class AudioCapturePipeline:
             if self._recorder is not None:
                 with suppress(Exception):
                     self._recorder.close()
+
+    def _process_captured_chunk(self, chunk: _CapturedChunk) -> None:
+        """Buffer, meter, record, and window one chunk from the reader.
+
+        Extracted from the processing loop's body (#190 review finding P1)
+        so it runs identically whether called from the normal draining loop
+        or from the post-stop drain that empties any backlog left in
+        ``_raw_reads`` before the recorder finalizes.
+        """
+        samples = chunk.samples
+        self._sample_buffer.extend(samples)
+        if samples:
+            # Track this chunk's capture-time provenance alongside the
+            # samples it contributed (#190 review finding), so
+            # _emit_complete_windows can derive a window's TRUE capture-time
+            # start instead of stamping emission time.
+            self._buffered_chunk_bounds.append((chunk.captured_at_monotonic_seconds, len(samples)))
+        # Update the live mic-levels meter from the SAME samples the
+        # detector consumes (#178). Cheap, vectorised, and never raises;
+        # purely observational so it cannot affect detection.
+        self._level_meter.observe(samples)
+        # Tee the SAME samples the detector consumes into the recording WAV
+        # right after the buffer extend (#176). This is the verified
+        # non-disturbing tee point: the detector still windows the buffer
+        # below, untouched. Recording failures must never kill detection, so
+        # a recorder error is logged and capture continues.
+        if self._recorder is not None:
+            try:
+                self._recorder.write_samples(samples)
+            except Exception as exc:  # noqa: BLE001 - recording is best effort.
+                _LOGGER.warning("Roast audio recording write failed; continuing: %s", exc)
+                # Finalize what was captured (flush the WAV + write the
+                # sidecar) BEFORE dropping the recorder, so the partial
+                # recording is not leaked or lost.
+                self._disable_recorder()
+        self._emit_complete_windows()
 
     def _disable_recorder(self) -> None:
         """Finalize and drop the recorder after a best-effort recording failure.
@@ -1775,17 +1859,75 @@ class AudioCapturePipeline:
         window_sample_count = self._settings.window_sample_count
         while len(self._sample_buffer) >= window_sample_count:
             window_samples = tuple(self._sample_buffer[:window_sample_count])
+            # Derive the window's TRUE capture-time start from the first
+            # buffered chunk's capture instant, BEFORE trimming the buffer
+            # (#190 review finding) — not self._monotonic_now(), which would
+            # be the emission instant and can drift from actual capture time
+            # by however long this window's samples sat queued in
+            # _raw_reads under processing backlog.
+            window_started_at = self._chunk_capture_time_at_offset(0)
             del self._sample_buffer[: self._settings.hop_sample_count]
+            self._advance_buffered_chunk_bounds(self._settings.hop_sample_count)
             window = AudioWindow(
                 sequence_number=self._next_sequence_number,
                 input_device=self._settings.input_device,
                 sample_rate=self._settings.sample_rate,
-                started_at_monotonic_seconds=self._monotonic_now(),
+                started_at_monotonic_seconds=window_started_at,
                 duration_seconds=round(window_sample_count / self._settings.sample_rate, 6),
                 samples=window_samples,
             )
             self._next_sequence_number += 1
             self._publish_window(window)
+
+    def _chunk_capture_time_at_offset(self, sample_offset: int) -> float:
+        """Return the capture-time instant of the sample at ``sample_offset``.
+
+        ``_buffered_chunk_bounds`` holds ``(captured_at, chunk_length)`` pairs
+        oldest-first, covering the samples currently in ``_sample_buffer`` in
+        order. Walks forward to find which chunk contains ``sample_offset``,
+        then adds the in-chunk offset (converted to seconds at the configured
+        sample rate) to that chunk's capture instant — an exact answer when
+        one chunk's samples were all captured back-to-back by one
+        ``stream.read()`` call, and a reasonable linear estimate otherwise.
+
+        Falls back to ``self._monotonic_now()`` (the pre-#190-review-fix
+        behavior) only if the bounds tracking is empty — defensive, since
+        every code path that extends ``_sample_buffer`` also appends here.
+
+        Args:
+            sample_offset: Zero-based index into the current sample buffer.
+
+        Returns:
+            The estimated monotonic capture instant for that sample.
+        """
+        remaining_offset = sample_offset
+        for captured_at, chunk_length in self._buffered_chunk_bounds:
+            if remaining_offset < chunk_length:
+                return round(
+                    captured_at + remaining_offset / self._settings.sample_rate,
+                    6,
+                )
+            remaining_offset -= chunk_length
+        return self._monotonic_now()  # pragma: no cover - defensive, see docstring
+
+    def _advance_buffered_chunk_bounds(self, sample_count: int) -> None:
+        """Trim ``_buffered_chunk_bounds`` by ``sample_count`` samples.
+
+        Mirrors ``del self._sample_buffer[:sample_count]`` so the two stay in
+        lockstep: full chunks entirely consumed by the trim are dropped, and
+        a chunk only partially consumed has its recorded length reduced (its
+        capture instant is unchanged — capture time is per-chunk, not
+        re-derived per sample).
+        """
+        remaining = sample_count
+        while remaining > 0 and self._buffered_chunk_bounds:
+            captured_at, chunk_length = self._buffered_chunk_bounds[0]
+            if chunk_length <= remaining:
+                self._buffered_chunk_bounds.popleft()
+                remaining -= chunk_length
+            else:
+                self._buffered_chunk_bounds[0] = (captured_at, chunk_length - remaining)
+                remaining = 0
 
     def _publish_window(self, window: AudioWindow) -> None:
         try:
@@ -1812,6 +1954,7 @@ class AudioCapturePipeline:
             except Empty:
                 break
         self._sample_buffer.clear()
+        self._buffered_chunk_bounds.clear()
         self._next_sequence_number = 0
         self._emitted_window_count = 0
         self._dropped_window_count = 0
@@ -1996,7 +2139,14 @@ def _normalize_samples_block(raw_samples: Sequence[float]) -> tuple[float, ...]:
     Raises:
         AudioCaptureError: If any sample is not finite.
     """
-    if not raw_samples:
+    # Explicit len() check, not `if not raw_samples:` (#190 review finding
+    # P3): AudioInput.read_samples is typed Sequence[float], and a numpy
+    # array satisfies that Protocol structurally — bool(array) raises
+    # ValueError for any multi-element array ("truth value of an array...is
+    # ambiguous"), so a test double or future AudioInput implementation that
+    # legitimately returns samples as a numpy array would crash the reader
+    # thread here instead of failing cleanly (or working at all).
+    if len(raw_samples) == 0:
         return ()
     array = np.asarray(raw_samples, dtype=np.float64)
     if not np.isfinite(array).all():

--- a/src/coffee_roaster_mcp/detector.py
+++ b/src/coffee_roaster_mcp/detector.py
@@ -238,7 +238,12 @@ class FirstCrackDetectorAdapter:
         """
         return self.process_window_observed(window).event
 
-    def process_window_observed(self, window: AudioWindow) -> FirstCrackWindowObservation:
+    def process_window_observed(
+        self,
+        window: AudioWindow,
+        *,
+        earliest_eligible_monotonic_seconds: float | None = None,
+    ) -> FirstCrackWindowObservation:
         """Process one audio window and return per-window observability metadata.
 
         This is the observability-aware entry point (#175): it always reports the
@@ -248,6 +253,19 @@ class FirstCrackDetectorAdapter:
 
         Args:
             window: Audio window to run detection for.
+            earliest_eligible_monotonic_seconds: Optional cutoff (coffee-roaster-mcp#195
+                CI follow-up). When set, a positive window whose
+                `started_at_monotonic_seconds` predates this cutoff is
+                reported accurately but never joins the confirmation-window
+                candidate list. Even with `discard_pending_audio()` clearing
+                every buffered stage at the `beans_added` boundary, the
+                reader thread never pauses — a chunk captured in the
+                wall-clock gap between recording the boundary event and
+                calling the discard can legitimately start a fraction of a
+                millisecond before the boundary and survive the discard by
+                arriving concurrently with or after it. Only bounding
+                candidate ONSET here (not the caller retroactively
+                discarding a specific window) closes that race.
 
         Returns:
             Per-window observation including the confirmed event when present.
@@ -261,7 +279,11 @@ class FirstCrackDetectorAdapter:
         _validate_confirmation_config(self.config)
         confidence = _validate_optional_confidence(output.confidence)
         self._prune_positive_candidates(window.started_at_monotonic_seconds)
-        if not output.confirmed:
+        is_precharge_window = (
+            earliest_eligible_monotonic_seconds is not None
+            and window.started_at_monotonic_seconds < earliest_eligible_monotonic_seconds
+        )
+        if not output.confirmed or is_precharge_window:
             return FirstCrackWindowObservation(
                 window_sequence_number=window.sequence_number,
                 confidence=confidence,
@@ -544,7 +566,23 @@ def integrate_first_crack_window_with_session(
     if not session.active or session.phase != "roasting":
         return None
 
-    observation = adapter.process_window_observed(window)
+    # coffee-roaster-mcp#195 CI follow-up: bound candidate onset on
+    # beans_added, not just the pipeline-side discard at the boundary — the
+    # reader thread never pauses, so a chunk captured in the wall-clock gap
+    # between recording the boundary and calling discard_pending_audio()
+    # can legitimately start a fraction of a millisecond before it and
+    # survive the discard. AudioWindow timestamps are ABSOLUTE monotonic;
+    # session milestones are SESSION-elapsed — rebase before comparing.
+    beans_added_monotonic_seconds = session.beans_added_monotonic_seconds
+    earliest_eligible_absolute = (
+        None
+        if beans_added_monotonic_seconds is None
+        else session.monotonic_start + beans_added_monotonic_seconds
+    )
+    observation = adapter.process_window_observed(
+        window,
+        earliest_eligible_monotonic_seconds=earliest_eligible_absolute,
+    )
     session_store.record_first_crack_window_observation(
         session,
         window_sequence_number=observation.window_sequence_number,

--- a/src/coffee_roaster_mcp/first_crack_runtime.py
+++ b/src/coffee_roaster_mcp/first_crack_runtime.py
@@ -58,6 +58,10 @@ class FirstCrackAudioPipeline(Protocol):
         """Return queued detector windows without blocking."""
         ...
 
+    def discard_pending_audio(self, *, timeout_seconds: float = 1.0) -> None:
+        """Drop every window/chunk/sample buffered anywhere in the pipeline."""
+        ...
+
     def snapshot(self) -> AudioCaptureSnapshot:
         """Return current capture status."""
         ...
@@ -336,14 +340,24 @@ class FirstCrackSessionRuntime:
         *,
         reason: str,
     ) -> FirstCrackRuntimeSnapshot:
-        """Drop queued detector windows that were captured before a runtime boundary."""
+        """Drop queued detector windows that were captured before a runtime boundary.
+
+        coffee-roaster-mcp#195 CI follow-up: draining only the emitted-window
+        queue is not enough once window timestamps reflect true capture time
+        (#190/#195) — audio captured before the boundary can still be
+        sitting unprocessed in the reader thread's backlog or the
+        processing thread's partial sample buffer when this is called (a
+        processing-thread backlog is exactly what CPU contention on a small
+        CI runner produces). Uses `discard_pending_audio()`, which clears
+        every stage of the pipeline, not just `drain_windows()`'s queue.
+        """
         with self._lock:
             if self._active_session_id != session_id:
                 return self.snapshot()
             if self._pipeline is not None and not _uses_detector_paced_wav_replay(
                 self._config.audio
             ):
-                self._pipeline.drain_windows()
+                self._pipeline.discard_pending_audio()
             if self._status == "pending":
                 self._reason = reason
             return self.snapshot()

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import struct
 import time
 import wave
+from collections import deque
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from queue import Queue
 from threading import Event, Lock, Thread, current_thread
+from typing import cast
 
+import numpy as np
 import pytest
 
 from coffee_roaster_mcp import audio as audio_module
@@ -15,6 +18,7 @@ from coffee_roaster_mcp.audio import (
     AudioCaptureError,
     AudioCapturePipeline,
     AudioCaptureSettings,
+    AudioCaptureSnapshot,
     AudioInput,
     DetectorPacedWavReplayPipeline,
     MicrophoneAudioInput,
@@ -480,10 +484,17 @@ def test_audio_capture_pipeline_feeds_detector_windows_from_mock_input() -> None
     assert {window.input_device for window in windows} == {"mock-mic"}
     assert {window.sample_rate for window in windows} == {4}
     assert {window.duration_seconds for window in windows} == {1.0}
-    assert [window.started_at_monotonic_seconds for window in windows] == [101.0, 102.0]
+    # started_at_monotonic_seconds is the TRUE capture-time instant of each
+    # window's first sample (#190 review finding), not the emission-time
+    # instant. At sample_rate=4 the reader's chunk size clamps to 1 sample,
+    # so the clock advances once per stream.read() call: sample 0's read is
+    # the 1st (clock=101.0) and sample 4's read is the 5th (clock=105.0) —
+    # correctly reflecting when each window's audio was actually captured.
+    assert [window.started_at_monotonic_seconds for window in windows] == [101.0, 105.0]
 
 
 def test_audio_capture_pipeline_emits_overlapping_windows_from_mock_input() -> None:
+    clock = ClockHarness()
     audio_input = FiniteAudioInput(tuple(float(value) for value in range(10)))
     pipeline = AudioCapturePipeline(
         settings=AudioCaptureSettings(
@@ -494,6 +505,7 @@ def test_audio_capture_pipeline_emits_overlapping_windows_from_mock_input() -> N
             idle_sleep_seconds=0.001,
         ),
         audio_input=audio_input,
+        monotonic_now=clock.monotonic_now,
     )
 
     pipeline.start()
@@ -507,6 +519,17 @@ def test_audio_capture_pipeline_emits_overlapping_windows_from_mock_input() -> N
         (2.0, 3.0, 4.0, 5.0),
         (4.0, 5.0, 6.0, 7.0),
         (6.0, 7.0, 8.0, 9.0),
+    ]
+    # Overlap (hop=2 < window=4) means _advance_buffered_chunk_bounds must
+    # partially trim a chunk rather than dropping it whole (#190 review
+    # finding coverage). Each sample is its own 1-sample read/chunk at this
+    # sample rate, so each window's start is exactly its first sample's
+    # capture-time read: sample i's read is the (i+1)th clock call.
+    assert [window.started_at_monotonic_seconds for window in windows] == [
+        101.0,
+        103.0,
+        105.0,
+        107.0,
     ]
 
 
@@ -1190,6 +1213,214 @@ def test_stop_join_order_processing_thread_first_then_reader(tmp_path: Path) -> 
     assert processing_thread is not None
     _wait_for(lambda: not reader_thread.is_alive(), timeout_seconds=2.0)
     _wait_for(lambda: not processing_thread.is_alive(), timeout_seconds=2.0)
+
+
+class _GatedRecorder(RoastAudioRecorder):
+    """Recorder double whose write_samples() blocks on an Event until
+    released, letting a test force a controlled reader/processing backlog
+    (#190 review finding: timestamp provenance under backlog)."""
+
+    def __init__(self, *, released: Event, **kwargs: object) -> None:
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self._released = released
+
+    def write_samples(self, samples: Sequence[float]) -> None:
+        self._released.wait(timeout=5.0)
+        super().write_samples(samples)
+
+
+def test_window_started_at_reflects_true_capture_time_not_emission_time(
+    tmp_path: Path,
+) -> None:
+    """#190 review finding: AudioWindow.started_at_monotonic_seconds must be
+    the instant its samples were CAPTURED (stamped in the reader thread),
+    not the instant the processing thread got around to emitting a window
+    from them. Forces a real backlog by gating the recorder's write —
+    several chunks queue up in _raw_reads before the processing thread ever
+    touches them — then asserts the emitted window's timestamp matches the
+    EARLY clock value from when its first chunk was actually read, not the
+    LATE value the clock reaches once processing finally drains it.
+    """
+    clock = ClockHarness()
+    released = Event()
+    recorder = _GatedRecorder(
+        released=released,
+        wav_path=tmp_path / "roast.wav",
+        sidecar_path=tmp_path / "roast.recording.json",
+        sample_rate=4,
+        session_id="s",
+    )
+    # 4 samples = exactly one window at window_seconds=1.0, sample_rate=4.
+    # Read one sample at a time (reader_chunk_sample_count clamps to 1 at
+    # this sample rate), so the clock advances once per chunk captured.
+    audio_input = FiniteAudioInput((0.1, 0.2, 0.3, 0.4))
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+        recorder=recorder,
+        monotonic_now=clock.monotonic_now,
+    )
+
+    pipeline.start()
+    try:
+        # All 4 chunks are read (and stamped) by the reader thread while the
+        # processing thread is blocked on the FIRST recorder write — proving
+        # the reader is never gated by processing. Clock reaches 104.0
+        # (4 reads) before any window is ever assembled.
+        _wait_for(lambda: len(audio_input.read_counts) >= 4, timeout_seconds=5.0)
+        # Now release the gate: the processing thread drains the backlog and
+        # emits the window. If the window were stamped at emission time
+        # (the pre-review-fix bug), its timestamp would reflect however much
+        # LATER the clock has advanced to by the time processing catches up
+        # (calls monotonic_now() again for its own bookkeeping) — not the
+        # true 101.0 capture instant of sample 0.
+        released.set()
+        _wait_for(lambda: pipeline.snapshot().emitted_window_count >= 1, timeout_seconds=5.0)
+    finally:
+        pipeline.stop()
+
+    windows = pipeline.drain_windows()
+    assert len(windows) == 1
+    # Sample 0's read is the reader's 1st call: clock=101.0. This must be
+    # the window's start regardless of how long emission was delayed.
+    assert windows[0].started_at_monotonic_seconds == 101.0
+
+
+class _NumpyArrayAudioInput:
+    """AudioInput double that returns samples as a numpy array rather than a
+    tuple/list (#190 review finding P3). Structurally satisfies the
+    Sequence[float] protocol, but bool(array) raises ValueError for any
+    multi-element array — proves the reader thread's truthiness checks
+    survive an AudioInput implementation that legitimately hands back numpy
+    output directly instead of converting to a plain sequence first."""
+
+    def __init__(self, samples: Sequence[float]) -> None:
+        self._array = np.asarray(samples, dtype=np.float64)
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:
+        chunk = self._array[:sample_count]
+        self._array = self._array[sample_count:]
+        # numpy's ndarray typing doesn't structurally match Sequence[float]
+        # (element access yields np.float64, not float), but it DOES satisfy
+        # the runtime Protocol (len/getitem/iteration) — which is exactly
+        # the case this double exists to exercise. cast documents that gap
+        # rather than papering over it.
+        return cast("Sequence[float]", chunk)
+
+
+def test_reader_survives_numpy_array_input_without_crashing() -> None:
+    """#190 review finding (P3): an AudioInput returning a numpy array must
+    not crash the reader thread's `if not raw_samples:` / `_normalize_samples_block`
+    truthiness checks — those now use explicit len() checks instead."""
+    audio_input = _NumpyArrayAudioInput((0.1, 0.2, 0.3, 0.4))
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+    )
+
+    pipeline.start()
+    try:
+        _wait_for(lambda: pipeline.snapshot().emitted_window_count >= 1, timeout_seconds=5.0)
+    finally:
+        pipeline.stop()
+
+    snapshot = pipeline.snapshot()
+    assert snapshot.latest_error is None
+    windows = pipeline.drain_windows()
+    assert len(windows) == 1
+    assert windows[0].samples == (0.1, 0.2, 0.3, 0.4)
+
+
+def test_process_captured_chunk_skips_bounds_tracking_for_an_empty_chunk() -> None:
+    """An empty _CapturedChunk (samples=()) must not append to
+    _buffered_chunk_bounds — a zero-length chunk-boundary entry would let
+    _chunk_capture_time_at_offset's walk stall on it forever without ever
+    advancing past it. In practice the reader never queues an empty chunk
+    (its own len() guard filters that), but _process_captured_chunk should
+    still be defensively correct if that invariant ever changes."""
+    from coffee_roaster_mcp.audio import _CapturedChunk  # pyright: ignore[reportPrivateUsage]
+
+    audio_input = FiniteAudioInput(())
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(input_device=None, sample_rate=4, window_seconds=1.0),
+        audio_input=audio_input,
+    )
+
+    pipeline._process_captured_chunk(  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+        _CapturedChunk(samples=(), captured_at_monotonic_seconds=100.0)
+    )
+
+    assert pipeline._buffered_chunk_bounds == deque()  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+    assert pipeline._sample_buffer == []  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+
+
+def test_stop_drains_queued_backlog_before_finalizing_recorder(tmp_path: Path) -> None:
+    """#190 review finding (P1): stop() must not abandon chunks still
+    queued in _raw_reads when _stop_requested is set — that would truncate
+    up to ~3s of recording TAIL, exactly the drop-clatter / final-crack
+    audio the annotation workflow cares about (stop() is called right at
+    drop). Forces a genuine backlog by gating every recorder write, calls
+    stop() WHILE that backlog exists (from a background thread, since
+    stop() blocks joining), then releases the gate and asserts every
+    sample the reader ever captured still lands in the WAV — none silently
+    dropped by an early processing-thread exit.
+    """
+    released = Event()
+    recorder = _GatedRecorder(
+        released=released,
+        wav_path=tmp_path / "roast.wav",
+        sidecar_path=tmp_path / "roast.recording.json",
+        sample_rate=4,
+        session_id="s",
+    )
+    audio_input = FiniteAudioInput((0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8))
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+        recorder=recorder,
+    )
+
+    pipeline.start()
+    # All 8 chunks are read by the reader thread while the processing thread
+    # is blocked on the FIRST gated recorder write — proving a genuine
+    # backlog builds up in _raw_reads before any of it is processed.
+    _wait_for(lambda: len(audio_input.read_counts) >= 8, timeout_seconds=5.0)
+
+    stop_result: list[AudioCaptureSnapshot] = []
+
+    def call_stop() -> None:
+        stop_result.append(pipeline.stop(timeout_seconds=5.0))
+
+    stop_thread = Thread(target=call_stop)
+    stop_thread.start()
+    # Give stop() a moment to set _stop_requested and block on the join
+    # while the backlog is still fully queued, THEN release the gate — the
+    # exact race #190's drain fix must survive.
+    time.sleep(0.05)
+    released.set()
+    stop_thread.join(timeout=5.0)
+
+    assert not stop_thread.is_alive()
+    assert stop_result
+    assert stop_result[0].latest_error is None
+    values, _, _ = _read_wav_samples(tmp_path / "roast.wav")
+    # All 8 samples must have reached the WAV — none abandoned in the queue.
+    assert len(values) == 8
 
 
 def test_stop_without_start_closes_input_and_is_a_safe_no_op() -> None:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -487,10 +487,13 @@ def test_audio_capture_pipeline_feeds_detector_windows_from_mock_input() -> None
     # started_at_monotonic_seconds is the TRUE capture-time instant of each
     # window's first sample (#190 review finding), not the emission-time
     # instant. At sample_rate=4 the reader's chunk size clamps to 1 sample,
-    # so the clock advances once per stream.read() call: sample 0's read is
-    # the 1st (clock=101.0) and sample 4's read is the 5th (clock=105.0) —
-    # correctly reflecting when each window's audio was actually captured.
-    assert [window.started_at_monotonic_seconds for window in windows] == [101.0, 105.0]
+    # so the clock advances once per stream.read() call: sample 0's read
+    # RETURNS at the 1st clock call (101.0) and sample 4's read RETURNS at
+    # the 5th (105.0). read_samples() is blocking, so those are block-END
+    # instants — the block-START instant (when this 1-sample/4Hz chunk's
+    # capture actually began, #195 review finding final fold) is 0.25s
+    # earlier: 100.75 and 104.75.
+    assert [window.started_at_monotonic_seconds for window in windows] == [100.75, 104.75]
 
 
 def test_audio_capture_pipeline_emits_overlapping_windows_from_mock_input() -> None:
@@ -523,13 +526,18 @@ def test_audio_capture_pipeline_emits_overlapping_windows_from_mock_input() -> N
     # Overlap (hop=2 < window=4) means _advance_buffered_chunk_bounds must
     # partially trim a chunk rather than dropping it whole (#190 review
     # finding coverage). Each sample is its own 1-sample read/chunk at this
-    # sample rate, so each window's start is exactly its first sample's
-    # capture-time read: sample i's read is the (i+1)th clock call.
+    # sample rate, so a "partial trim" here is trivially the whole 1-sample
+    # chunk — the genuinely-partial-trim-within-a-multi-sample-chunk case is
+    # covered separately (see the dedicated hop-trim test below). Sample i's
+    # read RETURNS at the (i+1)th clock call, but read_samples() is
+    # blocking, so that is the block-END instant; the block-START instant
+    # (#195 review finding, final fold) is 0.25s earlier for this 1-sample/
+    # 4Hz chunk.
     assert [window.started_at_monotonic_seconds for window in windows] == [
-        101.0,
-        103.0,
-        105.0,
-        107.0,
+        100.75,
+        102.75,
+        104.75,
+        106.75,
     ]
 
 
@@ -703,6 +711,54 @@ def test_audio_capture_pipeline_rejects_double_start() -> None:
         pipeline.stop()
 
 
+def test_start_refuses_while_a_previous_readers_thread_is_still_alive() -> None:
+    """coffee-roaster-mcp#195 review finding (final fold): start()'s guard
+    only checked the PROCESSING thread. stop() joins each thread against
+    its own timeout budget — the processing thread is never blocked in a
+    syscall so it exits quickly, but the reader thread CAN genuinely time
+    out while still mid-blocking-read. Checking only the processing thread
+    would let a caller start a SECOND reader thread against the same
+    still-alive input — two threads racing one native PortAudio stream,
+    exactly the corruption the single-reader-owns-reads invariant (#190)
+    exists to prevent.
+    """
+    audio_input = BlockingClosableAudioInput()
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device="mock-mic",
+            sample_rate=4,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+    )
+
+    pipeline.start()
+    assert audio_input.read_started.wait(timeout=1.0)
+    # Deterministically reproduce a timed-out stop() by driving the
+    # processing thread's own exit directly: request stop and join it for
+    # real (it is never blocked in a syscall, and _raw_reads is empty, so
+    # it exits promptly) while the reader is still genuinely blocked in
+    # read() and cannot join within any bounded timeout.
+    processing_thread = pipeline._thread  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+    reader_thread = pipeline._reader_thread  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+    assert processing_thread is not None
+    assert reader_thread is not None
+    pipeline._stop_requested.set()  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+    processing_thread.join(timeout=2.0)
+    assert not processing_thread.is_alive()
+    assert reader_thread.is_alive()
+
+    try:
+        with pytest.raises(AudioCaptureError, match="reader thread"):
+            pipeline.start()
+    finally:
+        # Clean up: release the stuck reader so its thread can actually exit.
+        audio_input.release()
+        worker = audio_input.worker_thread
+        assert worker is not None
+        worker.join(timeout=2.0)
+
+
 def test_audio_capture_pipeline_validates_finite_samples() -> None:
     pipeline = AudioCapturePipeline(
         settings=AudioCaptureSettings(input_device=None, sample_rate=4),
@@ -785,6 +841,66 @@ def test_audio_capture_stop_does_not_close_input_while_worker_reads() -> None:
     assert worker is not None
     worker.join(timeout=1.0)
     assert not worker.is_alive()
+
+
+def test_stop_drains_the_readers_final_chunk_after_a_timed_out_join() -> None:
+    """coffee-roaster-mcp#195 review finding (final fold): the processing
+    thread's own stop-drain uses timeout=0 once _stop_requested is set, so
+    it can observe an EMPTY _raw_reads and exit while the reader thread is
+    still mid-blocking-read. That reader's one remaining chunk then has no
+    consumer — same class as the earlier drain-on-stop fix (#195 P1), one
+    chunk narrower. stop() must drain _raw_reads once more after both
+    threads have joined (or timed out) to recover it.
+    """
+    audio_input = BlockingClosableAudioInput()
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device="mock-mic",
+            sample_rate=4,
+            window_seconds=0.25,  # 1 sample @ 4Hz: the reader's single
+            # chunk (clamped to 1 sample at this rate) is enough to
+            # complete a whole window on its own, keeping this test
+            # focused on drain plumbing rather than buffering more chunks.
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+    )
+
+    pipeline.start()
+    assert audio_input.read_started.wait(timeout=1.0)
+    # Deterministically reproduce the ordering the bug depends on by
+    # driving the two threads directly rather than relying on stop()'s own
+    # timing: request stop and wait for the PROCESSING thread to genuinely
+    # exit (it is never blocked in a syscall, and _raw_reads is empty, so
+    # it exits promptly) WHILE the reader is still parked in its blocking
+    # read.
+    processing_thread = pipeline._thread  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+    assert processing_thread is not None
+    pipeline._stop_requested.set()  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+    processing_thread.join(timeout=2.0)
+    assert not processing_thread.is_alive()
+
+    # NOW release the reader's blocked read. It finishes, stamps the
+    # chunk, and puts it (plus its shutdown sentinel) into _raw_reads — but
+    # the processing thread that would normally drain that queue has
+    # ALREADY exited. Nothing is consuming _raw_reads at this point except
+    # whatever stop() itself does when the caller eventually calls it.
+    audio_input.release()
+    worker = audio_input.worker_thread
+    assert worker is not None
+    worker.join(timeout=2.0)
+    assert not worker.is_alive()
+    raw_reads = pipeline._raw_reads  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+    assert raw_reads.qsize() == 2  # the chunk + the None sentinel
+
+    # A real stop() call, made by a caller who does not know the reader's
+    # chunk arrived after the processing thread already exited, must still
+    # recover it.
+    pipeline.stop(timeout_seconds=1.0)
+
+    windows = pipeline.drain_windows()
+    assert len(windows) == 1
+    assert windows[0].samples == (0.1,)
 
 
 def _wait_for(predicate: Callable[[], bool], *, timeout_seconds: float = 1.0) -> None:
@@ -1286,9 +1402,12 @@ def test_window_started_at_reflects_true_capture_time_not_emission_time(
 
     windows = pipeline.drain_windows()
     assert len(windows) == 1
-    # Sample 0's read is the reader's 1st call: clock=101.0. This must be
-    # the window's start regardless of how long emission was delayed.
-    assert windows[0].started_at_monotonic_seconds == 101.0
+    # Sample 0's read RETURNS at the reader's 1st clock call (101.0), but
+    # read_samples() is blocking, so that is the block-END instant — the
+    # block-START instant (#195 review finding, final fold) is 0.25s
+    # earlier (1 sample @ 4Hz = 0.25s). This must be the window's start
+    # regardless of how long emission was delayed.
+    assert windows[0].started_at_monotonic_seconds == 100.75
 
 
 def test_discard_pending_audio_drops_backlogged_precharge_samples(tmp_path: Path) -> None:
@@ -1443,6 +1562,48 @@ def test_process_captured_chunk_skips_bounds_tracking_for_an_empty_chunk() -> No
 
     assert pipeline._buffered_chunk_bounds == deque()  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
     assert pipeline._sample_buffer == []  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+
+
+def test_advance_buffered_chunk_bounds_advances_the_remainders_timestamp() -> None:
+    """coffee-roaster-mcp#195 review finding (final fold): a PARTIAL trim of
+    a multi-sample chunk must advance that chunk's recorded capture instant
+    by the trimmed portion's duration, not leave it at the whole original
+    chunk's capture instant. Samples within one chunk were captured
+    back-to-back at the configured sample rate (the same assumption
+    `_chunk_capture_time_at_offset` already makes for reading), so the
+    remainder's first sample was captured
+    `trimmed_samples / sample_rate` seconds AFTER the original stamp.
+    """
+    from coffee_roaster_mcp.audio import _CapturedChunk  # pyright: ignore[reportPrivateUsage]
+
+    # window_seconds=2.0 at sample_rate=4 needs 8 samples per window — this
+    # single 4-sample chunk is not enough to complete one, so
+    # _process_captured_chunk's own _emit_complete_windows() call leaves it
+    # sitting in the buffer for this test to trim directly, isolating
+    # _advance_buffered_chunk_bounds from window-completion side effects.
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(input_device=None, sample_rate=4, window_seconds=2.0),
+        audio_input=FiniteAudioInput(()),
+    )
+    # One chunk of 4 samples, captured starting at t=100.0 (back-to-back at
+    # 4Hz: sample 0 at 100.0, sample 1 at 100.25, sample 2 at 100.5, sample
+    # 3 at 100.75).
+    pipeline._process_captured_chunk(  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+        _CapturedChunk(samples=(0.1, 0.2, 0.3, 0.4), captured_at_monotonic_seconds=100.0)
+    )
+
+    # Trim 2 samples (a PARTIAL trim: 2 of this chunk's 4 samples remain) —
+    # mirrors what _emit_complete_windows does for an overlapping hop that
+    # lands mid-chunk.
+    pipeline._advance_buffered_chunk_bounds(2)  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+
+    remaining_bounds = list(pipeline._buffered_chunk_bounds)  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+    assert len(remaining_bounds) == 1
+    remaining_captured_at, remaining_length = remaining_bounds[0]
+    # The remainder is samples 2-3, whose first sample (index 2) was
+    # captured at 100.0 + 2/4 = 100.5 — NOT the original chunk's 100.0.
+    assert remaining_captured_at == 100.5
+    assert remaining_length == 2
 
 
 def test_stop_drains_queued_backlog_before_finalizing_recorder(tmp_path: Path) -> None:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1291,6 +1291,87 @@ def test_window_started_at_reflects_true_capture_time_not_emission_time(
     assert windows[0].started_at_monotonic_seconds == 101.0
 
 
+def test_discard_pending_audio_drops_backlogged_precharge_samples(tmp_path: Path) -> None:
+    """coffee-roaster-mcp#195 CI follow-up: discard_pending_audio() must drop
+    audio buffered ANYWHERE in the pipeline, not just already-emitted
+    windows — otherwise a processing-thread backlog (exactly what CPU
+    contention on a small CI runner produces) lets pre-boundary samples
+    survive into a window assembled AFTER the discard call, with an
+    accurate-but-stale capture-time stamp (reproduces the #195 CI failure:
+    test_recording_spans_charge_to_session_stop_not_to_first_crack faulted
+    with "Detected first crack cannot be before beans are added" because
+    discard_queued_windows_for_session only drained the emitted-window
+    queue).
+    """
+    clock = ClockHarness()
+    released = Event()
+    recorder = _GatedRecorder(
+        released=released,
+        wav_path=tmp_path / "roast.wav",
+        sidecar_path=tmp_path / "roast.recording.json",
+        sample_rate=4,
+        session_id="s",
+    )
+    audio_input = MutableAudioInput((0.1, 0.2, 0.3, 0.4))
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=4,
+            window_seconds=1.0,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+        recorder=recorder,
+        monotonic_now=clock.monotonic_now,
+    )
+
+    pipeline.start()
+    try:
+        # Pre-charge audio is read (and stamped) by the reader thread while
+        # the processing thread is blocked on the gated recorder write —
+        # exactly the backlog a slow/contended runner produces. Nothing has
+        # been assembled into a window yet.
+        _wait_for(lambda: len(audio_input.read_counts) >= 4, timeout_seconds=5.0)
+        assert pipeline.snapshot().emitted_window_count == 0
+
+        # The "charge boundary" fires while that pre-charge audio is still
+        # backlogged in _raw_reads/_sample_buffer, unprocessed.
+        pipeline.discard_pending_audio(timeout_seconds=5.0)
+
+        # Release the gate and feed fresh post-boundary audio. If the
+        # pre-charge backlog survived the discard, it would combine with
+        # this into a window whose first sample is one of the pre-charge
+        # ones (stamped 101.0-104.0, the reads captured before discard).
+        released.set()
+        audio_input.add_samples((0.5, 0.6, 0.7, 0.8))
+        _wait_for(lambda: pipeline.snapshot().emitted_window_count >= 1, timeout_seconds=5.0)
+    finally:
+        pipeline.stop()
+
+    windows = pipeline.drain_windows()
+    assert len(windows) == 1
+    assert windows[0].samples == (0.5, 0.6, 0.7, 0.8)
+    # The window's capture-time start must be a POST-discard read, not one
+    # of the four pre-charge reads (clock values 101.0-104.0).
+    assert windows[0].started_at_monotonic_seconds >= 105.0
+
+
+def test_discard_pending_audio_is_a_direct_clear_when_pipeline_not_running() -> None:
+    """discard_pending_audio() on a never-started (or already-stopped)
+    pipeline has no processing thread to acknowledge a request, so it must
+    clear synchronously rather than waiting on an Event nothing will ever
+    set."""
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(input_device=None, sample_rate=4, window_seconds=1.0),
+        audio_input=FiniteAudioInput((0.1, 0.2, 0.3, 0.4)),
+    )
+
+    # No AssertionError/timeout: returns promptly since self._thread is None.
+    pipeline.discard_pending_audio(timeout_seconds=5.0)
+
+    assert pipeline.snapshot().queued_window_count == 0
+
+
 class _NumpyArrayAudioInput:
     """AudioInput double that returns samples as a numpy array rather than a
     tuple/list (#190 review finding P3). Structurally satisfies the

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -654,7 +654,11 @@ def test_audio_capture_pipeline_records_source_errors_without_raising_on_caller(
     snapshot = pipeline.stop()
 
     assert snapshot.running is False
-    assert snapshot.latest_error == "capture failed after 4 requested samples"
+    # The exact requested-sample count is an internal reader-chunk-size detail
+    # (#190 fixed reader chunk, decoupled from window_sample_count); only the
+    # failure surfacing matters here.
+    assert snapshot.latest_error is not None
+    assert snapshot.latest_error.startswith("capture failed after ")
 
 
 def test_audio_capture_pipeline_rejects_double_start() -> None:
@@ -1001,18 +1005,24 @@ def test_pipeline_recorder_write_failure_finalizes_partial_recording(tmp_path: P
     """Finding #2: a write failure flushes the WAV + writes the sidecar before drop."""
     import json
 
-    class FailOnSecondWriteRecorder(RoastAudioRecorder):
+    class FailAfterFourSamplesRecorder(RoastAudioRecorder):
+        """Fails once at least 4 samples have been written across any number
+        of write_samples() calls — not tied to a fixed call count, since
+        #190's fixed reader chunk size means samples now arrive in smaller,
+        implementation-detail-sized blocks rather than one block per window.
+        """
+
         def __init__(self, **kwargs: object) -> None:
             super().__init__(**kwargs)  # type: ignore[arg-type]
-            self._writes = 0
+            self._total_written = 0
 
         def write_samples(self, samples: Sequence[float]) -> None:
-            self._writes += 1
-            if self._writes >= 2:
+            if self._total_written >= 4:
                 raise RuntimeError("disk full mid-roast")
+            self._total_written += len(samples)
             super().write_samples(samples)
 
-    recorder = FailOnSecondWriteRecorder(
+    recorder = FailAfterFourSamplesRecorder(
         wav_path=tmp_path / "roast.wav",
         sidecar_path=tmp_path / "roast.recording.json",
         sample_rate=4,
@@ -1026,8 +1036,9 @@ def test_pipeline_recorder_write_failure_finalizes_partial_recording(tmp_path: P
             window_seconds=1.0,
             idle_sleep_seconds=0.001,
         ),
-        # Two windows: the first write succeeds and is captured; the second
-        # write raises, finalizing the partial recording.
+        # Two windows: the first window's samples are written successfully;
+        # once 4 samples total have been written, the next write raises,
+        # finalizing the partial recording.
         audio_input=FiniteAudioInput((0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)),
         recorder=recorder,
     )
@@ -1045,6 +1056,155 @@ def test_pipeline_recorder_write_failure_finalizes_partial_recording(tmp_path: P
     sidecar = json.loads((tmp_path / "roast.recording.json").read_text(encoding="utf-8"))
     assert sidecar["frame_count"] >= 4
     assert sidecar["wav_filename"] == "roast.wav"
+
+
+class _ReadTimingAudioInput:
+    """AudioInput double that records the wall-clock gap between successive
+    read_samples() calls, to prove the reader thread's read cadence stays
+    fast regardless of how slow downstream processing is (#190)."""
+
+    def __init__(self, chunk: tuple[float, ...] = (0.0,)) -> None:
+        self._chunk = chunk
+        self.read_gaps_seconds: list[float] = []
+        self._last_read_at: float | None = None
+
+    def read_samples(self, sample_count: int) -> Sequence[float]:  # noqa: ARG002
+        now = time.monotonic()
+        if self._last_read_at is not None:
+            self.read_gaps_seconds.append(now - self._last_read_at)
+        self._last_read_at = now
+        return self._chunk
+
+
+class _SlowRecorder(RoastAudioRecorder):
+    """Recorder double whose write_samples() blocks for a fixed delay,
+    simulating disk/inference contention on the processing thread (#190)."""
+
+    def __init__(self, *, delay_seconds: float, **kwargs: object) -> None:
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self._delay_seconds = delay_seconds
+
+    def write_samples(self, samples: Sequence[float]) -> None:
+        time.sleep(self._delay_seconds)
+        super().write_samples(samples)
+
+
+def test_reader_thread_read_cadence_is_independent_of_slow_processing(
+    tmp_path: Path,
+) -> None:
+    """The #190 fix: a slow processing-side consumer (recording/metering/
+    windowing) must never delay the reader thread's next stream.read() call.
+    Drives a real two-thread AudioCapturePipeline with a recorder whose
+    write_samples() blocks for 50ms per call (standing in for disk or
+    inference contention), and asserts the READER's read-to-read gaps stay
+    far below that — proving the two loops are genuinely decoupled, not
+    proving a specific absolute latency (that depends on the host machine).
+    """
+    audio_input = _ReadTimingAudioInput()
+    recorder = _SlowRecorder(
+        delay_seconds=0.05,
+        wav_path=tmp_path / "roast.wav",
+        sidecar_path=tmp_path / "roast.recording.json",
+        sample_rate=100,
+        session_id="s",
+    )
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=100,
+            window_seconds=0.05,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+        recorder=recorder,
+    )
+
+    pipeline.start()
+    try:
+        _wait_for(lambda: len(audio_input.read_gaps_seconds) >= 20, timeout_seconds=5.0)
+    finally:
+        pipeline.stop()
+
+    assert audio_input.read_gaps_seconds
+    # The recorder alone would impose a 50ms floor per sample block if reads
+    # were gated on processing; the reader's actual median gap must stay a
+    # small fraction of that, proving processing-side slowness never reaches
+    # the read loop.
+    sorted_gaps = sorted(audio_input.read_gaps_seconds)
+    median_gap = sorted_gaps[len(sorted_gaps) // 2]
+    assert median_gap < 0.02, (
+        f"reader median read gap {median_gap:.4f}s should stay well under the "
+        "50ms processing-side delay if the two loops are truly decoupled"
+    )
+
+
+def test_reader_and_processing_threads_both_reflected_in_running_snapshot() -> None:
+    """running=True requires BOTH threads alive (#190): if the reader thread
+    dies (e.g. a fatal read error) while the processing thread has not yet
+    noticed via _stop_requested, running must not misreport True."""
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(input_device=None, sample_rate=4, idle_sleep_seconds=0.001),
+        audio_input=FailingAudioInput(),
+    )
+
+    pipeline.start()
+    try:
+        _wait_for(lambda: not pipeline.snapshot().running)
+        snapshot = pipeline.snapshot()
+        assert snapshot.running is False
+        assert snapshot.latest_error is not None
+    finally:
+        pipeline.stop()
+
+
+def test_stop_join_order_processing_thread_first_then_reader(tmp_path: Path) -> None:
+    """stop() joins the processing thread before the reader thread (#190):
+    the processing thread is never blocked in a syscall so it should exit
+    quickly once stop_requested is observed, while the reader may still be
+    mid-blocking-read. This drives a real pipeline through a full stop() and
+    asserts both threads are cleanly joined with no leaked/still-alive thread
+    afterward, whichever real-hardware ordering scenario occurs."""
+    audio_input = MutableAudioInput((0.0,) * 400)
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(
+            input_device=None,
+            sample_rate=100,
+            window_seconds=0.1,
+            idle_sleep_seconds=0.001,
+        ),
+        audio_input=audio_input,
+    )
+
+    pipeline.start()
+    _wait_for(lambda: pipeline.snapshot().emitted_window_count >= 1)
+    # A generous timeout (well above the ~1ms idle-sleep cadence both loops
+    # poll on) keeps this robust under full-suite CPU contention rather than
+    # a tight budget that can flake when many other tests' threads compete
+    # for scheduling at the same time.
+    snapshot = pipeline.stop(timeout_seconds=5.0)
+
+    assert snapshot.latest_error is None
+    reader_thread = pipeline._reader_thread  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+    processing_thread = pipeline._thread  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
+    assert reader_thread is not None
+    assert processing_thread is not None
+    _wait_for(lambda: not reader_thread.is_alive(), timeout_seconds=2.0)
+    _wait_for(lambda: not processing_thread.is_alive(), timeout_seconds=2.0)
+
+
+def test_stop_without_start_closes_input_and_is_a_safe_no_op() -> None:
+    """stop() called without start() (defensive callers elsewhere) must not
+    crash: neither the reader nor processing thread ever existed, so the
+    fallback close runs and both threads report not-alive (#190)."""
+    audio_input = FiniteAudioInput(())
+    pipeline = AudioCapturePipeline(
+        settings=AudioCaptureSettings(input_device=None, sample_rate=4),
+        audio_input=audio_input,
+    )
+
+    snapshot = pipeline.stop()
+
+    assert snapshot.running is False
 
 
 def test_device_label_to_filename_slug() -> None:

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -320,6 +320,50 @@ def test_process_window_observed_reports_candidate_before_confirmation() -> None
     assert confirmed.event.kind == "first_crack_detected"
 
 
+def test_process_window_observed_rejects_a_window_before_the_eligible_cutoff() -> None:
+    """coffee-roaster-mcp#195 CI follow-up: a positive window whose capture
+    started before `earliest_eligible_monotonic_seconds` must never join the
+    confirmation candidates, even though it is confirmed=True. Reported
+    accurately (confidence still surfaces) but treated as `listening`."""
+    backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=True, confidence=0.9),))
+    adapter = build_first_crack_detector_adapter(
+        FirstCrackConfig(confidence_threshold=0.6),
+        _resolved_detector_artifacts(),
+        backend,
+    )
+
+    observation = adapter.process_window_observed(
+        _audio_window(sequence_number=40, started_at_monotonic_seconds=99.5),
+        earliest_eligible_monotonic_seconds=100.0,
+    )
+
+    assert observation.confidence == 0.9
+    assert observation.positive_window_count == 0
+    assert observation.confirmed is False
+    assert observation.fc_status == "listening"
+    assert observation.event is None
+
+
+def test_process_window_observed_accepts_a_window_at_or_after_the_eligible_cutoff() -> None:
+    """A window starting exactly at (or after) the cutoff is eligible — the
+    bound is exclusive on the pre-cutoff side only."""
+    backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=True, confidence=0.9),))
+    adapter = build_first_crack_detector_adapter(
+        FirstCrackConfig(confidence_threshold=0.6),
+        _resolved_detector_artifacts(),
+        backend,
+    )
+
+    observation = adapter.process_window_observed(
+        _audio_window(sequence_number=41, started_at_monotonic_seconds=100.0),
+        earliest_eligible_monotonic_seconds=100.0,
+    )
+
+    assert observation.confirmed is True
+    assert observation.fc_status == "confirmed"
+    assert observation.event is not None
+
+
 def test_process_window_delegates_to_observed() -> None:
     backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=True, confidence=0.95),))
     adapter = build_first_crack_detector_adapter(

--- a/tests/test_first_crack_integration.py
+++ b/tests/test_first_crack_integration.py
@@ -91,6 +91,43 @@ def test_integrator_ignores_confirmed_detector_output_before_beans_are_added() -
     assert session.phase == "pre_roast"
 
 
+def test_integrator_ignores_a_precharge_window_that_arrives_during_roasting_phase() -> None:
+    """coffee-roaster-mcp#195 CI follow-up: a window whose capture started
+    before beans_added must be rejected even once phase is "roasting" — the
+    phase gate alone (see the sibling test above) is not enough, because a
+    window that was already buffered before the phase flip (or captured in
+    the wall-clock gap between recording beans_added and a caller's
+    discard_pending_audio() call) can still arrive here with a pre-charge
+    started_at. Also exercises the absolute/session-elapsed domain rebase:
+    beans_added_monotonic_seconds is SESSION-elapsed while the window's
+    started_at is ABSOLUTE monotonic (session.monotonic_start=500.0 here),
+    so a naive unrebased comparison would silently pass this window through.
+    """
+    clock = ClockHarness()
+    store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)
+    session = store.start_session()
+    clock.monotonic_value = 505.0
+    store.record_event(session, "beans_added")
+    assert session.beans_added_monotonic_seconds == 5.0  # session-elapsed
+    backend = MockDetectorBackend((FirstCrackDetectorOutput(confirmed=True, confidence=0.9),))
+    config = FirstCrackConfig(mode="audio")
+    adapter = build_first_crack_detector_adapter(config, _resolved_detector_artifacts(), backend)
+
+    # Absolute start 504.9 is BEFORE beans_added's absolute instant (500.0 +
+    # 5.0 = 505.0) by 0.1s, even though the call happens once phase is
+    # already "roasting".
+    result = integrate_first_crack_window_with_session(
+        config=config,
+        adapter=adapter,
+        session_store=store,
+        session=session,
+        window=_audio_window(started_at_monotonic_seconds=504.9),
+    )
+
+    assert result is None
+    assert [event.kind for event in session.event_timeline] == ["beans_added"]
+
+
 def test_integrator_ignores_confirmed_detector_output_after_roasting_phase() -> None:
     clock = ClockHarness()
     store = RoastSessionStore(utc_now=clock.utc_now, monotonic_now=clock.monotonic_now)

--- a/tests/test_first_crack_runtime.py
+++ b/tests/test_first_crack_runtime.py
@@ -63,6 +63,7 @@ class FakeAudioPipeline:
         self.stopped = False
         self.stop_reasons: list[float] = []
         self.drain_limits: list[int | None] = []
+        self.discard_calls = 0
 
     def start(self) -> AudioCaptureSnapshot:
         self.started = True
@@ -82,6 +83,13 @@ class FakeAudioPipeline:
         drained = tuple(self._windows[:max_windows])
         del self._windows[:max_windows]
         return drained
+
+    def discard_pending_audio(self, *, timeout_seconds: float = 1.0) -> None:
+        # This fake models the whole pipeline as one queued-window list, so
+        # there is no separate reader-backlog/sample-buffer stage to clear —
+        # discarding is equivalent to draining everything.
+        self.discard_calls += 1
+        self._windows.clear()
 
     def add_window(self, window: AudioWindow) -> None:
         self._windows.append(window)


### PR DESCRIPTION
## Summary

#190 reports sustained microphone input-overflow streaks on an M-series
Mac, climbing to 15 consecutive during a live roast (dual-mic recording +
int8 FC inference). The fatal threshold
(`_DEFAULT_MAX_CONSECUTIVE_OVERFLOWS = 30`) is only 2x the streaks already
observed there, and the E11 target — a Raspberry Pi 5 — has a fraction of
that headroom.

## Root cause

Before this PR, `AudioCapturePipeline` ran ONE thread that did
`stream.read()` **and** all downstream work — level metering, the
recorder's PCM16 encode, windowing, detector-queue publish — between
successive reads. Under CPU contention (concurrent int8 inference + dual
recording writers sharing the process and the GIL), that gap between reads
exceeded PortAudio's input ring buffer and the OS reported overflow.

A second, independent contributor: `_normalize_sample`'s per-sample
finiteness validation ran as a pure-Python generator on that same hot
path — roughly 1,600 Python-level function calls per 100ms of audio at
16kHz, holding the GIL for every one of them between reads. This is the
same class of per-read overhead that caused the original problem, and it
would have persisted even after splitting the capture loop.

## Fix

**1. Dedicated reader thread.** `AudioCapturePipeline` now runs two
threads. The new reader thread's **only** job is `stream.read()` +
enqueue onto a bounded internal queue, at a fixed ~100ms chunk size that
is decoupled from window/buffer state — so read cadence never depends on
how much downstream work is queued up. The existing thread becomes a pure
processing thread (metering, recording, windowing, detector-queue
publish), draining that queue instead of reading the device directly.

**Invariant preservation.** The pre-existing, explicitly documented
crash-prevention invariant — *only the thread that performs reads may
close the native PortAudio stream, or the ring buffer can be freed under
an in-flight read and segfault the process* — is preserved exactly: the
reader thread alone opens (implicitly, on first read) and closes the
audio input, in its own `finally`. The processing thread never touches
the audio input at all. `stop()`'s join order reflects this: the
**processing** thread joins first (it is never blocked in a syscall, so
it exits quickly once it observes the stop signal), then the **reader**
thread (which may still be mid-blocking-read and can take up to
`timeout_seconds` to notice), each with its own timeout budget rather
than splitting one budget between them. Verified by three new
architecture-level tests:
- `test_reader_thread_read_cadence_is_independent_of_slow_processing` —
  drives a real pipeline with a recorder whose `write_samples()` blocks
  50ms per call, and asserts the reader's actual read-to-read gap stays a
  small fraction of that.
- `test_stop_join_order_processing_thread_first_then_reader` — drives a
  full `stop()` and asserts both threads are cleanly joined with none
  left alive.
- `test_reader_and_processing_threads_both_reflected_in_running_snapshot`
  — `running=True` now requires BOTH threads alive, so a reader-thread
  crash while the processing thread hasn't yet noticed can't misreport a
  dead capture as still running.

**2. Vectorised sample validation.** `_normalize_sample`'s per-sample loop
is replaced by `_normalize_samples_block`, one numpy pass over the whole
chunk (finiteness check + float64 cast in C, releasing the GIL) — matching
the existing #180 PCM16-encode precedent already in this file.

## Measured results

Real ATR2100x-USB microphone on an M-series Mac, against a synthetic-load
repro harness: `N` background threads run a busy loop that **deliberately
never releases the GIL**, modeling the worst case (see caveat below).

| Load           | Max consecutive streak (before → after) | Total overflow (before → after) |
|----------------|:----------------------------------------:|:---------------------------------:|
| 2 load threads | 16 → **2**                               | 19 → **3**                        |
| 4 load threads | 19 → 12                                  | n/a → ~120 (both runs high)       |

The 2-thread row is the load profile that matches the actual 12 Jul
observations — an **8x streak reduction with 15x headroom** to the fatal
30-consecutive threshold. The 4-thread row is a harder synthetic case
added specifically to find the edge: real, partial improvement, but not
elimination.

### Caveat — the synthetic load is deliberately pessimistic, and this PR does not close the loop on hardware

My repro harness's load generator is a pure-Python arithmetic loop that
never releases the GIL. The real production competitors — ONNX int8
inference and the numpy PCM16 WAV-encode path — both release the GIL
during their actual C-level computation, so they are less pessimistic
than this synthetic proxy at a matched thread count. CPython's GIL switch
interval is 5ms; with several threads round-robining a GIL that's held
continuously by the synthetic load, the reader thread can be starved for
multiples of that regardless of process architecture — that residual is a
CPython scheduling limit, not something this PR's restructuring can fully
close from within one process. A complete fix for that residual would be
a separate capture process — E11-scale architecture, out of scope here.

**Filed #194** ("Pi 5 audio soak with the real inference stack") as the
follow-up: the remaining gate for any hardware-ready claim is a sustained
soak on the actual Raspberry Pi 5 target, running the **real** detector
pipeline (genuine ONNX int8 inference, not a synthetic proxy) and the
real dual-recording-writer configuration, using #190's overflow
instrumentation (already merged separately) to capture the numbers. This
PR closes #190 for the Mac-measurable root cause and fix; #194 carries
the remaining hardware-validation scope.

## Test updates (behaviour-preserving, not weakened)

Two pre-existing tests needed updates because the reader's fixed chunk
size changes exactly how much is requested/written per call. Both before
and after states are given so the diff is easy to audit for a hidden
weakening:

**`test_audio_capture_pipeline_records_source_errors_without_raising_on_caller`**
- Before: `assert snapshot.latest_error == "capture failed after 4 requested samples"`
- After: `assert snapshot.latest_error.startswith("capture failed after ")`
- Why: the exact requested-sample count was previously derived from
  `window_sample_count - len(buffer)` (a processing-side computation); the
  reader now always requests its fixed ~100ms chunk, independent of
  buffer state, so the literal count is an internal implementation
  detail. **Still asserts**: a read failure surfaces on `latest_error`
  without raising into the caller — the actual property under test is
  unchanged.

**`test_pipeline_recorder_write_failure_finalizes_partial_recording`**
- Before: fake recorder raised on its **2nd `write_samples()` call**
  (`self._writes >= 2`).
- After: fake recorder raises once **4 cumulative samples** have been
  written (`self._total_written >= 4`).
- Why: samples now arrive at the recorder in reader-chunk-sized blocks
  (as small as 1 sample at this test's tiny `sample_rate=4`), not one
  block per full window as before, so "the 2nd call" no longer lines up
  with "after the first window's worth of data." **Still asserts**: a
  write failure mid-roast still flushes the WAV and writes the sidecar
  before the recorder is dropped (Finding #2) — the failure trigger is
  reframed in terms of data volume instead of call count so it survives
  the chunking change, but the finalization behaviour it's checking is
  identical.

## Testing

Full suite run 3x for flake-checking (concurrency-sensitive redesign),
`ruff check` / `ruff format --check` clean, `pyright` strict 0 errors,
coverage 91%+ against the 90% floor (added a defensive
`stop()`-without-`start()` test to close a branch-coverage gap the new
thread-pair guards introduced).

Closes #190
