### PR TITLE
fix: support Core Metadata 2.5 publishing in v0.1.15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,7 @@ jobs:
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
 
   publish-mcp-registry:
     name: Publish MCP Registry

--- a/docs/release.md
+++ b/docs/release.md
@@ -10,9 +10,22 @@ The release workflow is `.github/workflows/release.yml`. It supports two paths:
 
 ## Changelog
 
+### 0.1.15
+
+- Fix-forward release for #202 after `v0.1.14` failed before upload because
+  the pinned PyPI publishing action rejected Core Metadata 2.5.
+- Updates `pypa/gh-action-pypi-publish` to the commit behind upstream v1.14.2,
+  which adds Core Metadata 2.5 support through Twine 7.
+- Carries forward the corrected component-scope description and
+  `coffee-roaster-control` keyword from the unpublished `v0.1.14` artifacts.
+- No runtime or hardware-control behaviour changes.
+
 ### 0.1.14
 
-- Metadata-only release for #200. Publishes the component-scope description
+- Unpublished metadata-only release attempt for #200. The tag workflow built
+  and smoke-tested the artifacts, but PyPI rejected Core Metadata 2.5 before
+  upload. The corrected metadata therefore moves forward in `v0.1.15`.
+- Carries the component-scope description
   merged in PR #198: coffee-roaster telemetry and controlled actuation, without
   the previous autonomous-roasting claim.
 - Replaces the published `autonomous-roasting` keyword with

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,12 +16,12 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: v0.1 complete and live-validated end-to-end (E7-S6 done)
-- Active story: issue #200 is complete in PR #201; merge and publication of
-  the metadata-only `v0.1.14` release remain pending
+- Active story: issue #202 prepares fix-forward `v0.1.15` after the
+  `v0.1.14` PyPI job failed before upload
 - Current target: publish the corrected component-scope package metadata in
-  `v0.1.14`, then verify the live PyPI and MCP Registry records
-- Latest package release: `v0.1.13`; `v0.1.14` is prepared but not yet
-  published
+  `v0.1.15`, then verify the live PyPI and MCP Registry records
+- Latest package release: `v0.1.13`; `v0.1.14` is tagged but unpublished, and
+  `v0.1.15` is the fix-forward candidate
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -73,8 +73,14 @@ The first implementation milestone is a mock vertical slice that requires no roa
   are aligned at `0.1.14`; the package summary describes coffee-roaster
   telemetry and controlled actuation, and the `autonomous-roasting` keyword is
   replaced by `coffee-roaster-control`. Runtime and hardware-control behaviour
-  are unchanged. PyPI and MCP Registry publication remain pending until PR
-  #201 is merged and the release workflow succeeds.
+  are unchanged. PR #201 merged, but the `v0.1.14` workflow failed before
+  upload; publication moves forward through issue #202 and `v0.1.15`.
+- The `v0.1.14` release workflow run `32651985421` passed checks, metadata
+  validation, package build, and built-wheel smoke, but PyPI rejected the
+  wheel before upload because the pinned publishing action did not support
+  Core Metadata 2.5. Issue #202 updates the action to the immutable commit
+  behind upstream v1.14.2, prepares fix-forward `v0.1.15`, and leaves runtime
+  and hardware-control behaviour unchanged.
 - `E7-S5a` is inserted before the final release checklist to close the
   first-crack MCP validation gap without requiring Hottop hardware or live
   microphone input. It uses the mock roaster, released Hugging Face first-crack
@@ -998,8 +1004,18 @@ Goal: prove the package works from install through mock roast, MCP client calls,
     them to PyPI. This follow-up aligns the package and MCP Registry versions
     at `0.1.14` and records the metadata-only release boundary.
   - No runtime or hardware-control behaviour changes.
-  - Live PyPI and MCP Registry publication remain pending until PR #201 is
-    merged and the release workflow succeeds.
+  - PR #201 merged, but the `v0.1.14` workflow failed before upload. Live PyPI
+    and MCP Registry publication move forward through issue #202 and
+    `v0.1.15`.
+
+- [x] Maintenance issue #202: support Core Metadata 2.5 and prepare
+  fix-forward `v0.1.15`.
+  - Update the pinned PyPI publishing action to upstream v1.14.2 commit
+    `dc37677b2e1c63e2034f94d8a5b11f265b73ba33`, which supports Core Metadata
+    2.5 through Twine 7.
+  - Align package and MCP Registry versions at `0.1.15` and carry forward the
+    corrected metadata from the unpublished `v0.1.14` artifacts.
+  - No runtime or hardware-control behaviour changes.
 
 ### Epic Acceptance Criteria
 
@@ -1058,6 +1074,24 @@ After completing a story:
 
 ## Validation Notes
 
+- Validation run for issue #202:
+  - Confirmed failed release run `32651985421` stopped before upload with
+    `InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid
+    metadata version`; MCP Registry publishing was skipped.
+  - Confirmed upstream `pypa/gh-action-pypi-publish` v1.14.2 explicitly adds
+    Core Metadata 2.5 upload support through Twine 7 and pinned its immutable
+    commit `dc37677b2e1c63e2034f94d8a5b11f265b73ba33`.
+  - Ran `./.venv/bin/python -m pytest`: 559 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed after formatting
+    the new release-workflow assertion.
+  - Ran `./.venv/bin/python -m pyright`: 0 errors.
+  - Built `coffee_roaster_mcp-0.1.15.tar.gz` and
+    `coffee_roaster_mcp-0.1.15-py3-none-any.whl`; built-wheel smoke returned
+    `mock disabled int8` and `coffee-roaster-mcp 0.1.15`.
+  - Confirmed the wheel retains `Metadata-Version: 2.5`, carries the corrected
+    summary and keywords, and therefore exercises the compatibility boundary
+    fixed by the updated publishing action.
 - Validation run for issue #200:
   - Confirmed the built wheel reports version `0.1.14`, summary `RoastPilot: an
     MCP server for coffee-roaster telemetry and controlled actuation.`, and the

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -20,10 +20,12 @@
 
 ## Active Context
 
-Issue #200 is preparing a metadata-only `v0.1.14` release. PR #198 already
-corrected the source package description and keywords; this slice aligns the
-package and MCP Registry versions so the corrected metadata can reach PyPI.
-Runtime and hardware-control behaviour are unchanged.
+Issue #202 is preparing fix-forward `v0.1.15`. The `v0.1.14` workflow built and
+smoke-tested the package but failed before upload because its pinned PyPI action
+rejected Core Metadata 2.5. The fix updates that action to upstream v1.14.2,
+aligns the package and MCP Registry versions at `0.1.15`, and carries forward
+the corrected component-scope metadata from #200. Runtime and hardware-control
+behaviour are unchanged.
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.syamaner/coffee-roaster-mcp",
   "title": "RoastPilot",
   "description": "RoastPilot controls coffee roasting sessions through local stdio MCP tools and exports logs.",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "websiteUrl": "https://github.com/syamaner/coffee-roaster-mcp#readme",
   "repository": {
     "url": "https://github.com/syamaner/coffee-roaster-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "coffee-roaster-mcp",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "runtimeHint": "uvx",
       "packageArguments": [
         {

--- a/src/coffee_roaster_mcp/__init__.py
+++ b/src/coffee_roaster_mcp/__init__.py
@@ -1,3 +1,3 @@
 """RoastPilot MCP server package."""
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -110,7 +110,7 @@ _EXPECTED_AMBIENT_STATUS_KEYS = {
 
 
 def test_version_is_defined() -> None:
-    assert __version__ == "0.1.14"
+    assert __version__ == "0.1.15"
 
 
 def test_cli_parser_program_name() -> None:

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -8,6 +8,7 @@ import yaml
 
 WORKFLOW_PATH = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release.yml"
 PINNED_ACTION_REF = re.compile(r"^[\w.-]+/[\w.-]+@[0-9a-f]{40}$")
+PYPI_PUBLISH_ACTION = "pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33"
 
 
 def test_release_workflow_runs_on_tags_and_manual_dry_run() -> None:
@@ -51,6 +52,7 @@ def test_release_workflow_uses_trusted_publishing_and_release_environment() -> N
     assert pypi_job["environment"] == "release"
     assert pypi_job["permissions"] == {"contents": "read", "id-token": "write"}
     assert _step_uses_pinned_action(pypi_job, "pypa/gh-action-pypi-publish")
+    assert any(step.get("uses") == PYPI_PUBLISH_ACTION for step in pypi_job["steps"])
 
     assert registry_job["environment"] == "release"
     assert registry_job["permissions"] == {"contents": "read", "id-token": "write"}


### PR DESCRIPTION
## Summary

- update the pinned PyPI publishing action to upstream v1.14.2 commit `dc37677b`, which supports Core Metadata 2.5 through Twine 7
- lock the compatible action pin in release-workflow coverage
- prepare fix-forward package and MCP Registry version 0.1.15
- record that v0.1.14 built successfully but failed before PyPI upload

No runtime or hardware-control behaviour changes.

## Root cause

Release run 32651985421 built a wheel with `Metadata-Version: 2.5`. The older pinned `gh-action-pypi-publish` rejected that metadata before upload. Upstream v1.14.2 explicitly adds Metadata 2.5 support.

## Validation

- `pytest`: 559 passed
- `ruff check .`: passed
- `ruff format --check .`: passed
- `pyright`: 0 errors
- focused release/package tests: 27 passed
- sdist and wheel build: passed
- built-wheel smoke: passed (`mock disabled int8`, `coffee-roaster-mcp 0.1.15`)
- wheel metadata: version 0.1.15, Metadata-Version 2.5, corrected summary and keywords confirmed

Closes #202