### PR TITLE
chore: publish corrected metadata in 0.1.14

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -10,6 +10,15 @@ The release workflow is `.github/workflows/release.yml`. It supports two paths:
 
 ## Changelog
 
+### 0.1.14
+
+- Metadata-only release for #200. Publishes the component-scope description
+  merged in PR #198: coffee-roaster telemetry and controlled actuation, without
+  the previous autonomous-roasting claim.
+- Replaces the published `autonomous-roasting` keyword with
+  `coffee-roaster-control`.
+- No runtime or hardware-control behaviour changes.
+
 ### 0.1.13
 
 - #190 audio-overflow arc: dedicated capture reader thread (blocking-read

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,14 +16,12 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: v0.1 complete and live-validated end-to-end (E7-S6 done)
-- Active story: none — all v0.1 stories complete
-- Current target: post-validation follow-ups — ship the `server.json`
-  `packageArguments: serve` fix in the next release, and extend
-  `get_runtime_config` (`RuntimeConfigSnapshot`) with detector-profile,
-  model-revision, and audio capture fields so MCP clients can verify the
-  active first-crack configuration through the tool surface
-- Latest package release: `v0.1.3` (used for the E7-S6 live validation
-  roasts)
+- Active story: issue #200 is complete in PR #201; merge and publication of
+  the metadata-only `v0.1.14` release remain pending
+- Current target: publish the corrected component-scope package metadata in
+  `v0.1.14`, then verify the live PyPI and MCP Registry records
+- Latest package release: `v0.1.13`; `v0.1.14` is prepared but not yet
+  published
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -70,6 +68,13 @@ The first implementation milestone is a mock vertical slice that requires no roa
   published PyPI and MCP Registry metadata, and published-package smoke with
   `uvx --refresh-package coffee-roaster-mcp --from coffee-roaster-mcp==0.1.2 coffee-roaster-mcp --version`
   returned `coffee-roaster-mcp 0.1.2`.
+- Issue #200 prepares `v0.1.14` as a metadata-only release of the
+  component-scope wording merged in PR #198. Package and MCP Registry versions
+  are aligned at `0.1.14`; the package summary describes coffee-roaster
+  telemetry and controlled actuation, and the `autonomous-roasting` keyword is
+  replaced by `coffee-roaster-control`. Runtime and hardware-control behaviour
+  are unchanged. PyPI and MCP Registry publication remain pending until PR
+  #201 is merged and the release workflow succeeds.
 - `E7-S5a` is inserted before the final release checklist to close the
   first-crack MCP validation gap without requiring Hottop hardware or live
   microphone input. It uses the mock roaster, released Hugging Face first-crack
@@ -988,6 +993,14 @@ Goal: prove the package works from install through mock roast, MCP client calls,
     repo for the next release), and `get_runtime_config` does not yet expose
     detector-profile/audio fields (follow-up).
 
+- [x] Maintenance issue #200: prepare corrected package metadata for release.
+  - PR #198 corrected the source description and keywords but did not publish
+    them to PyPI. This follow-up aligns the package and MCP Registry versions
+    at `0.1.14` and records the metadata-only release boundary.
+  - No runtime or hardware-control behaviour changes.
+  - Live PyPI and MCP Registry publication remain pending until PR #201 is
+    merged and the release workflow succeeds.
+
 ### Epic Acceptance Criteria
 
 - Full mock roast works from install to exported logs.
@@ -1045,6 +1058,19 @@ After completing a story:
 
 ## Validation Notes
 
+- Validation run for issue #200:
+  - Confirmed the built wheel reports version `0.1.14`, summary `RoastPilot: an
+    MCP server for coffee-roaster telemetry and controlled actuation.`, and the
+    `coffee-roaster-control` keyword without `autonomous-roasting`.
+  - Ran `./.venv/bin/python -m pytest`: 559 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Ran CLI help and version smoke checks: passed; version output was
+    `coffee-roaster-mcp 0.1.14`.
+  - Built the sdist and wheel and ran the built-wheel smoke test: passed.
+  - Live PyPI and MCP Registry publication were not performed in this story
+    branch and remain release-workflow follow-up work.
 - E1-S1 created durable state docs and the copied overall plan.
 - E1-S2 added the initial Python package scaffold, console entrypoint declaration, package module, CLI module, and package smoke tests.
 - E1-S3 added CLI help/version behavior and smoke coverage.

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -20,6 +20,11 @@
 
 ## Active Context
 
+Issue #200 is preparing a metadata-only `v0.1.14` release. PR #198 already
+corrected the source package description and keywords; this slice aligns the
+package and MCP Registry versions so the corrected metadata can reach PyPI.
+Runtime and hardware-control behaviour are unchanged.
+
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 
 The `v0.1.1` fix-forward release is published for the post-E7-S4 recovery

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.syamaner/coffee-roaster-mcp",
   "title": "RoastPilot",
   "description": "RoastPilot controls coffee roasting sessions through local stdio MCP tools and exports logs.",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "websiteUrl": "https://github.com/syamaner/coffee-roaster-mcp#readme",
   "repository": {
     "url": "https://github.com/syamaner/coffee-roaster-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "coffee-roaster-mcp",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "runtimeHint": "uvx",
       "packageArguments": [
         {

--- a/src/coffee_roaster_mcp/__init__.py
+++ b/src/coffee_roaster_mcp/__init__.py
@@ -1,3 +1,3 @@
 """RoastPilot MCP server package."""
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -110,7 +110,7 @@ _EXPECTED_AMBIENT_STATUS_KEYS = {
 
 
 def test_version_is_defined() -> None:
-    assert __version__ == "0.1.13"
+    assert __version__ == "0.1.14"
 
 
 def test_cli_parser_program_name() -> None:


### PR DESCRIPTION
## Summary

- bump the package and MCP Registry versions to 0.1.14
- document that this is a metadata-only release of the component-scope wording merged in #198
- record the release in the epic registry

This changes no runtime or hardware-control behaviour.

## Validation

- `pytest`: 559 passed
- `ruff check .`: passed
- `ruff format --check .`: passed
- `pyright`: 0 errors
- CLI help and version smoke: passed (`coffee-roaster-mcp 0.1.14`)
- sdist and wheel build: passed
- built-wheel smoke: passed
- wheel metadata: corrected summary and `coffee-roaster-control` keyword confirmed

Closes #200