### PR TITLE
docs: describe MCP scope precisely

### DIFF
--- a/.github/instructions/copilot.instructions.md
+++ b/.github/instructions/copilot.instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-RoastPilot is a spec-driven Python MCP server for autonomous coffee roasting. The server will own roaster control, telemetry, first-crack event integration, roast timing, derived metrics, event logging, and export in one local stdio process.
+RoastPilot is a Python MCP server for coffee-roaster telemetry and controlled actuation. The server will own roaster control, telemetry, first-crack event integration, roast timing, derived metrics, event logging, and export in one local stdio process.
 
 Full project rules are in `AGENTS.md` at the repo root.
 
@@ -54,4 +54,3 @@ Full project rules are in `AGENTS.md` at the repo root.
 - Tests live under `tests/`.
 - Avoid production-only fakes created solely for tests.
 - Config tests should cover defaults, YAML overrides, environment overrides, and validation failures.
-

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 <!-- mcp-name: io.github.syamaner/coffee-roaster-mcp -->
 
-RoastPilot is a spec-driven MCP server for autonomous coffee roasting.
+RoastPilot is an MCP server for coffee-roaster telemetry and controlled
+actuation.
 
 The package name is `coffee-roaster-mcp`. It is published on production PyPI
 and listed in the MCP Registry as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "coffee-roaster-mcp"
 dynamic = ["version"]
-description = "RoastPilot: a spec-driven MCP server for autonomous coffee roasting."
+description = "RoastPilot: an MCP server for coffee-roaster telemetry and controlled actuation."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }
@@ -16,7 +16,7 @@ maintainers = [
   { name = "Sertan Yamaner" }
 ]
 keywords = [
-  "autonomous-roasting",
+  "coffee-roaster-control",
   "coffee",
   "coffee-roasting",
   "mcp",

--- a/src/coffee_roaster_mcp/cli.py
+++ b/src/coffee_roaster_mcp/cli.py
@@ -28,7 +28,9 @@ def build_parser() -> argparse.ArgumentParser:
     """Build the RoastPilot command line parser."""
     parser = argparse.ArgumentParser(
         prog="coffee-roaster-mcp",
-        description="RoastPilot: a spec-driven MCP server for autonomous coffee roasting.",
+        description=(
+            "RoastPilot: an MCP server for coffee-roaster telemetry and controlled actuation."
+        ),
     )
     parser.add_argument(
         "--version",

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -9,7 +9,7 @@ def test_installed_distribution_metadata_is_complete() -> None:
 
     assert package_metadata["Name"] == "coffee-roaster-mcp"
     assert package_metadata["Summary"] == (
-        "RoastPilot: a spec-driven MCP server for autonomous coffee roasting."
+        "RoastPilot: an MCP server for coffee-roaster telemetry and controlled actuation."
     )
     assert package_metadata["Requires-Python"] == ">=3.11"
     assert package_metadata["Author"] == "Sertan Yamaner"
@@ -17,7 +17,7 @@ def test_installed_distribution_metadata_is_complete() -> None:
 
     keywords = {token.strip() for token in package_metadata["Keywords"].split(",") if token.strip()}
     assert {
-        "autonomous-roasting",
+        "coffee-roaster-control",
         "coffee",
         "coffee-roasting",
         "mcp",


### PR DESCRIPTION
## Summary

- replace the public “autonomous coffee roasting” package description with the component's actual scope: coffee-roaster telemetry and controlled actuation
- replace the `autonomous-roasting` package keyword with `coffee-roaster-control`
- keep README, CLI help, package metadata tests, and contributor instructions consistent

This changes source metadata only. Production PyPI will show the correction after the next package release; this PR does not publish a release.

## Validation

- `python -m pytest`: 559 passed, 1 existing warning
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m pyright`
- `coffee-roaster-mcp --help`
- `coffee-roaster-mcp --version`
- isolated wheel build verified:
  - `Summary: RoastPilot: an MCP server for coffee-roaster telemetry and controlled actuation.`
  - keywords include `coffee-roaster-control` and exclude `autonomous-roasting`
- exact-head local Codex review: clean

Closes #197