### PR TITLE
docs: publish current live-roast evidence in v0.1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,28 @@ RoastPilot provides one local MCP runtime for roaster control, telemetry, first-
 
 ## Status
 
-✅ **v0.1 complete — verified end-to-end on real hardware (2026-06-07).**
+✅ **v0.1 component scope complete, published on PyPI and in the MCP Registry,
+and exercised in supervised agent-controlled hardware roasts through
+2026-08-16.**
+
+The latest integrated evidence is two completed Hottop roasts on 2026-08-16.
+Together they exercised live telemetry and control, automatic T0, first-crack
+handling, post-first-crack decisions, safety evaluation, advisor-triggered
+drop, operator-controlled cooling completion, ambient sensing, log export, and
+paired-microphone capture. The agent ledger recorded 19 successful advisor
+decisions, each linked to an `allow` safety evaluation; both advisor-proposed
+drops were executed, with no failed command events or safety alerts in either
+completed run.
+
+Those roasts used the pinned `coffee-roaster-mcp` 0.1.13 runtime. Versions
+0.1.14 and 0.1.15 changed package metadata and release plumbing only; this
+0.1.16 update changes documentation and release metadata only. Runtime
+behaviour is unchanged. See the
+[2026-08-16 agent-roast validation report](https://github.com/syamaner/coffee-roaster-mcp/blob/main/docs/session-summaries/2026-08-16-agent-roast-validation.md)
+for the authority-ledger, session, ambient, and capture evidence, including its
+provenance limits.
+
+The original published-package baseline remains the 2026-06-07 validation:
 
 The published `coffee-roaster-mcp` 0.1.3 package, installed through the MCP
 Registry `uvx` path into the Warp agent, ran two complete supervised roasts
@@ -58,7 +79,9 @@ server, conservative hardware boundaries, and releaseable package metadata.
 
 ## What RoastPilot Is
 
-RoastPilot is the human-facing product name. `coffee-roaster-mcp` is the infrastructure and packaging name used for the repository, Python package, and future distribution.
+RoastPilot is the human-facing product name. `coffee-roaster-mcp` is the
+infrastructure and packaging name used for the repository, Python package, and
+published distribution.
 
 The v0.1 scope is one local stdio MCP server that owns:
 
@@ -68,9 +91,9 @@ The v0.1 scope is one local stdio MCP server that owns:
 - derived roast metrics
 - roast log export
 
-All v0.1 epics are complete and live-validated. The package scaffold, config
-loading, local development commands, pull-request CI, stdio MCP entrypoint,
-roast-session tool surface, Hottop driver, audio first-crack runtime,
+All MCP-component v0.1 epics are complete and live-validated. The package
+scaffold, config loading, local development commands, pull-request CI, stdio
+MCP entrypoint, roast-session tool surface, Hottop driver, audio first-crack runtime,
 automatic T0 path, metrics/log export, release workflow, and MCP Registry
 metadata are in place, and the full end-to-end path has been verified on
 connected Hottop hardware with a real microphone through the published
@@ -143,6 +166,22 @@ coffee-roaster-mcp --help
 coffee-roaster-mcp --version
 ```
 
+### Hardware And Audio Checks
+
+Two explicit pre-roast checks cover the configured microphone and independent
+multi-device recording paths without starting a roast:
+
+```bash
+coffee-roaster-mcp mic-check --config coffee-roaster-mcp.yaml
+coffee-roaster-mcp record-check --config coffee-roaster-mcp.yaml
+```
+
+`mic-check` reports whether the selected input contains a real signal and can
+write a small JSON evidence record. `record-check` captures each configured
+recording device into a temporary or explicit output directory and reports the
+result. The resulting audio may contain ambient conversation and must not be
+committed.
+
 ## Local Mock Run
 
 The default local path is intentionally mock-safe:
@@ -180,10 +219,16 @@ The current MCP tool surface includes:
 - `stop_cooling`
 - `export_roast_log`
 - `emergency_stop`
+- `set_recording_metadata`
 
 `export_roast_log` writes `roast.jsonl`, `roast.csv`, and `summary.json` files
 for the current in-process session. Runtime events and sampled telemetry are
 also appended to `roast.jsonl` during the roast.
+
+Before a recorded roast, `set_recording_metadata` stores the bean-origin slug
+and roast number used for capture filenames and the session sidecar. It sends
+no hardware command and does not expose a generic file-write or tool-execution
+surface.
 
 ### Operational MCP Flow
 
@@ -221,6 +266,20 @@ records `beans_added` when the current bean temperature drops from that max by
 `session.auto_t0_drop_threshold_c`. `get_roast_state.t0_status` exposes the
 configured threshold, tracked charge temperature, current drop, and detected
 bean temperature when automatic T0 records the event.
+
+Optional ambient sensing and roast recording are also disabled by default.
+When enabled deliberately, `get_roast_state` exposes fail-soft Yoctopuce
+ambient readings and live microphone/overflow status, while the recording
+runtime can capture one or more independent microphone streams into a
+session-scoped directory. Recording uses the audio first-crack capture runtime;
+it therefore requires `first_crack.mode: audio`. A live roast recording also
+requires `audio.source: microphone`, with `recording.enabled` and
+`recording.autocapture` both set to `true`. When `recording.devices` is set,
+its first entry must match `audio.input_device`: that stream is captured by the
+detector and teed into the first WAV rather than opened independently. Any
+additional entries are opened as independent recording streams. These paths
+have been exercised together during the August 2026 hardware roasts described
+in the current validation report.
 
 `get_roast_state.first_crack_status.status` is one of:
 
@@ -353,6 +412,21 @@ audio:
   overlap: 0.0
   hop_seconds: null
 
+ambient:
+  mode: disabled
+  device: null
+  poll_interval_seconds: 30.0
+
+recording:
+  # Recording runs through the audio first-crack capture runtime.
+  # Live capture also requires first_crack.mode: audio and audio.source: microphone.
+  enabled: false
+  autocapture: false
+  export_location: null
+  sample_rate: null
+  # When set, the first entry must match audio.input_device.
+  devices: null
+
 logging:
   log_dir: ./logs
   sample_interval_seconds: 5.0
@@ -391,6 +465,14 @@ Supported environment overrides:
 - `COFFEE_AUDIO_WINDOW_SECONDS`
 - `COFFEE_AUDIO_OVERLAP`
 - `COFFEE_AUDIO_HOP_SECONDS`
+- `COFFEE_AMBIENT_MODE`
+- `COFFEE_AMBIENT_DEVICE`
+- `COFFEE_AMBIENT_POLL_INTERVAL_SECONDS`
+- `COFFEE_RECORDING_ENABLED`
+- `COFFEE_RECORDING_AUTOCAPTURE`
+- `COFFEE_RECORDING_EXPORT_LOCATION`
+- `COFFEE_RECORDING_SAMPLE_RATE`
+- `COFFEE_RECORDING_DEVICES`
 - `COFFEE_ROAST_LOG_DIR`
 - `COFFEE_AUTO_T0_DROP_THRESHOLD_C`
 - `HF_HOME`
@@ -503,5 +585,7 @@ Current export files:
   metrics, roaster driver, and first-crack model metadata
 - output under `logs/roasts/{session_id}/`
 
-Cross-format log schema completeness tests are in place. Broad release
-validation and end-to-end agent roast validation land in later stories.
+Cross-format log schema completeness tests are in place. The June 2026
+published-package baseline and August 2026 integrated agent-roast report record
+the current live-validation boundary; new hardware configurations still require
+their own supervised validation.

--- a/docs/release.md
+++ b/docs/release.md
@@ -10,6 +10,18 @@ The release workflow is `.github/workflows/release.yml`. It supports two paths:
 
 ## Changelog
 
+### 0.1.16
+
+- Documentation release for #204. Updates the README with the live package and
+  MCP Registry status, the complete MCP tool/configuration surface, and the
+  16 August 2026 integrated RoastPilot evidence boundary.
+- Adds a privacy-safe validation report derived from two completed Hottop
+  roasts, including authority-ledger counts, ambient readings, paired-capture
+  metadata, source hashes, and the current cross-store provenance limitation.
+- Removes the stale statement that end-to-end agent-roast validation is future
+  work.
+- No runtime or hardware-control behaviour changes.
+
 ### 0.1.15
 
 - Fix-forward release for #202 after `v0.1.14` failed before upload because

--- a/docs/session-summaries/2026-08-16-agent-roast-validation.md
+++ b/docs/session-summaries/2026-08-16-agent-roast-validation.md
@@ -1,0 +1,92 @@
+# Agent Roast Validation — 16 August 2026
+
+## Verdict
+
+Two supervised RoastPilot runs completed on connected Hottop hardware. The
+component path covered telemetry and control, automatic T0, first-crack event
+handling, advisor decisions, safety evaluation, advisor-triggered drop,
+operator-controlled cooling completion, ambient readings, export, and
+two-microphone recording.
+
+This is operational evidence from two roasts. It is not a claim that every
+hardware configuration is validated, that every roast outcome succeeds, or
+that the system is production-ready or fully autonomous.
+
+## Version Boundary
+
+The RoastPilot agent environment pins `coffee-roaster-mcp==0.1.13`; its lock
+file records the same version and published artifact hashes. Releases 0.1.14
+and 0.1.15 changed component-scope metadata and release infrastructure only.
+Version 0.1.16 adds this report and the corresponding README update. None of
+those releases change runtime or hardware-control behaviour.
+
+## Evidence Summary
+
+| Evidence | Roast 1 | Roast 2 |
+| --- | --- | --- |
+| Agent run | `09318196f41041d688d7039d5555c9c2` | `63b8bbdc678f461e92892686caefc9d9` |
+| MCP session | `55ea96f2cb484344b921727072832e4f` | `f3aad1725eb74753ac036ad97a58b0cd` |
+| Outcome | completed | completed |
+| Agent interval (UTC) | 13:27:54–13:49:10 | 14:06:34–14:25:36 |
+| Advisor decisions | 10/10 `ok` | 9/9 `ok` |
+| Linked advisor safety verdicts | 10/10 `allow` | 9/9 `allow` |
+| All safety evaluations | 1,308 `allow` | 1,164 `allow` |
+| Executed command events | 12 | 7 |
+| Failed command events | 0 | 0 |
+| Safety-alert events | 0 | 0 |
+| First-crack authority | MCP | operator |
+| Drop authority | advisor | advisor |
+| Cooling completion authority | operator | operator |
+| Ambient captured | 27.04 °C, 37.9%, 1009.47 hPa | 27.82 °C, 36.6%, 1009.29 hPa |
+| Audio capture | 2 independent 16 kHz mono streams, 1129.60/1129.75 s | 2 independent 16 kHz mono streams, 917.00/917.25 s |
+
+## Authority Trace
+
+The local agent ledger keeps the decision stages separate:
+
+1. `advisor_decisions` records the provider decision and its status.
+2. `advisor_decisions.safety_evaluation_id` identifies the safety evaluation
+   that validated the decision.
+3. `roast_events` records consequential commands that were actually executed,
+   including the authority source.
+4. `operator_actions` separately records accepted operator interventions.
+
+In both runs, the last advisor decision set `should_drop: true`, its linked
+safety evaluation returned `allow`, and the subsequent `command_executed`
+event recorded `drop_beans` with `source: advisor`. Cooling was later stopped
+through an accepted operator action. Roast 1 recorded first crack from MCP;
+Roast 2 recorded the explicit operator mark instead. This distinction is part of
+the evidence: the ledger does not collapse proposal, validation, execution,
+and operator authority into one generic agent action.
+
+## MCP Session And Capture Evidence
+
+Each agent run points its exported log directory at the corresponding MCP
+session identifier. The agent and MCP start timestamps align to within 50 ms.
+The MCP JSONL files contain live Hottop temperature/control telemetry through
+cooling completion. The recording manifests identify two independent USB
+microphone streams per session and record their sample rate, frame count, and
+duration.
+
+Raw WAV files, roast logs, the live SQLite store, and local filesystem paths
+remain private and are not committed. The source files used for this report are
+identified below by session id and SHA-256 so the local evidence can be checked
+without publishing ambient conversation or full operational traces.
+
+| Session | Artifact | SHA-256 |
+| --- | --- | --- |
+| `55ea96f2cb484344b921727072832e4f` | recording manifest | `796ba5035f63cc9b448608529b274f9c82ebbed1b4c3ae10ebed45443d2cd13f` |
+| `55ea96f2cb484344b921727072832e4f` | export summary | `e9283fee7244ef1e27ac2a4c2e283b50eb7f737b0906ac83441bd357bd3ed217` |
+| `55ea96f2cb484344b921727072832e4f` | MCP JSONL log | `2b258c7d67fe352608c5059a8df7425e8afe67efaacedd776c1d3d6e1dfaf925` |
+| `f3aad1725eb74753ac036ad97a58b0cd` | recording manifest | `4c41523b15b30ed9612cd4d8c9a637501099bf52d9d6b33512a698461b4bb570` |
+| `f3aad1725eb74753ac036ad97a58b0cd` | export summary | `4c99ac9130edcb37ab0ffadfe27d1e81febcb7fa40ce8c4d586746886f2ed593` |
+| `f3aad1725eb74753ac036ad97a58b0cd` | MCP JSONL log | `d6c126a3325960ada2adcc7a2450b972372de8640fcc1d636b51116e9597f986` |
+
+## Provenance Limit
+
+The current agent rows have a null `mcp_session_id`. This report correlates
+each run to its MCP session using the session identifier in `log_dir` and the
+aligned start timestamps. That is strong operational evidence, but it is not a
+database foreign-key join. Claims that require exact cross-store provenance
+should wait for a persisted run-to-session binding or another supervised
+hardware run with that binding enabled.

--- a/docs/state/epics/coffee-roaster-mcp-v0.1.md
+++ b/docs/state/epics/coffee-roaster-mcp-v0.1.md
@@ -16,12 +16,10 @@ The first implementation milestone is a mock vertical slice that requires no roa
 ## Active Context
 
 - Current phase: v0.1 complete and live-validated end-to-end (E7-S6 done)
-- Active story: issue #202 prepares fix-forward `v0.1.15` after the
-  `v0.1.14` PyPI job failed before upload
-- Current target: publish the corrected component-scope package metadata in
-  `v0.1.15`, then verify the live PyPI and MCP Registry records
-- Latest package release: `v0.1.13`; `v0.1.14` is tagged but unpublished, and
-  `v0.1.15` is the fix-forward candidate
+- Active story: issue #204 prepares documentation release `v0.1.16`
+- Current target: publish the current live-roast evidence boundary and complete
+  README tool/configuration surface, then update the PyPI long description
+- Latest package release: `v0.1.15`; PyPI and MCP Registry publication verified
 - Product/display name: `RoastPilot`
 - GitHub repo: `syamaner/coffee-roaster-mcp`
 - PyPI package: `coffee-roaster-mcp`
@@ -81,6 +79,17 @@ The first implementation milestone is a mock vertical slice that requires no roa
   Core Metadata 2.5. Issue #202 updates the action to the immutable commit
   behind upstream v1.14.2, prepares fix-forward `v0.1.15`, and leaves runtime
   and hardware-control behaviour unchanged.
+- `v0.1.15` is published on production PyPI and in the MCP Registry. Release
+  workflow run `32652660041` passed metadata validation, checks, package build,
+  PyPI publishing, and MCP Registry publishing; a clean `uvx` smoke reported
+  `coffee-roaster-mcp 0.1.15`, and the registry marks it latest.
+- Issue #204 prepares `v0.1.16` as a documentation release. It adds a
+  privacy-safe report for two completed 16 August 2026 agent-controlled Hottop
+  roasts, updates the README with recording and ambient surfaces already
+  released by 0.1.13, and removes a stale future-validation statement. The
+  August roasts used the pinned 0.1.13 runtime; 0.1.14 and 0.1.15 changed
+  metadata/release plumbing only. No runtime or hardware-control behaviour
+  changes in 0.1.16.
 - `E7-S5a` is inserted before the final release checklist to close the
   first-crack MCP validation gap without requiring Hottop hardware or live
   microphone input. It uses the mock roaster, released Hugging Face first-crack
@@ -1017,6 +1026,16 @@ Goal: prove the package works from install through mock roast, MCP client calls,
     corrected metadata from the unpublished `v0.1.14` artifacts.
   - No runtime or hardware-control behaviour changes.
 
+- [x] Maintenance issue #204: publish current live-roast status and complete
+  the README surface in `v0.1.16`.
+  - Add a privacy-safe evidence report derived from the agent authority ledger,
+    MCP session exports, ambient readings, and paired capture manifests.
+  - Document the released recording, microphone observability, ambient, and
+    recording-metadata surfaces and remove the stale future-validation claim.
+  - Align package and MCP Registry versions at `0.1.16` so the corrected long
+    description reaches PyPI.
+  - No runtime or hardware-control behaviour changes.
+
 ### Epic Acceptance Criteria
 
 - Full mock roast works from install to exported logs.
@@ -1074,6 +1093,24 @@ After completing a story:
 
 ## Validation Notes
 
+- Validation run for issue #204:
+  - Queried the live RoastPilot SQLite store read-only and matched the two
+    completed 16 August agent runs to MCP session exports by the session id in
+    `log_dir` and start timestamps aligned within 50 ms. Recorded the null
+    `mcp_session_id` provenance limit explicitly.
+  - Verified 19/19 advisor decisions were `ok` and linked to `allow` safety
+    evaluations; both advisor-proposed drops were executed, and the two runs
+    contained zero failed-command and zero safety-alert events.
+  - Verified ambient readings and two independent 16 kHz microphone streams
+    in both capture manifests; recorded source hashes without committing raw
+    audio, roast logs, the SQLite store, or local paths.
+  - Ran `./.venv/bin/python -m pytest`: 559 passed.
+  - Ran `./.venv/bin/python -m ruff check .`: passed.
+  - Ran `./.venv/bin/python -m ruff format --check .`: passed.
+  - Ran `./.venv/bin/python -m pyright` under Python 3.11: 0 errors.
+  - Built `coffee_roaster_mcp-0.1.16.tar.gz` and
+    `coffee_roaster_mcp-0.1.16-py3-none-any.whl`; built-wheel smoke returned
+    `mock disabled int8` and `coffee-roaster-mcp 0.1.16`.
 - Validation run for issue #202:
   - Confirmed failed release run `32651985421` stopped before upload with
     `InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid

--- a/docs/state/registry.md
+++ b/docs/state/registry.md
@@ -20,11 +20,14 @@
 
 ## Active Context
 
-Issue #202 is preparing fix-forward `v0.1.15`. The `v0.1.14` workflow built and
-smoke-tested the package but failed before upload because its pinned PyPI action
-rejected Core Metadata 2.5. The fix updates that action to upstream v1.14.2,
-aligns the package and MCP Registry versions at `0.1.15`, and carries forward
-the corrected component-scope metadata from #200. Runtime and hardware-control
+Issue #204 prepares documentation release `v0.1.16`. PyPI 0.1.15 and the MCP
+Registry entry are live, but the README still omitted the released recording,
+microphone observability, ambient-sensor, and recording-metadata surfaces and
+ended with a stale future-validation statement. The update records two
+completed 16 August 2026 agent-controlled Hottop roasts from the authority
+ledger and session/capture evidence while preserving the provenance boundary:
+the agent rows and MCP sessions are correlated by log-directory session id and
+aligned start time, not a persisted foreign key. Runtime and hardware-control
 behaviour are unchanged.
 
 RoastPilot is being bootstrapped as a standalone Python MCP server that owns roaster control, first-crack detection integration, roast timing, metrics, and log export in one local stdio process.

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.syamaner/coffee-roaster-mcp",
   "title": "RoastPilot",
   "description": "RoastPilot controls coffee roasting sessions through local stdio MCP tools and exports logs.",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "websiteUrl": "https://github.com/syamaner/coffee-roaster-mcp#readme",
   "repository": {
     "url": "https://github.com/syamaner/coffee-roaster-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "coffee-roaster-mcp",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "runtimeHint": "uvx",
       "packageArguments": [
         {

--- a/src/coffee_roaster_mcp/__init__.py
+++ b/src/coffee_roaster_mcp/__init__.py
@@ -1,3 +1,3 @@
 """RoastPilot MCP server package."""
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -110,7 +110,7 @@ _EXPECTED_AMBIENT_STATUS_KEYS = {
 
 
 def test_version_is_defined() -> None:
-    assert __version__ == "0.1.15"
+    assert __version__ == "0.1.16"
 
 
 def test_cli_parser_program_name() -> None:


### PR DESCRIPTION
## Summary

- update the README from the June-only baseline to a dated August integrated status
- add a privacy-safe authority-ledger, ambient, MCP-session and paired-capture evidence report for two completed Hottop roasts
- document the released recording, microphone observability, ambient-sensor, recording-metadata, `mic-check`, and `record-check` surfaces
- remove the stale claim that end-to-end agent-roast validation is future work
- prepare documentation release 0.1.16 so the corrected long description reaches PyPI and the MCP Registry

## Accuracy boundary

The August roasts used the agent-pinned `coffee-roaster-mcp==0.1.13`. Versions 0.1.14 and 0.1.15 changed metadata/release plumbing only; 0.1.16 changes documentation and release metadata only. The report also discloses that agent runs are correlated to MCP sessions by `log_dir` session id and aligned start time because `mcp_session_id` is currently null.

No raw audio, roast logs, SQLite data, serial captures, private paths, or model output rationales are committed.

## Validation

- `python -m pytest` — 559 passed
- `python -m ruff check .` — passed
- `python -m ruff format --check .` — passed
- `python -m pyright` — 0 errors
- CLI help/version — passed; `coffee-roaster-mcp 0.1.16`
- built sdist and wheel — passed
- clean built-wheel smoke — `mock disabled int8`, help and version passed
- final wheel metadata — Core Metadata 2.5, corrected controlled-actuation summary/keywords, absolute evidence-report link
- src-logic churn — 2 lines, version bump only

Closes #204